### PR TITLE
WebClientResponseException 예외 핸들링

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/advice/member/MemberControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/member/MemberControllerAdvice.java
@@ -4,6 +4,7 @@ package com.konggogi.veganlife.global.advice.member;
 import com.konggogi.veganlife.global.exception.ApiException;
 import com.konggogi.veganlife.global.exception.dto.response.ErrorResponse;
 import com.konggogi.veganlife.global.security.exception.InvalidJwtException;
+import com.konggogi.veganlife.global.security.exception.InvalidOauthTokenException;
 import com.konggogi.veganlife.global.security.exception.MismatchTokenException;
 import com.konggogi.veganlife.global.util.AopUtils;
 import com.konggogi.veganlife.global.util.LoggingUtils;
@@ -35,9 +36,9 @@ public class MemberControllerAdvice {
                 .body(ErrorResponse.from(exception.getErrorCode()));
     }
 
-    @ExceptionHandler(InvalidJwtException.class)
+    @ExceptionHandler({InvalidJwtException.class, InvalidOauthTokenException.class})
     public ResponseEntity<ErrorResponse> handleInvalidJwtException(
-            HandlerMethod handlerMethod, InvalidJwtException exception) {
+            HandlerMethod handlerMethod, ApiException exception) {
         LoggingUtils.exceptionLog(
                 AopUtils.extractMethodSignature(handlerMethod), HttpStatus.UNAUTHORIZED, exception);
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     MISMATCH_REFRESH_TOKEN("AUTH_008", "RefreshToken이 일치하지 않습니다."),
 
     // oauth
-    UNSUPPORTED_PROVIDER("OATUH_001", "지원되지 않는 provider입니다."),
+    UNSUPPORTED_PROVIDER("OAUTH_001", "지원되지 않는 provider입니다."),
+    INVALID_OAUTH_TOKEN("OAUTH_002", "Oauth 액세스 토큰이 유효하지 않습니다."),
 
     // member
     DUPLICATED_NICKNAME("MEMBER_001", "중복된 닉네임입니다."),

--- a/src/main/java/com/konggogi/veganlife/global/security/exception/InvalidOauthTokenException.java
+++ b/src/main/java/com/konggogi/veganlife/global/security/exception/InvalidOauthTokenException.java
@@ -1,0 +1,15 @@
+package com.konggogi.veganlife.global.security.exception;
+
+
+import com.konggogi.veganlife.global.exception.ApiException;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+
+public class InvalidOauthTokenException extends ApiException {
+    public InvalidOauthTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public InvalidOauthTokenException(ErrorCode errorCode, String description) {
+        super(errorCode, description);
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#119 )

## 요약
WebClientResponseException 예외를 커스텀 InvalidOauthTokenException 으로 처리
MemberControllerAdvice에서 핸들링하도록 처리

## 변경 내용

