### PR TITLE
식사 기록 등록 API 구현

### DIFF
--- a/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
@@ -1,0 +1,32 @@
+package com.konggogi.veganlife.meallog.controller;
+
+
+import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.service.MealLogAddService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/meal-log")
+public class MealLogController {
+
+    private final MealLogAddService mealLogAddService;
+
+    @PostMapping
+    public ResponseEntity<Void> addMealLog(
+            @Valid @RequestBody MealLogAddRequest request,
+            @Valid @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        mealLogAddService.add(request, userDetails.id());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
@@ -24,7 +24,7 @@ public class MealLogController {
     @PostMapping
     public ResponseEntity<Void> addMealLog(
             @Valid @RequestBody MealLogAddRequest request,
-            @Valid @AuthenticationPrincipal UserDetailsImpl userDetails) {
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         mealLogAddService.add(request, userDetails.id());
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealAddRequest.java
@@ -1,0 +1,17 @@
+package com.konggogi.veganlife.meallog.controller.dto.request;
+
+
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MealAddRequest(
+        @NotBlank String name,
+        @NotNull @Min(0) Integer intake,
+        @NotNull IntakeUnit intakeUnit,
+        @NotNull @Min(0) Integer calorie,
+        @NotNull @Min(0) Integer carbs,
+        @NotNull @Min(0) Integer protein,
+        @NotNull @Min(0) Integer fat,
+        @NotNull Long mealDataId) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
@@ -1,0 +1,10 @@
+package com.konggogi.veganlife.meallog.controller.dto.request;
+
+
+import com.konggogi.veganlife.meallog.domain.MealType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record MealLogAddRequest(
+        @NotNull MealType mealType, @Size(min = 1) List<MealAddRequest> mealAddRequests) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
@@ -8,4 +8,4 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record MealLogAddRequest(
-        @NotNull MealType mealType, @Valid @Size(min = 1) List<MealAddRequest> mealAddRequests) {}
+        @NotNull MealType mealType, @Valid @NotNull @Size(min = 1) List<MealAddRequest> mealAddRequests) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
@@ -8,4 +8,5 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record MealLogAddRequest(
-        @NotNull MealType mealType, @Valid @NotNull @Size(min = 1) List<MealAddRequest> mealAddRequests) {}
+        @NotNull MealType mealType,
+        @Valid @NotNull @Size(min = 1) List<MealAddRequest> mealAddRequests) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
@@ -2,9 +2,10 @@ package com.konggogi.veganlife.meallog.controller.dto.request;
 
 
 import com.konggogi.veganlife.meallog.domain.MealType;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record MealLogAddRequest(
-        @NotNull MealType mealType, @Size(min = 1) List<MealAddRequest> mealAddRequests) {}
+        @NotNull MealType mealType, @Valid @Size(min = 1) List<MealAddRequest> mealAddRequests) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/Meal.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/Meal.java
@@ -1,0 +1,85 @@
+package com.konggogi.veganlife.meallog.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Meal extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meal_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer intake;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private IntakeUnit intakeUnit;
+
+    @Column(nullable = false)
+    private Integer calorie;
+
+    @Column(nullable = false)
+    private Integer carbs;
+
+    @Column(nullable = false)
+    private Integer protein;
+
+    @Column(nullable = false)
+    private Integer fat;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meal_log_id")
+    private MealLog mealLog;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meal_data_id")
+    private MealData mealData;
+
+    @Builder
+    public Meal(
+            Long id,
+            String name,
+            Integer intake,
+            IntakeUnit intakeUnit,
+            Integer calorie,
+            Integer carbs,
+            Integer protein,
+            Integer fat,
+            MealLog mealLog,
+            MealData mealData) {
+        this.id = id;
+        this.name = name;
+        this.intake = intake;
+        this.intakeUnit = intakeUnit;
+        this.calorie = calorie;
+        this.carbs = carbs;
+        this.protein = protein;
+        this.fat = fat;
+        this.mealLog = mealLog;
+        this.mealData = mealData;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -1,0 +1,42 @@
+package com.konggogi.veganlife.meallog.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import com.konggogi.veganlife.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MealLog extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meal_log_id")
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MealType mealType;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public MealLog(Long id, MealType mealType, Member member) {
+        this.id = id;
+        this.mealType = mealType;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealType.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealType.java
@@ -1,0 +1,20 @@
+package com.konggogi.veganlife.meallog.domain;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum MealType {
+    BREAKFAST("아침 식사"),
+    BREAKFAST_SNACK("아침 간식"),
+    LUNCH("점심 식사"),
+    LUNCH_SNACK("점심 간식"),
+    DINNER("저녁 식사"),
+    DINNER_SNACK("저녁 간식");
+
+    private final String value;
+
+    @JsonCreator
+    MealType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -1,0 +1,13 @@
+package com.konggogi.veganlife.meallog.domain.mapper;
+
+
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.member.domain.Member;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface MealLogMapper {
+
+    MealLog mealLogAddRequestToEntity(MealLogAddRequest mealLogAddRequest, Member member);
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
@@ -1,0 +1,21 @@
+package com.konggogi.veganlife.meallog.domain.mapper;
+
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface MealMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "mealAddRequest.mealDataId", ignore = true)
+    @Mapping(source = "mealLog", target = "mealLog")
+    @Mapping(source = "mealData", target = "mealData")
+    @Mapping(source = "mealAddRequest.name", target = "name")
+    @Mapping(source = "mealAddRequest.intakeUnit", target = "intakeUnit")
+    Meal mealAddRequestToEntity(MealAddRequest mealAddRequest, MealLog mealLog, MealData mealData);
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
@@ -13,8 +13,6 @@ public interface MealMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "mealAddRequest.mealDataId", ignore = true)
-    @Mapping(source = "mealLog", target = "mealLog")
-    @Mapping(source = "mealData", target = "mealData")
     @Mapping(source = "mealAddRequest.name", target = "name")
     @Mapping(source = "mealAddRequest.intakeUnit", target = "intakeUnit")
     Meal mealAddRequestToEntity(MealAddRequest mealAddRequest, MealLog mealLog, MealData mealData);

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -1,0 +1,9 @@
+package com.konggogi.veganlife.meallog.repository;
+
+
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MealLogRepository extends JpaRepository<MealLog, Long> {}

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealRepository.java
@@ -1,0 +1,9 @@
+package com.konggogi.veganlife.meallog.repository;
+
+
+import com.konggogi.veganlife.meallog.domain.Meal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MealRepository extends JpaRepository<Meal, Long> {}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogAddService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogAddService.java
@@ -1,0 +1,38 @@
+package com.konggogi.veganlife.meallog.service;
+
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MealLogAddService {
+
+    private final MealLogService mealLogService;
+    private final MealService mealService;
+    private final MemberQueryService memberQueryService;
+    private final MealDataQueryService mealDataQueryService;
+
+    public void add(MealLogAddRequest mealLogAddRequest, Long memberId) {
+
+        Member member = memberQueryService.search(memberId);
+        MealLog mealLog = mealLogService.add(mealLogAddRequest, member);
+
+        List<MealAddRequest> mealAddRequests = mealLogAddRequest.mealAddRequests();
+        mealAddRequests.forEach(
+                mealAddRequest -> {
+                    MealData mealData = mealDataQueryService.search(mealAddRequest.mealDataId());
+                    mealService.add(mealAddRequest, mealLog, mealData);
+                });
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogAddService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogAddService.java
@@ -25,7 +25,7 @@ public class MealLogAddService {
 
     public void add(MealLogAddRequest mealLogAddRequest, Long memberId) {
 
-        Member member = memberQueryService.search(memberId);
+        Member member = memberQueryService.findMemberById(memberId);
         MealLog mealLog = mealLogService.add(mealLogAddRequest, member);
 
         List<MealAddRequest> mealAddRequests = mealLogAddRequest.mealAddRequests();

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -1,0 +1,26 @@
+package com.konggogi.veganlife.meallog.service;
+
+
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
+import com.konggogi.veganlife.meallog.repository.MealLogRepository;
+import com.konggogi.veganlife.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MealLogService {
+
+    private final MealLogRepository mealLogRepository;
+    private final MealLogMapper mealLogMapper;
+
+    public MealLog add(MealLogAddRequest mealLogAddRequest, Member member) {
+
+        return mealLogRepository.save(
+                mealLogMapper.mealLogAddRequestToEntity(mealLogAddRequest, member));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealService.java
@@ -1,0 +1,25 @@
+package com.konggogi.veganlife.meallog.service;
+
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.domain.mapper.MealMapper;
+import com.konggogi.veganlife.meallog.repository.MealRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MealService {
+
+    private final MealRepository mealRepository;
+    private final MealMapper mealMapper;
+
+    public void add(MealAddRequest mealAddRequest, MealLog mealLog, MealData mealData) {
+
+        mealRepository.save(mealMapper.mealAddRequestToEntity(mealAddRequest, mealLog, mealData));
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#94 )

## 요약
식사 기록을 등록하는 API를 구현하였습니다.
MealLog와 Meal 엔티티를 저장합니다.
