### PR TITLE
Controller 단위테스트 시, SecurityConfig 자동 설정으로 발생하는 접근권한 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ dependencies {
 
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
@@ -2,15 +2,20 @@ package com.konggogi.veganlife.support.docs;
 
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.konggogi.veganlife.global.security.filter.JwtAuthenticationFilter;
+import com.konggogi.veganlife.mealdata.config.MapStructConfig;
+import com.konggogi.veganlife.support.security.MockSecurityFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -26,7 +31,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @AutoConfigureRestDocs
 @ActiveProfiles("test")
 @WebMvcTest
-public class RestDocsTest {
+public abstract class RestDocsTest {
 
     @Autowired private ObjectMapper objectMapper;
     protected MockMvc mockMvc;
@@ -43,9 +48,9 @@ public class RestDocsTest {
                         .apply(
                                 documentationConfiguration(provider)
                                         .uris()
-                                        .withScheme("http")
-                                        .withHost("veganlife.com")
-                                        .withPort(8080))
+                                        .withScheme("https")
+                                        .withHost("dev.konggogi.store"))
+                        .apply(springSecurity(new MockSecurityFilter()))
                         .addFilter(new CharacterEncodingFilter("UTF-8", true))
                         .alwaysDo(print())
                         .alwaysDo(document("api/v1"))

--- a/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
@@ -7,15 +7,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.konggogi.veganlife.global.security.filter.JwtAuthenticationFilter;
-import com.konggogi.veganlife.mealdata.config.MapStructConfig;
 import com.konggogi.veganlife.support.security.MockSecurityFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;

--- a/src/test/java/com/konggogi/veganlife/support/security/MockSecurityFilter.java
+++ b/src/test/java/com/konggogi/veganlife/support/security/MockSecurityFilter.java
@@ -1,0 +1,38 @@
+package com.konggogi.veganlife.support.security;
+
+
+import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class MockSecurityFilter implements Filter {
+
+    @Override
+    public void init(FilterConfig filterConfig) {}
+
+    @Override
+    public void destroy() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        UserDetailsImpl loginUser = new UserDetailsImpl(1L, "test123@kakao.com", "test");
+
+        SecurityContextHolder.getContext()
+                .setAuthentication(
+                        new UsernamePasswordAuthenticationToken(
+                                loginUser, "password", loginUser.getAuthorities()));
+
+        chain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#72)

## 요약
테스트 환경에서는 `MockSecurityFilter`를 적용하여 사용자 인증

## 변경 내용
`MockSecurityFilter` 추가