### PR TITLE
MemberProfileResponse의 age 필드 삭제

### DIFF
--- a/src/main/java/com/konggogi/veganlife/member/controller/dto/response/MemberProfileResponse.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/dto/response/MemberProfileResponse.java
@@ -9,7 +9,6 @@ public record MemberProfileResponse(
         String nickname,
         VegetarianType vegetarianType,
         Gender gender,
-        Integer age,
         String imageUrl,
         Integer height,
         Integer weight) {}


### PR DESCRIPTION
## 이슈 번호 (#57 )
MemberProfileResponse의 age 필드 삭제

## 요약
MemberProfileResponse의 age 필드 삭제

## 변경 내용

