### PR TITLE
dev 서버에서 RestDocs 페이지에 접근할 수 없는 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,23 +90,9 @@ asciidoctor {
     dependsOn test
 }
 
-bootJar {
+bootJar { // jar의 templates에 문서 복사
     dependsOn asciidoctor
-    from("${asciidoctor.outputDir}/html5") {
-        into 'BOOT-INF/classes/static/docs'
+    from ("${asciidoctor.outputDir}") {
+        into 'BOOT-INF/classes/templates'
     }
-    finalizedBy('copyDocument')
-}
-
-tasks.register('copyDocument', Copy) {
-    from file("build/docs/asciidoc")
-    into file("src/main/resources/templates")
-}
-
-copyDocument{
-    dependsOn processResources
-}
-
-spotlessJava{
-    dependsOn copyDocument
 }


### PR DESCRIPTION
## 이슈 번호 (#79)

## 요약
배포 환경에서 restdocs에 접근할 수 없었음
`.jar` 파일의 올바른 경로에 restdocs 파일을 포함하도록 task를 수정하여 이를 해결함

## 변경 내용
`build.gradle` restdocs 관련 task
