### PR TITLE
MealLog에 MealImage 컬럼 추가

### DIFF
--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
@@ -10,4 +10,4 @@ import java.util.List;
 public record MealLogAddRequest(
         @NotNull MealType mealType,
         @Valid @NotNull @Size(min = 1, max = 5) List<MealAddRequest> meals,
-        @Size(max = 5) List<String> imageUrls) {}
+        @NotNull @Size(max = 5) List<String> imageUrls) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
@@ -8,4 +8,6 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record MealLogAddRequest(
-        @NotNull MealType mealType, @Valid @NotNull @Size(min = 1) List<MealAddRequest> meals) {}
+        @NotNull MealType mealType,
+        @Valid @NotNull @Size(min = 1, max = 5) List<MealAddRequest> meals,
+        @Size(max = 5) List<String> imageUrls) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealImage.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealImage.java
@@ -1,0 +1,42 @@
+package com.konggogi.veganlife.meallog.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MealImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @ManyToOne
+    @JoinColumn(name = "meal_log_id")
+    private MealLog mealLog;
+
+    @Builder
+    public MealImage(Long id, String imageUrl, MealLog mealLog) {
+        this.id = id;
+        this.imageUrl = imageUrl;
+        this.mealLog = mealLog;
+    }
+
+    public void setMealLog(MealLog mealLog) {
+        this.mealLog = mealLog;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -35,8 +35,11 @@ public class MealLog extends TimeStamped {
     @Enumerated(EnumType.STRING)
     private MealType mealType;
 
-    @OneToMany(mappedBy = "mealLog", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "mealLog", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Meal> meals = new ArrayList<>();
+
+    @OneToMany(mappedBy = "mealLog", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MealImage> mealImages = new ArrayList<>();
 
     @ManyToOne
     @JoinColumn(name = "member_id")
@@ -52,5 +55,10 @@ public class MealLog extends TimeStamped {
     public void addMeal(Meal meal) {
         meals.add(meal);
         meal.setMealLog(this);
+    }
+
+    public void addMealImage(MealImage mealImage) {
+        mealImages.add(mealImage);
+        mealImage.setMealLog(this);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealImageMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealImageMapper.java
@@ -1,0 +1,11 @@
+package com.konggogi.veganlife.meallog.domain.mapper;
+
+
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface MealImageMapper {
+
+    MealImage toEntity(String imageUrl);
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
@@ -13,5 +13,5 @@ public interface MealMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(source = "mealAddRequest.name", target = "name")
     @Mapping(source = "mealAddRequest.intakeUnit", target = "intakeUnit")
-    Meal mealAddRequestToEntity(MealAddRequest mealAddRequest, MealData mealData);
+    Meal toEntity(MealAddRequest mealAddRequest, MealData mealData);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealImageRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealImageRepository.java
@@ -1,0 +1,7 @@
+package com.konggogi.veganlife.meallog.repository;
+
+
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MealImageRepository extends JpaRepository<MealImage, Long> {}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -2,12 +2,15 @@ package com.konggogi.veganlife.meallog.service;
 
 
 import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
 import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.domain.mapper.MealImageMapper;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
 import com.konggogi.veganlife.meallog.domain.mapper.MealMapper;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.service.MemberQueryService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,18 +25,28 @@ public class MealLogService {
     private final MealLogRepository mealLogRepository;
     private final MealLogMapper mealLogMapper;
     private final MealMapper mealMapper;
+    private final MealImageMapper mealImageMapper;
 
     public void add(MealLogAddRequest mealLogAddRequest, Long memberId) {
 
         MealLog mealLog =
                 mealLogMapper.toEntity(
                         mealLogAddRequest.mealType(), memberQueryService.search(memberId));
-        mealLogAddRequest.meals().stream()
+        addMeals(mealLogAddRequest.meals(), mealLog);
+        addMealImages(mealLogAddRequest.imageUrls(), mealLog);
+        mealLogRepository.save(mealLog);
+    }
+
+    private void addMeals(List<MealAddRequest> mealAddRequests, MealLog mealLog) {
+        mealAddRequests.stream()
                 .map(
                         request ->
-                                mealMapper.mealAddRequestToEntity(
+                                mealMapper.toEntity(
                                         request, mealDataQueryService.search(request.mealDataId())))
                 .forEach(mealLog::addMeal);
-        mealLogRepository.save(mealLog);
+    }
+
+    private void addMealImages(List<String> mealImages, MealLog mealLog) {
+        mealImages.stream().map(mealImageMapper::toEntity).forEach(mealLog::addMealImage);
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -57,12 +57,14 @@ public class MealLogControllerTest extends RestDocsTest {
                             10,
                             MealDataFixture.PROCESSED.getWithName(2L, "통밀크래커", member).getId()));
 
+    List<String> imageUrls = List.of("image1.png", "image2.png", "image3.png");
+
     @Test
     @DisplayName("식사 기록 등록 API")
     void addMealLogTest() throws Exception {
 
         MealLogAddRequest mealLogAddRequest =
-                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests, imageUrls);
 
         ResultActions perform =
                 mockMvc.perform(
@@ -87,7 +89,7 @@ public class MealLogControllerTest extends RestDocsTest {
     void addMealLogMemberNotFoundTest() throws Exception {
 
         MealLogAddRequest mealLogAddRequest =
-                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests, imageUrls);
 
         willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
                 .given(mealLogService)
@@ -111,7 +113,7 @@ public class MealLogControllerTest extends RestDocsTest {
     void addMealLogMealDataNotFoundTest() throws Exception {
 
         MealLogAddRequest mealLogAddRequest =
-                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests, imageUrls);
 
         willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEAL_DATA))
                 .given(mealLogService)

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealImageFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealImageFixture.java
@@ -1,0 +1,30 @@
+package com.konggogi.veganlife.meallog.fixture;
+
+
+import com.konggogi.veganlife.meallog.domain.MealImage;
+
+public enum MealImageFixture {
+    DEFAULT("default.png");
+
+    private String imageUrl;
+
+    MealImageFixture(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public MealImage get() {
+        return MealImage.builder().imageUrl(imageUrl).build();
+    }
+
+    public MealImage get(Long id) {
+        return MealImage.builder().id(id).imageUrl(imageUrl).build();
+    }
+
+    public MealImage getWithImageUrl(String imageUrl) {
+        return MealImage.builder().imageUrl(imageUrl).build();
+    }
+
+    public MealImage getWithImageUrl(Long id, String imageUrl) {
+        return MealImage.builder().imageUrl(imageUrl).build();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.meallog.fixture;
 
 
 import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.member.domain.Member;
@@ -24,15 +25,17 @@ public enum MealLogFixture {
         this.mealType = mealType;
     }
 
-    public MealLog get(List<Meal> meals, Member member) {
+    public MealLog get(List<Meal> meals, List<MealImage> mealImages, Member member) {
         MealLog mealLog = MealLog.builder().mealType(mealType).member(member).build();
         meals.forEach(mealLog::addMeal);
+        mealImages.forEach(mealLog::addMealImage);
         return mealLog;
     }
 
-    public MealLog getWithId(Long id, List<Meal> meals, Member member) {
+    public MealLog get(Long id, List<Meal> meals, List<MealImage> mealImages, Member member) {
         MealLog mealLog = MealLog.builder().id(id).mealType(mealType).member(member).build();
         meals.forEach(mealLog::addMeal);
+        mealImages.forEach(mealLog::addMealImage);
         return mealLog;
     }
 

--- a/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
@@ -6,8 +6,10 @@ import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
 import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.fixture.MealFixture;
+import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
 import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.repository.MemberRepository;
@@ -16,6 +18,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,7 +50,10 @@ public class MealLogRepositoryTest {
     void mealLogSaveTest() {
         // given
         List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
-        MealLog mealLog = MealLogFixture.BREAKFAST.get(meals, member);
+        List<MealImage> mealImages =
+                IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
+
+        MealLog mealLog = MealLogFixture.BREAKFAST.get(meals, mealImages, member);
         // when
         MealLog result = mealLogRepository.save(mealLog);
         // then
@@ -56,6 +62,10 @@ public class MealLogRepositoryTest {
         assertThat(result.getMeals().size()).isEqualTo(mealLog.getMeals().size());
         assertThat(result.getMeals().stream().map(Meal::getId)).allMatch(Objects::nonNull);
         assertThat(result.getMeals().stream().map(Meal::getMealLog)).allMatch(Objects::nonNull);
+        assertThat(result.getMealImages().stream().map(MealImage::getId))
+                .allMatch(Objects::nonNull);
+        assertThat(result.getMealImages().stream().map(MealImage::getMealLog))
+                .allMatch(Objects::nonNull);
     }
 
     @Test

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -13,6 +13,8 @@ import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.meallog.domain.mapper.MealImageMapper;
+import com.konggogi.veganlife.meallog.domain.mapper.MealImageMapperImpl;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapperImpl;
 import com.konggogi.veganlife.meallog.domain.mapper.MealMapper;
@@ -37,6 +39,7 @@ public class MealLogServiceTest {
     @Mock MealLogRepository mealLogRepository;
     @Spy MealLogMapper mealLogMapper = new MealLogMapperImpl();
     @Spy MealMapper mealMapper = new MealMapperImpl();
+    @Spy MealImageMapper mealImageMapper = new MealImageMapperImpl();
     @InjectMocks MealLogService mealLogService;
 
     Member member = Member.builder().id(1L).email("test123@test.com").build();
@@ -53,12 +56,14 @@ public class MealLogServiceTest {
                                             "테스트", 100, IntakeUnit.G, 100, 10, 10, 10, m.getId()))
                     .toList();
 
+    List<String> imageUrls = List.of("image1.png", "image2.png", "image3.png");
+
     @Test
     @DisplayName("식사 기록 저장")
     void mealLogAddTest() {
         // given
         MealLogAddRequest mealLogAddRequest =
-                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests, imageUrls);
         given(memberQueryService.search(1L)).willReturn(member);
         mealData.forEach(m -> given(mealDataQueryService.search(m.getId())).willReturn(m));
         // when


### PR DESCRIPTION
## 이슈 번호 (#136)

## 요약
- `MealImage` 엔티티를 추가하고 `MealLog` 엔티티와의 연관관계를 설정해주었습니다.
- 엔티티 추가에 따라 식사 기록 등록 기능을 수정했습니다.
- 식사 기록 등록 기능을 테스트했습니다.

## 변경 내용
`MealImage` 엔티티 추가