### PR TITLE
식사 기록 등록 단위 테스트 + ErrorCode 이름 수정

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,3 +15,5 @@ include::{docdir}/src/docs/asciidoc/auth.adoc[]
 include::{docdir}/src/docs/asciidoc/oauth.adoc[]
 
 include::{docdir}/src/docs/asciidoc/post.adoc[]
+
+include::{docdir}/src/docs/asciidoc/meal-log.adoc[]

--- a/src/docs/asciidoc/meal-log.adoc
+++ b/src/docs/asciidoc/meal-log.adoc
@@ -1,0 +1,35 @@
+= Meal Log API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== 식사 기록 등록 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/meal-log-add/request-headers.adoc[]
+
+==== Parameter
+
+include::{snippets}/meal-log-add/http-request.adoc[]
+
+=== Response
+
+==== 201 CREATED
+include::{snippets}/meal-log-add/http-response.adoc[]
+
+==== 404 NOT FOUND
+include::{snippets}/meal-log-add-meal-data-not-found/http-response.adoc[]
+
+==== 404 NOT FOUND
+include::{snippets}/meal-log-add-member-not-found/http-response.adoc[]
+

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -27,7 +27,7 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER("MEMBER_002", "사용자를 찾을 수 없습니다."),
 
     // meal-data
-    MEAL_DATA_NOT_FOUND("MEAL_DATA_001", "식품 정보를 찾을 수 없습니다.");
+    NOT_FOUND_MEAL_DATA("MEAL_DATA_001", "식품 정보를 찾을 수 없습니다.");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataQueryService.java
@@ -27,6 +27,6 @@ public class MealDataQueryService {
 
         return mealDataRepository
                 .findById(id)
-                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.MEAL_DATA_NOT_FOUND));
+                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEAL_DATA));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/config/MapStructConfig.java
+++ b/src/test/java/com/konggogi/veganlife/config/MapStructConfig.java
@@ -3,6 +3,10 @@ package com.konggogi.veganlife.config;
 
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapperImpl;
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapperImpl;
+import com.konggogi.veganlife.meallog.domain.mapper.MealMapper;
+import com.konggogi.veganlife.meallog.domain.mapper.MealMapperImpl;
 import com.konggogi.veganlife.member.domain.mapper.AuthMapper;
 import com.konggogi.veganlife.member.domain.mapper.AuthMapperImpl;
 import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
@@ -27,6 +31,16 @@ public class MapStructConfig {
     @Bean
     public AuthMapper authMapper() {
         return new AuthMapperImpl();
+    }
+
+    @Bean
+    public MealMapper mealMapper() {
+        return new MealMapperImpl();
+    }
+
+    @Bean
+    public MealLogMapper mealLogMapper() {
+        return new MealLogMapperImpl();
     }
 
     @Bean

--- a/src/test/java/com/konggogi/veganlife/mealdata/fixture/MealDataFixture.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/fixture/MealDataFixture.java
@@ -21,7 +21,6 @@ public enum MealDataFixture {
             IntakeUnit.G,
             OwnerType.MEMBER);
 
-    private Long id = 1L;
     private String name;
     private MealDataType type;
     private Integer amount;
@@ -58,35 +57,71 @@ public enum MealDataFixture {
 
     public MealData get(Member member) {
 
-        return new MealData(
-                id++,
-                name,
-                type,
-                amount,
-                amountPerServe,
-                caloriePerUnit,
-                proteinPerUnit,
-                fatPerUnit,
-                carbsPerUnit,
-                intakeUnit,
-                ownerType,
-                member);
+        return MealData.builder()
+                .name(name)
+                .type(type)
+                .amount(amount)
+                .amountPerServe(amountPerServe)
+                .caloriePerUnit(caloriePerUnit)
+                .proteinPerUnit(proteinPerUnit)
+                .fatPerUnit(fatPerUnit)
+                .carbsPerUnit(carbsPerUnit)
+                .intakeUnit(intakeUnit)
+                .ownerType(ownerType)
+                .member(member)
+                .build();
+    }
+
+    public MealData get(Long id, Member member) {
+
+        return MealData.builder()
+                .id(id)
+                .name(name)
+                .type(type)
+                .amount(amount)
+                .amountPerServe(amountPerServe)
+                .caloriePerUnit(caloriePerUnit)
+                .proteinPerUnit(proteinPerUnit)
+                .fatPerUnit(fatPerUnit)
+                .carbsPerUnit(carbsPerUnit)
+                .intakeUnit(intakeUnit)
+                .ownerType(ownerType)
+                .member(member)
+                .build();
     }
 
     public MealData getWithName(String name, Member member) {
 
-        return new MealData(
-                id++,
-                name,
-                type,
-                amount,
-                amountPerServe,
-                caloriePerUnit,
-                proteinPerUnit,
-                fatPerUnit,
-                carbsPerUnit,
-                intakeUnit,
-                ownerType,
-                member);
+        return MealData.builder()
+                .name(name)
+                .type(type)
+                .amount(amount)
+                .amountPerServe(amountPerServe)
+                .caloriePerUnit(caloriePerUnit)
+                .proteinPerUnit(proteinPerUnit)
+                .fatPerUnit(fatPerUnit)
+                .carbsPerUnit(carbsPerUnit)
+                .intakeUnit(intakeUnit)
+                .ownerType(ownerType)
+                .member(member)
+                .build();
+    }
+
+    public MealData getWithName(Long id, String name, Member member) {
+
+        return MealData.builder()
+                .id(id)
+                .name(name)
+                .type(type)
+                .amount(amount)
+                .amountPerServe(amountPerServe)
+                .caloriePerUnit(caloriePerUnit)
+                .proteinPerUnit(proteinPerUnit)
+                .fatPerUnit(fatPerUnit)
+                .carbsPerUnit(carbsPerUnit)
+                .intakeUnit(intakeUnit)
+                .ownerType(ownerType)
+                .member(member)
+                .build();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/mealdata/repository/MealDataRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/repository/MealDataRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import java.util.List;
 import java.util.Optional;
@@ -22,7 +21,7 @@ public class MealDataRepositoryTest {
     @Autowired private MealDataRepository mealDataRepository;
     @Autowired private MemberRepository memberRepository;
 
-    Member member = MemberFixture.DEFAULT_M.getMember();
+    Member member = Member.builder().email("test123@test.com").build();
 
     @BeforeEach
     void setup() {
@@ -35,7 +34,6 @@ public class MealDataRepositoryTest {
         // given
         List<String> valid = List.of("통밀빵", "통밀크래커");
         List<String> invalid = List.of("가지볶음");
-        memberRepository.save(member);
         mealDataRepository.saveAll(
                 valid.stream()
                         .map(name -> MealDataFixture.MEAL.getWithName(name, member))

--- a/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataQueryServiceTest.java
@@ -12,7 +12,6 @@ import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.fixture.MemberFixture;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -29,7 +28,7 @@ public class MealDataQueryServiceTest {
     @Mock MealDataRepository mealDataRepository;
     @InjectMocks MealDataQueryService mealDataQueryService;
 
-    Member member = MemberFixture.DEFAULT_M.getMember();
+    Member member = Member.builder().email("test123@test.com").build();
 
     @Test
     @DisplayName("키워드를 포함하는 이름을 가진 식품 데이터들을 조회")
@@ -53,7 +52,7 @@ public class MealDataQueryServiceTest {
     @DisplayName("식품 데이터 ID에 해당하는 식품 데이터 상세 조회")
     void searchTest() {
         // given
-        MealData found = MealDataFixture.MEAL.getWithName("통밀빵", member);
+        MealData found = MealDataFixture.MEAL.getWithName(1L, "통밀빵", member);
         given(mealDataRepository.findById(anyLong())).willReturn(Optional.ofNullable(found));
         // when
         MealData result = mealDataQueryService.search(found.getId());
@@ -69,6 +68,6 @@ public class MealDataQueryServiceTest {
         // when
         assertThatThrownBy(() -> mealDataQueryService.search(0L))
                 .isInstanceOf(NotFoundEntityException.class)
-                .hasMessage(ErrorCode.MEAL_DATA_NOT_FOUND.getDescription());
+                .hasMessage(ErrorCode.NOT_FOUND_MEAL_DATA.getDescription());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -1,0 +1,132 @@
+package com.konggogi.veganlife.meallog.controller;
+
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.meallog.service.MealLogService;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.support.docs.RestDocsTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(MealLogController.class)
+public class MealLogControllerTest extends RestDocsTest {
+
+    @MockBean MealLogService mealLogService;
+
+    Member member = Member.builder().id(1L).email("test123@test.com").build();
+
+    List<MealAddRequest> mealAddRequests =
+            List.of(
+                    new MealAddRequest(
+                            "통밀빵",
+                            100,
+                            IntakeUnit.G,
+                            100,
+                            10,
+                            10,
+                            10,
+                            MealDataFixture.MEAL.getWithName(1L, "통밀빵", member).getId()),
+                    new MealAddRequest(
+                            "통밀크래커",
+                            100,
+                            IntakeUnit.G,
+                            100,
+                            10,
+                            10,
+                            10,
+                            MealDataFixture.PROCESSED.getWithName(2L, "통밀크래커", member).getId()));
+
+    @Test
+    @DisplayName("식사 기록 등록 API")
+    void addMealLogTest() throws Exception {
+
+        MealLogAddRequest mealLogAddRequest =
+                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/meal-log")
+                                .headers(authorizationHeader())
+                                .content(toJson(mealLogAddRequest))
+                                .contentType(MediaType.APPLICATION_JSON));
+
+        perform.andExpect(status().isCreated());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "meal-log-add",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc())));
+    }
+
+    @Test
+    @DisplayName("식사 기록 등록 API Member Not Found 예외")
+    void addMealLogMemberNotFoundTest() throws Exception {
+
+        MealLogAddRequest mealLogAddRequest =
+                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+
+        willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
+                .given(mealLogService)
+                .add(any(MealLogAddRequest.class), anyLong());
+
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/meal-log")
+                                .headers(authorizationHeader())
+                                .content(toJson(mealLogAddRequest))
+                                .contentType(MediaType.APPLICATION_JSON));
+
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("meal-log-add-member-not-found", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("식사 기록 등록 API MealData Not Found 예외")
+    void addMealLogMealDataNotFoundTest() throws Exception {
+
+        MealLogAddRequest mealLogAddRequest =
+                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+
+        willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEAL_DATA))
+                .given(mealLogService)
+                .add(any(MealLogAddRequest.class), anyLong());
+
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/meal-log")
+                                .headers(authorizationHeader())
+                                .content(toJson(mealLogAddRequest))
+                                .contentType(MediaType.APPLICATION_JSON));
+
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("meal-log-add-meal-data-not-found", getDocumentResponse()));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealFixture.java
@@ -1,0 +1,64 @@
+package com.konggogi.veganlife.meallog.fixture;
+
+
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.meallog.domain.Meal;
+
+public enum MealFixture {
+    DEFAULT("디폴트 음식", 100, IntakeUnit.G, 100, 10, 10, 10);
+
+    private String name;
+    private Integer intake;
+    private IntakeUnit intakeUnit;
+    private Integer calorie;
+    private Integer carbs;
+    private Integer protein;
+    private Integer fat;
+
+    MealFixture(
+            String name,
+            Integer intake,
+            IntakeUnit intakeUnit,
+            Integer calorie,
+            Integer carbs,
+            Integer protein,
+            Integer fat) {
+        this.name = name;
+        this.intake = intake;
+        this.intakeUnit = intakeUnit;
+        this.calorie = calorie;
+        this.carbs = carbs;
+        this.protein = protein;
+        this.fat = fat;
+    }
+
+    public Meal get(MealData mealData) {
+
+        return Meal.builder()
+                .name(name)
+                .intake(intake)
+                .intakeUnit(intakeUnit)
+                .calorie(calorie)
+                .carbs(carbs)
+                .protein(protein)
+                .fat(fat)
+                .mealData(mealData)
+                .build();
+    }
+
+    public Meal getWithId(Long id, MealData mealData) {
+
+        return Meal.builder()
+                .id(id)
+                .name(name)
+                .intake(intake)
+                .intakeUnit(intakeUnit)
+                .calorie(calorie)
+                .carbs(carbs)
+                .protein(protein)
+                .fat(fat)
+                .mealData(mealData)
+                .build();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
@@ -1,0 +1,37 @@
+package com.konggogi.veganlife.meallog.fixture;
+
+
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.member.domain.Member;
+import java.util.List;
+
+public enum MealLogFixture {
+    BREAKFAST(MealType.BREAKFAST),
+    BREAKFAST_SNACK(MealType.BREAKFAST_SNACK),
+    LUNCH(MealType.LUNCH),
+    LUNCH_SNACK(MealType.LUNCH_SNACK),
+    DINNER(MealType.DINNER),
+    DINNER_SNACK(MealType.DINNER_SNACK);
+
+    private MealType mealType;
+
+    MealLogFixture(MealType mealType) {
+        this.mealType = mealType;
+    }
+
+    public MealLog get(List<Meal> meals, Member member) {
+
+        MealLog mealLog = MealLog.builder().mealType(mealType).member(member).build();
+        meals.forEach(mealLog::addMeal);
+        return mealLog;
+    }
+
+    public MealLog getWithId(Long id, List<Meal> meals, Member member) {
+
+        MealLog mealLog = MealLog.builder().id(id).mealType(mealType).member(member).build();
+        meals.forEach(mealLog::addMeal);
+        return mealLog;
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
@@ -1,0 +1,57 @@
+package com.konggogi.veganlife.meallog.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.fixture.MealFixture;
+import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.repository.MemberRepository;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class MealLogRepositoryTest {
+
+    @Autowired MealLogRepository mealLogRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired MealDataRepository mealDataRepository;
+
+    Member member = Member.builder().email("test123@test.com").build();
+    List<MealData> mealData =
+            List.of(
+                    MealDataFixture.MEAL.get(member),
+                    MealDataFixture.MEAL.get(member),
+                    MealDataFixture.MEAL.get(member));
+
+    @BeforeEach
+    void setup() {
+        memberRepository.save(member);
+        mealDataRepository.saveAll(mealData);
+    }
+
+    @Test
+    @DisplayName("MealLog 저장 테스트")
+    void mealLogSaveTest() {
+        // given
+        List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
+        MealLog mealLog = MealLogFixture.BREAKFAST.get(meals, member);
+        // when
+        MealLog result = mealLogRepository.save(mealLog);
+        // then
+        assertThat(result.getId()).isNotNull();
+        assertThat(result.getMember()).isEqualTo(member);
+        assertThat(result.getMeals().size()).isEqualTo(mealLog.getMeals().size());
+        assertThat(result.getMeals().stream().map(Meal::getId)).allMatch(Objects::nonNull);
+        assertThat(result.getMeals().stream().map(Meal::getMealLog)).allMatch(Objects::nonNull);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -1,0 +1,71 @@
+package com.konggogi.veganlife.meallog.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapperImpl;
+import com.konggogi.veganlife.meallog.domain.mapper.MealMapper;
+import com.konggogi.veganlife.meallog.domain.mapper.MealMapperImpl;
+import com.konggogi.veganlife.meallog.repository.MealLogRepository;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MealLogServiceTest {
+
+    @Mock MemberQueryService memberQueryService;
+    @Mock MealDataQueryService mealDataQueryService;
+    @Mock MealLogRepository mealLogRepository;
+    @Spy MealLogMapper mealLogMapper = new MealLogMapperImpl();
+    @Spy MealMapper mealMapper = new MealMapperImpl();
+    @InjectMocks MealLogService mealLogService;
+
+    Member member = Member.builder().id(1L).email("test123@test.com").build();
+    List<MealData> mealData =
+            List.of(
+                    MealDataFixture.MEAL.get(1L, member),
+                    MealDataFixture.MEAL.get(2L, member),
+                    MealDataFixture.MEAL.get(3L, member));
+    List<MealAddRequest> mealAddRequests =
+            mealData.stream()
+                    .map(
+                            m ->
+                                    new MealAddRequest(
+                                            "테스트", 100, IntakeUnit.G, 100, 10, 10, 10, m.getId()))
+                    .toList();
+
+    @Test
+    @DisplayName("식사 기록 저장")
+    void mealLogAddTest() {
+        // given
+        MealLogAddRequest mealLogAddRequest =
+                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+        given(memberQueryService.search(1L)).willReturn(member);
+        mealData.forEach(m -> given(mealDataQueryService.search(m.getId())).willReturn(m));
+        // when
+        mealLogService.add(mealLogAddRequest, member.getId());
+        // then
+        then(memberQueryService).should(times(1)).search(member.getId());
+        mealData.forEach(m -> then(mealDataQueryService).should(times(1)).search(m.getId()));
+        then(mealLogRepository).should(times(1)).save(any(MealLog.class));
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#99 )

## 요약
식사 기록 등록 API에 대한 단위 테스트를 진행하였습니다.
ErrorCode의 이름을 일관되게 수정한다.

## 변경 내용
`MEAL_DATA_NOT_FOUND` -> `NOT_FOUND_MEAL_DATA`