### PR TITLE
JpaAuditing 오류 수정

### DIFF
--- a/src/main/java/com/konggogi/veganlife/VeganlifeApplication.java
+++ b/src/main/java/com/konggogi/veganlife/VeganlifeApplication.java
@@ -3,10 +3,8 @@ package com.konggogi.veganlife;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class VeganlifeApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/konggogi/veganlife/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/konggogi/veganlife/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.konggogi.veganlife.global.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaAuditingConfig {}

--- a/src/test/java/com/konggogi/veganlife/VeganlifeApplicationTests.java
+++ b/src/test/java/com/konggogi/veganlife/VeganlifeApplicationTests.java
@@ -3,8 +3,10 @@ package com.konggogi.veganlife;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class VeganlifeApplicationTests {
 
     @Test


### PR DESCRIPTION
## 이슈 번호 (#73)

## 요약
`SpringBootApplication`에 `@EnableJpaAuditing`이 붙어있어 Controller 단위 테스트 시 jpaAuditingHandler를 생성하려고 시도해 오류가 발생했음
`JpaAuditingConfig` 클래스를 따로 두어 그곳에 어노테이션을 붙여 Test 시에는 JpaAuditing 기능을 사용하지 않도록 함

## 변경 내용
`JpaAuditingConfig` 클래스 생성