### PR TITLE
주간 섭취량 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -141,3 +141,27 @@ include::{snippets}/today-nutrients/http-response.adoc[]
 ==== 400 NOT FOUND
 
 include::{snippets}/today-nutrients-not-found/http-response.adoc[]
+
+== 주간 섭취량 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/weekly-intake/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/weekly-intake/query-parameters.adoc[]
+
+include::{snippets}/weekly-intake/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/weekly-intake/http-response.adoc[]
+
+==== 400 NOT FOUND
+
+include::{snippets}/weekly-intake-not-found/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealType.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealType.java
@@ -17,4 +17,8 @@ public enum MealType {
     MealType(String value) {
         this.value = value;
     }
+
+    public boolean isSnack() {
+        return this == BREAKFAST_SNACK || this == LUNCH_SNACK || this == DINNER_SNACK;
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
@@ -4,19 +4,18 @@ package com.konggogi.veganlife.member.controller;
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
 import com.konggogi.veganlife.member.controller.dto.request.MemberInfoRequest;
 import com.konggogi.veganlife.member.controller.dto.request.MemberProfileRequest;
-import com.konggogi.veganlife.member.controller.dto.response.MemberInfoResponse;
-import com.konggogi.veganlife.member.controller.dto.response.MemberProfileResponse;
-import com.konggogi.veganlife.member.controller.dto.response.RecommendNutrientsResponse;
-import com.konggogi.veganlife.member.controller.dto.response.TodayIntakeResponse;
+import com.konggogi.veganlife.member.controller.dto.response.*;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
 import com.konggogi.veganlife.member.domain.mapper.NutrientsMapper;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.member.service.MemberService;
 import com.konggogi.veganlife.member.service.NutrientsQueryService;
+import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -76,5 +75,18 @@ public class MemberController {
         IntakeNutrients intakeNutrients =
                 nutrientsQueryService.searchDailyIntakeNutrients(userDetails.id(), date);
         return ResponseEntity.ok(nutrientsMapper.toTodayIntakeResponse(intakeNutrients));
+    }
+
+    @GetMapping("/nutrients/week")
+    public ResponseEntity<CalorieIntakeResponse> getWeeklyIntakeCalorie(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam("endDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
+        List<CaloriesOfMealType> mealCalories =
+                nutrientsQueryService.searchWeeklyIntakeCalories(
+                        userDetails.id(), startDate, endDate);
+        int totalCalorie = nutrientsQueryService.calcTotalCalorie(mealCalories);
+        return ResponseEntity.ok(
+                nutrientsMapper.toCalorieIntakeResponse(totalCalorie, mealCalories));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/dto/response/CalorieIntakeResponse.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/dto/response/CalorieIntakeResponse.java
@@ -1,0 +1,7 @@
+package com.konggogi.veganlife.member.controller.dto.response;
+
+
+import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
+import java.util.List;
+
+public record CalorieIntakeResponse(Integer totalCalorie, List<CaloriesOfMealType> weekly) {}

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/NutrientsMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/NutrientsMapper.java
@@ -1,11 +1,19 @@
 package com.konggogi.veganlife.member.domain.mapper;
 
 
+import com.konggogi.veganlife.member.controller.dto.response.CalorieIntakeResponse;
 import com.konggogi.veganlife.member.controller.dto.response.TodayIntakeResponse;
+import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
+import java.util.List;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface NutrientsMapper {
     TodayIntakeResponse toTodayIntakeResponse(IntakeNutrients intakeNutrients);
+
+    @Mapping(source = "caloriesOfMealTypes", target = "weekly")
+    CalorieIntakeResponse toCalorieIntakeResponse(
+            int totalCalorie, List<CaloriesOfMealType> caloriesOfMealTypes);
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/NutrientsQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/NutrientsQueryService.java
@@ -47,6 +47,19 @@ public class NutrientsQueryService {
                 .toList();
     }
 
+    public int calcTotalCalorie(List<CaloriesOfMealType> caloriesOfMealTypes) {
+        return caloriesOfMealTypes.parallelStream()
+                .reduce(
+                        0,
+                        (accumulator, mealCalorie) ->
+                                accumulator
+                                        + mealCalorie.breakfast()
+                                        + mealCalorie.lunch()
+                                        + mealCalorie.dinner()
+                                        + mealCalorie.snack(),
+                        Integer::sum);
+    }
+
     private List<Meal> findAllMealOfMealLog(
             Long memberId, LocalDateTime startDate, LocalDateTime endDate) {
         return findMealLog(memberId, startDate, endDate).stream()

--- a/src/main/java/com/konggogi/veganlife/member/service/NutrientsQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/NutrientsQueryService.java
@@ -75,17 +75,17 @@ public class NutrientsQueryService {
     }
 
     private IntakeNutrients sumIntakeNutrients(List<Meal> meals) {
-        IntakeNutrients initIntakeNutrients = new IntakeNutrients(0, 0, 0, 0);
-        return meals.stream()
-                .reduce(
-                        initIntakeNutrients,
-                        (accumulator, meal) ->
-                                new IntakeNutrients(
-                                        accumulator.calorie() + meal.getCalorie(),
-                                        accumulator.carbs() + meal.getCarbs(),
-                                        accumulator.protein() + meal.getProtein(),
-                                        accumulator.fat() + meal.getFat()),
-                        IntakeNutrients::combine);
+        int totalCalorie = 0;
+        int totalCarbs = 0;
+        int totalProtein = 0;
+        int totalFat = 0;
+        for (Meal meal : meals) {
+            totalCalorie += meal.getCalorie();
+            totalCarbs += meal.getCarbs();
+            totalProtein += meal.getProtein();
+            totalFat += meal.getFat();
+        }
+        return new IntakeNutrients(totalCalorie, totalCarbs, totalProtein, totalFat);
     }
 
     private CaloriesOfMealType sumCalorieByMealType(List<MealLog> mealLogs) {

--- a/src/main/java/com/konggogi/veganlife/member/service/NutrientsQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/NutrientsQueryService.java
@@ -3,13 +3,15 @@ package com.konggogi.veganlife.member.service;
 
 import com.konggogi.veganlife.meallog.domain.Meal;
 import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
+import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,25 +25,45 @@ public class NutrientsQueryService {
 
     public IntakeNutrients searchDailyIntakeNutrients(Long memberId, LocalDate date) {
         memberQueryService.search(memberId);
-        LocalDateTime startDate = date.atStartOfDay();
-        LocalDateTime endDate = date.atTime(LocalTime.MAX);
-        List<Meal> meals = findAllMealOfMealLog(memberId, startDate, endDate);
+        LocalDateTime startDateTime = date.atStartOfDay();
+        LocalDateTime endDateTime = date.atTime(LocalTime.MAX);
+        List<Meal> meals = findAllMealOfMealLog(memberId, startDateTime, endDateTime);
         return sumIntakeNutrients(meals);
+    }
+
+    public List<CaloriesOfMealType> searchWeeklyIntakeCalories(
+            Long memberId, LocalDate startDate, LocalDate endDate) {
+        memberQueryService.search(memberId);
+        return startDate
+                .datesUntil(endDate.plusDays(1))
+                .map(
+                        date -> {
+                            LocalDateTime startDateTime = date.atStartOfDay();
+                            LocalDateTime endDateTime = date.atTime(LocalTime.MAX);
+                            List<MealLog> mealLogs =
+                                    findMealLog(memberId, startDateTime, endDateTime);
+                            return sumCalorieByMealType(mealLogs);
+                        })
+                .toList();
     }
 
     private List<Meal> findAllMealOfMealLog(
             Long memberId, LocalDateTime startDate, LocalDateTime endDate) {
-        return mealLogRepository
-                .findAllByMemberIdAndModifiedAtBetween(memberId, startDate, endDate)
-                .stream()
+        return findMealLog(memberId, startDate, endDate).stream()
                 .map(MealLog::getMeals)
                 .flatMap(Collection::stream)
                 .toList();
     }
 
+    private List<MealLog> findMealLog(
+            Long memberId, LocalDateTime startDate, LocalDateTime endDate) {
+        return mealLogRepository.findAllByMemberIdAndModifiedAtBetween(
+                memberId, startDate, endDate);
+    }
+
     private IntakeNutrients sumIntakeNutrients(List<Meal> meals) {
         IntakeNutrients initIntakeNutrients = new IntakeNutrients(0, 0, 0, 0);
-        return meals.parallelStream()
+        return meals.stream()
                 .reduce(
                         initIntakeNutrients,
                         (accumulator, meal) ->
@@ -51,5 +73,37 @@ public class NutrientsQueryService {
                                         accumulator.protein() + meal.getProtein(),
                                         accumulator.fat() + meal.getFat()),
                         IntakeNutrients::combine);
+    }
+
+    private CaloriesOfMealType sumCalorieByMealType(List<MealLog> mealLogs) {
+        Map<MealType, Integer> caloriesByMealTypeGroup = calcCaloriesByMealTypeGroup(mealLogs);
+        int snackTotalCalorie = sumSnackTotalCalorie(caloriesByMealTypeGroup);
+        return new CaloriesOfMealType(
+                caloriesByMealTypeGroup.getOrDefault(MealType.BREAKFAST, 0),
+                caloriesByMealTypeGroup.getOrDefault(MealType.LUNCH, 0),
+                caloriesByMealTypeGroup.getOrDefault(MealType.DINNER, 0),
+                snackTotalCalorie);
+    }
+
+    private Map<MealType, Integer> calcCaloriesByMealTypeGroup(List<MealLog> mealLogs) {
+        return mealLogs.stream()
+                .flatMap(
+                        mealLog ->
+                                mealLog.getMeals().stream()
+                                        .map(
+                                                meal ->
+                                                        new AbstractMap.SimpleEntry<>(
+                                                                mealLog.getMealType(),
+                                                                meal.getCalorie())))
+                .collect(
+                        Collectors.groupingBy(
+                                Map.Entry::getKey, Collectors.summingInt(Map.Entry::getValue)));
+    }
+
+    private int sumSnackTotalCalorie(Map<MealType, Integer> caloriesByType) {
+        return Arrays.stream(MealType.values())
+                .filter(MealType::isSnack)
+                .mapToInt(type -> caloriesByType.getOrDefault(type, 0))
+                .sum();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/dto/CaloriesOfMealType.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/dto/CaloriesOfMealType.java
@@ -1,0 +1,3 @@
+package com.konggogi.veganlife.member.service.dto;
+
+public record CaloriesOfMealType(Integer breakfast, Integer lunch, Integer dinner, Integer snack) {}

--- a/src/test/java/com/konggogi/veganlife/member/fixture/CaloriesOfMealTypeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/member/fixture/CaloriesOfMealTypeFixture.java
@@ -1,0 +1,23 @@
+package com.konggogi.veganlife.member.fixture;
+
+
+import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
+
+public enum CaloriesOfMealTypeFixture {
+    DEFAULT(10, 10, 10, 10);
+    private final int breakfast;
+    private final int lunch;
+    private final int dinner;
+    private final int snack;
+
+    CaloriesOfMealTypeFixture(int breakfast, int lunch, int dinner, int snack) {
+        this.breakfast = breakfast;
+        this.lunch = lunch;
+        this.dinner = dinner;
+        this.snack = snack;
+    }
+
+    public CaloriesOfMealType get() {
+        return new CaloriesOfMealType(breakfast, lunch, dinner, snack);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/member/service/NutrientsQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/NutrientsQueryServiceTest.java
@@ -2,6 +2,8 @@ package com.konggogi.veganlife.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
@@ -14,7 +16,9 @@ import com.konggogi.veganlife.meallog.fixture.MealFixture;
 import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.CaloriesOfMealTypeFixture;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -80,5 +84,76 @@ class NutrientsQueryServiceTest {
                                         memberId, LocalDate.now()))
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
+    }
+
+    @Test
+    @DisplayName("주간 섭취량 조회")
+    void searchWeeklyIntakeCalorieTest() {
+        // given
+        Long memberId = member.getId();
+        Meal meal = meals.get(0);
+        LocalDate startDate = LocalDate.of(2023, 12, 17);
+        LocalDate endDate = LocalDate.of(2023, 12, 23);
+        List<MealLog> mealLogs = createMealLogs(startDate);
+        given(memberQueryService.search(memberId)).willReturn(member);
+        given(
+                        mealLogRepository.findAllByMemberIdAndModifiedAtBetween(
+                                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .willReturn(mealLogs);
+        // when
+        List<CaloriesOfMealType> caloriesOfMealTypes =
+                nutrientsQueryService.searchWeeklyIntakeCalories(memberId, startDate, endDate);
+        // then
+        assertThat(caloriesOfMealTypes).hasSize(7);
+        assertThat(caloriesOfMealTypes.get(0).breakfast())
+                .isEqualTo(meal.getCalorie() * meals.size());
+        assertThat(caloriesOfMealTypes.get(0).lunch()).isEqualTo(meal.getCalorie() * meals.size());
+        assertThat(caloriesOfMealTypes.get(0).dinner()).isEqualTo(meal.getCalorie() * meals.size());
+        assertThat(caloriesOfMealTypes.get(0).snack())
+                .isEqualTo(meal.getCalorie() * meals.size() * 3);
+    }
+
+    @Test
+    @DisplayName("주간 섭취량 조회시 없는 회원이면 예외 발생")
+    void searchWeeklyIntakeNutrientsNotMemberTest() {
+        // given
+        Long memberId = member.getId();
+        given(memberQueryService.search(memberId))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
+        // when, then
+        assertThatThrownBy(
+                        () ->
+                                nutrientsQueryService.searchWeeklyIntakeCalories(
+                                        memberId, LocalDate.now(), LocalDate.now()))
+                .isInstanceOf(NotFoundEntityException.class)
+                .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
+    }
+
+    @Test
+    @DisplayName("총 섭취한 칼로리 계산")
+    void calcTotalCalorieTest() {
+        // given
+        List<CaloriesOfMealType> caloriesOfMealTypes =
+                List.of(
+                        CaloriesOfMealTypeFixture.DEFAULT.get(),
+                        CaloriesOfMealTypeFixture.DEFAULT.get());
+        int expectedCalorie =
+                CaloriesOfMealTypeFixture.DEFAULT.get().breakfast()
+                        * 4
+                        * caloriesOfMealTypes.size();
+        // when
+        int totalCalorie = nutrientsQueryService.calcTotalCalorie(caloriesOfMealTypes);
+        // then
+        assertThat(totalCalorie).isEqualTo(expectedCalorie);
+    }
+
+    private List<MealLog> createMealLogs(LocalDate date) {
+        return List.of(
+                MealLogFixture.BREAKFAST.getWithDate(meals, member, date),
+                MealLogFixture.LUNCH.getWithDate(meals, member, date),
+                MealLogFixture.DINNER.getWithDate(meals, member, date),
+                MealLogFixture.BREAKFAST_SNACK.getWithDate(meals, member, date),
+                MealLogFixture.LUNCH_SNACK.getWithDate(meals, member, date),
+                MealLogFixture.DINNER_SNACK.getWithDate(meals, member, date));
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#127 )

## 요약
주간 섭취량 조회 API 구현

## 변경 내용
sumIntakeNutrients() 로직 반복분으로 변경
(금일 섭취량 조회 API에서만 사용되므로 많은 데이터 예상 x -> stream, reduce 오버헤드가 더 큼 > 반복문 변경)

