### PR TITLE
식단 메뉴 검색 기능 구현, MapStruct 에러 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### RestDocs ###
+src/main/resources/templates

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,9 @@
+= Vegan Life API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+include::{docdir}/src/docs/asciidoc/meal-data.adoc[]

--- a/src/docs/asciidoc/meal-data.adoc
+++ b/src/docs/asciidoc/meal-data.adoc
@@ -1,0 +1,25 @@
+= Meal Data API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== 식품 정보 검색 API
+
+=== Request
+
+include::{snippets}/meal-data-list/query-parameters.adoc[]
+
+한글은 URI상에서 인코딩되어 보여집니다. (keyword="통")
+
+include::{snippets}/meal-data-list/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/meal-data-list/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/mealdata/controller/MealDataController.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/controller/MealDataController.java
@@ -1,0 +1,32 @@
+package com.konggogi.veganlife.mealdata.controller;
+
+
+import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataListResponse;
+import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
+import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/meal-data")
+public class MealDataController {
+
+    private final MealDataQueryService mealDataQueryService;
+    private final MealDataMapper mealDataMapper;
+
+    @GetMapping
+    public ResponseEntity<Page<MealDataListResponse>> getMealDataList(
+            String keyword, Pageable pageable) {
+
+        return ResponseEntity.ok(
+                mealDataQueryService
+                        .searchByKeyword(keyword, pageable)
+                        .map(mealDataMapper::toMealDataListResponse));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/mealdata/controller/dto/response/MealDataListResponse.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/controller/dto/response/MealDataListResponse.java
@@ -1,0 +1,3 @@
+package com.konggogi.veganlife.mealdata.controller.dto.response;
+
+public record MealDataListResponse(Long id, String name) {}

--- a/src/main/java/com/konggogi/veganlife/mealdata/domain/IntakeUnit.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/domain/IntakeUnit.java
@@ -1,0 +1,16 @@
+package com.konggogi.veganlife.mealdata.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum IntakeUnit {
+    G("g"),
+    ML("ml");
+
+    private String unit;
+
+    @JsonCreator
+    IntakeUnit(String unit) {
+        this.unit = unit;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/mealdata/domain/MealData.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/domain/MealData.java
@@ -1,0 +1,99 @@
+package com.konggogi.veganlife.mealdata.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MealData extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meal_data_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MealDataType type;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Column(nullable = false)
+    private Integer amountPerServe;
+
+    @Column(nullable = false)
+    private Double calorie;
+
+    @Column(nullable = false)
+    private Double protein;
+
+    @Column(nullable = false)
+    private Double fat;
+
+    @Column(nullable = false)
+    private Double carbs;
+
+    @Column(nullable = false)
+    private Double caloriePerGram;
+
+    @Column(nullable = false)
+    private Double proteinPerGram;
+
+    @Column(nullable = false)
+    private Double fatPerGram;
+
+    @Column(nullable = false)
+    private Double carbsPerGram;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private IntakeUnit intakeUnit;
+
+    @Builder
+    public MealData(
+            Long id,
+            String name,
+            MealDataType type,
+            Integer amount,
+            Integer amountPerServe,
+            Double calorie,
+            Double protein,
+            Double fat,
+            Double carbs,
+            Double caloriePerGram,
+            Double proteinPerGram,
+            Double fatPerGram,
+            Double carbsPerGram,
+            IntakeUnit intakeUnit) {
+        this.id = id;
+        this.name = name;
+        this.type = type;
+        this.amount = amount;
+        this.amountPerServe = amountPerServe;
+        this.calorie = calorie;
+        this.protein = protein;
+        this.fat = fat;
+        this.carbs = carbs;
+        this.caloriePerGram = caloriePerGram;
+        this.proteinPerGram = proteinPerGram;
+        this.fatPerGram = fatPerGram;
+        this.carbsPerGram = carbsPerGram;
+        this.intakeUnit = intakeUnit;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/mealdata/domain/MealDataType.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/domain/MealDataType.java
@@ -1,0 +1,16 @@
+package com.konggogi.veganlife.mealdata.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum MealDataType {
+    MEAL("meal"),
+    PROCESSED("processed");
+
+    private String type;
+
+    @JsonCreator
+    MealDataType(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/mealdata/domain/mapper/MealDataMapper.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/domain/mapper/MealDataMapper.java
@@ -1,0 +1,12 @@
+package com.konggogi.veganlife.mealdata.domain.mapper;
+
+
+import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataListResponse;
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface MealDataMapper {
+
+    MealDataListResponse toMealDataListResponse(MealData mealData);
+}

--- a/src/main/java/com/konggogi/veganlife/mealdata/repository/MealDataRepository.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/repository/MealDataRepository.java
@@ -1,0 +1,14 @@
+package com.konggogi.veganlife.mealdata.repository;
+
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MealDataRepository extends JpaRepository<MealData, Long> {
+
+    Page<MealData> findMealDataByNameContaining(String Keyword, Pageable pageable);
+}

--- a/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataQueryService.java
@@ -1,0 +1,24 @@
+package com.konggogi.veganlife.mealdata.service;
+
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MealDataQueryService {
+
+    private final MealDataRepository mealDataRepository;
+
+    // TODO: 필요에 따라 Pagenation 적용
+    public Page<MealData> searchByKeyword(String keyword, Pageable pageable) {
+
+        return mealDataRepository.findMealDataByNameContaining(keyword, pageable);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataQueryService.java
@@ -10,13 +10,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MealDataQueryService {
 
     private final MealDataRepository mealDataRepository;
 
-    // TODO: 필요에 따라 Pagenation 적용
     public Page<MealData> searchByKeyword(String keyword, Pageable pageable) {
 
         return mealDataRepository.findMealDataByNameContaining(keyword, pageable);

--- a/src/test/java/com/konggogi/veganlife/config/MapStructConfig.java
+++ b/src/test/java/com/konggogi/veganlife/config/MapStructConfig.java
@@ -1,0 +1,23 @@
+package com.konggogi.veganlife.config;
+
+
+import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
+import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapperImpl;
+import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
+import com.konggogi.veganlife.member.domain.mapper.MemberMapperImpl;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class MapStructConfig {
+
+    @Bean
+    public MemberMapper memberMapper() {
+        return new MemberMapperImpl();
+    }
+
+    @Bean
+    public MealDataMapper mealDataMapper() {
+        return new MealDataMapperImpl();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/mealdata/controller/MealDataControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/controller/MealDataControllerTest.java
@@ -1,0 +1,68 @@
+package com.konggogi.veganlife.mealdata.controller;
+
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
+import com.konggogi.veganlife.support.docs.RestDocsTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MealDataController.class)
+public class MealDataControllerTest extends RestDocsTest {
+
+    @MockBean MealDataQueryService mealDataQueryService;
+
+    @Test
+    @DisplayName("식단 메뉴 검색 API")
+    void getMealDataListTest() throws Exception {
+        // given
+        List<String> valid = List.of("통밀빵", "통밀크래커");
+        Page<MealData> result =
+                new PageImpl<>(valid.stream().map(MealDataFixture.MEAL::getWithName).toList());
+        given(mealDataQueryService.searchByKeyword(anyString(), any(Pageable.class)))
+                .willReturn(result);
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/api/v1/meal-data")
+                                .queryParam("keyword", "통")
+                                .queryParam("page", "0")
+                                .queryParam("size", "12"));
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(1))
+                .andExpect(jsonPath("$.content[0].name").value("통밀빵"))
+                .andExpect(jsonPath("$.numberOfElements").value(2));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "meal-data-list",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                queryParameters(
+                                        parameterWithName("keyword").description("검색을 위한 키워드"),
+                                        parameterWithName("page").description("페이지 번호"),
+                                        parameterWithName("size").description("페이지 사이즈"))));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/mealdata/fixture/MealDataFixture.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/fixture/MealDataFixture.java
@@ -1,0 +1,138 @@
+package com.konggogi.veganlife.mealdata.fixture;
+
+
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.domain.MealDataType;
+
+public enum MealDataFixture {
+    MEAL(
+            "디폴트 음식",
+            MealDataType.MEAL,
+            100,
+            100,
+            100D,
+            100D,
+            100D,
+            100D,
+            100D,
+            1D,
+            1D,
+            1D,
+            IntakeUnit.G),
+    PROCESSED(
+            "디폴트 가공식품",
+            MealDataType.PROCESSED,
+            100,
+            100,
+            100D,
+            100D,
+            100D,
+            100D,
+            100D,
+            1D,
+            1D,
+            1D,
+            IntakeUnit.G);
+
+    private Long id = 1L;
+    private String name;
+    private MealDataType type;
+    private Integer amount;
+    private Integer amountPerServe;
+    private Double calorie;
+    private Double protein;
+    private Double fat;
+    private Double carbs;
+    private Double caloriePerGram;
+    private Double proteinPerGram;
+    private Double fatPerGram;
+    private Double carbsPerGram;
+    private IntakeUnit intakeUnit;
+
+    MealDataFixture(
+            String name,
+            MealDataType type,
+            Integer amount,
+            Integer amountPerServe,
+            Double calorie,
+            Double protein,
+            Double fat,
+            Double carbs,
+            Double caloriePerGram,
+            Double proteinPerGram,
+            Double fatPerGram,
+            Double carbsPerGram,
+            IntakeUnit intakeUnit) {
+        this.name = name;
+        this.type = type;
+        this.amount = amount;
+        this.amountPerServe = amountPerServe;
+        this.calorie = calorie;
+        this.protein = protein;
+        this.fat = fat;
+        this.carbs = carbs;
+        this.caloriePerGram = caloriePerGram;
+        this.proteinPerGram = proteinPerGram;
+        this.fatPerGram = fatPerGram;
+        this.carbsPerGram = carbsPerGram;
+        this.intakeUnit = intakeUnit;
+    }
+
+    public MealData get() {
+
+        return new MealData(
+                id++,
+                name,
+                type,
+                amount,
+                amountPerServe,
+                calorie,
+                protein,
+                fat,
+                carbs,
+                caloriePerGram,
+                proteinPerGram,
+                fatPerGram,
+                carbsPerGram,
+                intakeUnit);
+    }
+
+    public MealData getWithName(String name) {
+
+        return new MealData(
+                id++,
+                name,
+                type,
+                amount,
+                amountPerServe,
+                calorie,
+                protein,
+                fat,
+                carbs,
+                caloriePerGram,
+                proteinPerGram,
+                fatPerGram,
+                carbsPerGram,
+                intakeUnit);
+    }
+
+    public MealData getWithNameAndIntakeUnit(String name, IntakeUnit intakeUnit) {
+
+        return new MealData(
+                id++,
+                name,
+                type,
+                amount,
+                amountPerServe,
+                calorie,
+                protein,
+                fat,
+                carbs,
+                caloriePerGram,
+                proteinPerGram,
+                fatPerGram,
+                carbsPerGram,
+                intakeUnit);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/mealdata/repository/MealDataRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/repository/MealDataRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.konggogi.veganlife.mealdata.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+public class MealDataRepositoryTest {
+
+    @Autowired private MealDataRepository mealDataRepository;
+
+    @Test
+    @DisplayName("name에 키워드를 포함하는 레코드 조회")
+    void findMealDataByNameContainingTest() {
+        // given
+        List<String> valid = List.of("통밀빵", "통밀크래커");
+        List<String> invalid = List.of("가지볶음");
+        mealDataRepository.saveAll(valid.stream().map(MealDataFixture.MEAL::getWithName).toList());
+        mealDataRepository.saveAll(
+                invalid.stream().map(MealDataFixture.MEAL::getWithName).toList());
+        String keyword = "통";
+        Pageable pageable = Pageable.ofSize(12);
+        // when
+        Page<MealData> result = mealDataRepository.findMealDataByNameContaining(keyword, pageable);
+        // then
+        assertThat(result.getNumberOfElements()).isEqualTo(valid.size());
+        assertThat(result.getContent().stream().map(MealData::getName))
+                .allMatch(s -> s.contains(keyword));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataQueryServiceTest.java
@@ -1,0 +1,44 @@
+package com.konggogi.veganlife.mealdata.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+public class MealDataQueryServiceTest {
+
+    @Mock MealDataRepository mealDataRepository;
+    @InjectMocks MealDataQueryService mealDataQueryService;
+
+    @Test
+    @DisplayName("키워드를 포함하는 이름을 가진 식품 데이터들을 조회")
+    void searchByKeyword() {
+        // given
+        List<String> valid = List.of("통밀빵", "통밀크래커");
+        Page<MealData> found =
+                new PageImpl<>(valid.stream().map(MealDataFixture.MEAL::getWithName).toList());
+        given(mealDataRepository.findMealDataByNameContaining(anyString(), any(Pageable.class)))
+                .willReturn(found);
+        String keyword = "통";
+        Pageable pageable = Pageable.ofSize(12);
+        // when
+        Page<MealData> result = mealDataQueryService.searchByKeyword(keyword, pageable);
+        // then
+        assertThat(result).hasSize(found.getSize());
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/support/docs/ApiDocumentUtils.java
+++ b/src/test/java/com/konggogi/veganlife/support/docs/ApiDocumentUtils.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.support.docs;
 
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -10,7 +11,9 @@ import org.springframework.restdocs.operation.preprocess.OperationResponsePrepro
 public interface ApiDocumentUtils {
 
     static OperationRequestPreprocessor getDocumentRequest() {
-        return preprocessRequest(prettyPrint());
+        return preprocessRequest(
+                modifyUris().scheme("https").host("dev.konggogi.store").removePort(),
+                prettyPrint());
     }
 
     static OperationResponsePreprocessor getDocumentResponse() {

--- a/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
@@ -8,12 +8,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.konggogi.veganlife.config.MapStructConfig;
+import com.konggogi.veganlife.global.security.filter.JwtAuthenticationFilter;
 import com.konggogi.veganlife.support.security.MockSecurityFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -32,6 +34,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 public abstract class RestDocsTest {
 
     @Autowired private ObjectMapper objectMapper;
+    @MockBean private JwtAuthenticationFilter jwtAuthenticationFilter;
     protected MockMvc mockMvc;
 
     protected String toJson(Object value) throws JsonProcessingException {

--- a/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.konggogi.veganlife.config.MapStructConfig;
 import com.konggogi.veganlife.support.security.MockSecurityFilter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +25,7 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
-@Import(RestDocsConfiguration.class)
+@Import({RestDocsConfiguration.class, MapStructConfig.class})
 @AutoConfigureRestDocs
 @ActiveProfiles("test")
 @WebMvcTest


### PR DESCRIPTION
## 이슈 번호 (#59, #72)

## 요약
식단 메뉴 검색 API를 구현하고 테스트를 완료했습니다.
테스트 환경에서 MapStruct mapper Bean이 등록되지 않는 에러를 해결했습니다.
테스트 환경에서 JwtAuthenticationFilter Bean이 등록되지 않는 에러를 해결했습니다.

## ETC
목록 조회 시에 상세 데이터까지 받아와서 상세 조회할 때 바로 보여주는 방법과
목록 조회 시에는 최소한의 데이터를 받아오고 상세 조회할 때 따로 상세 조회 API를 호출하는 방법 중 어느 것이 좋을까요?
(Pagenation 적용된 상태입니다)
