### PR TITLE
Restdocs Index 페이지 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
     // map struct
     implementation group: 'org.mapstruct', name: 'mapstruct', version: '1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
+    // thymeleaf (for restdocs)
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }
 
 test {

--- a/src/main/java/com/konggogi/veganlife/global/config/SecurityConfig.java
+++ b/src/main/java/com/konggogi/veganlife/global/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
         return web ->
                 web.ignoring()
                         .requestMatchers(PathRequest.toH2Console())
-                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
+                        .requestMatchers(new AntPathRequestMatcher("/api/v1/docs"));
     }
 
     @Bean

--- a/src/main/java/com/konggogi/veganlife/restdocs/controller/RestDocsController.java
+++ b/src/main/java/com/konggogi/veganlife/restdocs/controller/RestDocsController.java
@@ -1,0 +1,17 @@
+package com.konggogi.veganlife.restdocs.controller;
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/api/v1/docs")
+public class RestDocsController {
+
+    @GetMapping
+    public String getRestDocs() {
+
+        return "index";
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#43)

## 요약
Restdocs 페이지를 조회할 수 있는 API 구현

## 변경 내용
thymeleaf 의존성 추가 (이게 있어야 `resourcce/templates` 패키지 내의 `index.html` 파일을 읽어 올 수 있음
해당 API URI는 인가 필요 대상에서 제외
