### PR TITLE
AOP request parmeter가 들어오지 않았을 경우 예외 처리 해결

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/aop/LoggerAop.java
+++ b/src/main/java/com/konggogi/veganlife/global/aop/LoggerAop.java
@@ -3,6 +3,8 @@ package com.konggogi.veganlife.global.aop;
 import static com.konggogi.veganlife.global.util.AopUtils.extractMethodSignature;
 
 import com.konggogi.veganlife.global.aop.domain.MethodSignature;
+import java.util.Objects;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.*;
@@ -24,9 +26,14 @@ public class LoggerAop {
         log.debug("[START] - {}.{}", signature.className(), signature.methodName());
 
         Object[] args = joinPoint.getArgs();
-        for (Object arg : args) {
-            log.debug("type: {} | value: {}", arg.getClass().getSimpleName(), arg);
-        }
+        Stream.of(args)
+                .filter(Objects::nonNull)
+                .forEach(
+                        arg ->
+                                log.debug(
+                                        "type: {} | value: {}",
+                                        arg.getClass().getSimpleName(),
+                                        arg));
     }
 
     @AfterReturning(value = "cuts()")


### PR DESCRIPTION
## 이슈 번호 (#90)

## 요약
메서드 인자(request parameter)가 null일 경우 AOP 로깅 예외 발생

## 변경 내용
`LoggerAop` 코드 수정