### PR TITLE
게시글 좋아요/좋아요 취소 API 구현

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/advice/member/MemberControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/member/MemberControllerAdvice.java
@@ -8,7 +8,7 @@ import com.konggogi.veganlife.global.security.exception.InvalidOauthTokenExcepti
 import com.konggogi.veganlife.global.security.exception.MismatchTokenException;
 import com.konggogi.veganlife.global.util.AopUtils;
 import com.konggogi.veganlife.global.util.LoggingUtils;
-import com.konggogi.veganlife.member.exception.DuplicateNicknameException;
+import com.konggogi.veganlife.member.exception.DuplicatedNicknameException;
 import com.konggogi.veganlife.member.exception.UnsupportedProviderException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,9 +18,9 @@ import org.springframework.web.method.HandlerMethod;
 
 @RestControllerAdvice
 public class MemberControllerAdvice {
-    @ExceptionHandler(DuplicateNicknameException.class)
+    @ExceptionHandler(DuplicatedNicknameException.class)
     public ResponseEntity<ErrorResponse> handleDuplicatedNicknameException(
-            HandlerMethod handlerMethod, DuplicateNicknameException exception) {
+            HandlerMethod handlerMethod, DuplicatedNicknameException exception) {
         LoggingUtils.exceptionLog(
                 AopUtils.extractMethodSignature(handlerMethod), HttpStatus.CONFLICT, exception);
         return ResponseEntity.status(HttpStatus.CONFLICT)

--- a/src/main/java/com/konggogi/veganlife/global/advice/post/PostControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/post/PostControllerAdvice.java
@@ -4,7 +4,7 @@ package com.konggogi.veganlife.global.advice.post;
 import com.konggogi.veganlife.global.exception.dto.response.ErrorResponse;
 import com.konggogi.veganlife.global.util.AopUtils;
 import com.konggogi.veganlife.global.util.LoggingUtils;
-import com.konggogi.veganlife.post.exception.DuplicateLikeException;
+import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -13,9 +13,9 @@ import org.springframework.web.method.HandlerMethod;
 
 @RestControllerAdvice
 public class PostControllerAdvice {
-    @ExceptionHandler(DuplicateLikeException.class)
+    @ExceptionHandler(IllegalLikeStatusException.class)
     public ResponseEntity<ErrorResponse> handleDuplicateLikeExceptionException(
-            HandlerMethod handlerMethod, DuplicateLikeException exception) {
+            HandlerMethod handlerMethod, IllegalLikeStatusException exception) {
         LoggingUtils.exceptionLog(
                 AopUtils.extractMethodSignature(handlerMethod), HttpStatus.CONFLICT, exception);
         return ResponseEntity.status(HttpStatus.CONFLICT)

--- a/src/main/java/com/konggogi/veganlife/global/advice/post/PostControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/post/PostControllerAdvice.java
@@ -1,0 +1,24 @@
+package com.konggogi.veganlife.global.advice.post;
+
+
+import com.konggogi.veganlife.global.exception.dto.response.ErrorResponse;
+import com.konggogi.veganlife.global.util.AopUtils;
+import com.konggogi.veganlife.global.util.LoggingUtils;
+import com.konggogi.veganlife.post.exception.DuplicateLikeException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.HandlerMethod;
+
+@RestControllerAdvice
+public class PostControllerAdvice {
+    @ExceptionHandler(DuplicateLikeException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateLikeExceptionException(
+            HandlerMethod handlerMethod, DuplicateLikeException exception) {
+        LoggingUtils.exceptionLog(
+                AopUtils.extractMethodSignature(handlerMethod), HttpStatus.CONFLICT, exception);
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ErrorResponse.from(exception.getErrorCode()));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -27,7 +27,14 @@ public enum ErrorCode {
     NOT_FOUND_MEMBER("MEMBER_002", "사용자를 찾을 수 없습니다."),
 
     // meal-data
-    NOT_FOUND_MEAL_DATA("MEAL_DATA_001", "식품 정보를 찾을 수 없습니다.");
+    NOT_FOUND_MEAL_DATA("MEAL_DATA_001", "식품 정보를 찾을 수 없습니다."),
+
+    // post
+    NOT_FOUND_POST("POST_001", "게시글을 찾을 수 없습니다."),
+
+    // post-like
+    ALREADY_LIKED("POST_LIKE_001", "좋아요가 되어 있는 게시글입니다."),
+    ALREADY_UNLIKED("POST_LIKE_002", "좋아요가 되어 있지 않은 게시글입니다.");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/konggogi/veganlife/member/exception/DuplicatedNicknameException.java
+++ b/src/main/java/com/konggogi/veganlife/member/exception/DuplicatedNicknameException.java
@@ -4,8 +4,8 @@ package com.konggogi.veganlife.member.exception;
 import com.konggogi.veganlife.global.exception.ApiException;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 
-public class DuplicateNicknameException extends ApiException {
-    public DuplicateNicknameException(ErrorCode errorCode) {
+public class DuplicatedNicknameException extends ApiException {
+    public DuplicatedNicknameException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -6,7 +6,7 @@ import com.konggogi.veganlife.global.security.jwt.RefreshToken;
 import com.konggogi.veganlife.member.controller.dto.request.MemberInfoRequest;
 import com.konggogi.veganlife.member.controller.dto.request.MemberProfileRequest;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.exception.DuplicateNicknameException;
+import com.konggogi.veganlife.member.exception.DuplicatedNicknameException;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
@@ -79,7 +79,7 @@ public class MemberService {
                 .findByNickname(nickname)
                 .ifPresent(
                         member -> {
-                            throw new DuplicateNicknameException(ErrorCode.DUPLICATED_NICKNAME);
+                            throw new DuplicatedNicknameException(ErrorCode.DUPLICATED_NICKNAME);
                         });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
@@ -32,9 +32,16 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/likes")
-    public ResponseEntity<Void> addLike(
+    public ResponseEntity<Void> addPostLike(
             @PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
         likeService.addPostLike(userDetails.id(), postId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{postId}/likes")
+    public ResponseEntity<Void> removePostLike(
+            @PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeService.removePostLike(userDetails.id(), postId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
@@ -6,21 +6,21 @@ import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
 import com.konggogi.veganlife.post.controller.dto.response.PostAddResponse;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.domain.mapper.PostMapper;
+import com.konggogi.veganlife.post.service.LikeService;
 import com.konggogi.veganlife.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/posts")
 public class PostController {
     private final PostService postService;
+    private final LikeService likeService;
     private final PostMapper postMapper;
 
     @PostMapping
@@ -29,5 +29,12 @@ public class PostController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         Post post = postService.add(userDetails.id(), postAddRequest);
         return ResponseEntity.ok(postMapper.toPostAddResponse(post));
+    }
+
+    @PostMapping("/{postId}/likes")
+    public ResponseEntity<Void> addLike(
+            @PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeService.addPostLike(userDetails.id(), postId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -32,6 +32,9 @@ public class Post extends TimeStamped {
     @OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<PostTag> tags = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<PostLike> likes = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -52,5 +55,10 @@ public class Post extends TimeStamped {
     public void addPostImage(PostImage postImage) {
         imageUrls.add(postImage);
         postImage.setPost(this);
+    }
+
+    public void addPostLike(PostLike postLike) {
+        likes.add(postLike);
+        postLike.setPostAndMember(this, member);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -61,4 +61,8 @@ public class Post extends TimeStamped {
         likes.add(postLike);
         postLike.setPostAndMember(this, member);
     }
+
+    public void removePostLike(PostLike postLike) {
+        likes.remove(postLike);
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/post/domain/PostLike.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/PostLike.java
@@ -1,0 +1,39 @@
+package com.konggogi.veganlife.post.domain;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public PostLike(Long id, Post post, Member member) {
+        this.id = id;
+        this.post = post;
+        this.member = member;
+    }
+
+    public void setPostAndMember(Post post, Member member) {
+        this.post = post;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostLikeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostLikeMapper.java
@@ -1,0 +1,14 @@
+package com.konggogi.veganlife.post.domain.mapper;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.PostLike;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface PostLikeMapper {
+    @Mapping(target = "id", ignore = true)
+    PostLike toEntity(Member member, Post post);
+}

--- a/src/main/java/com/konggogi/veganlife/post/exception/DuplicateLikeException.java
+++ b/src/main/java/com/konggogi/veganlife/post/exception/DuplicateLikeException.java
@@ -1,0 +1,15 @@
+package com.konggogi.veganlife.post.exception;
+
+
+import com.konggogi.veganlife.global.exception.ApiException;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+
+public class DuplicateLikeException extends ApiException {
+    public DuplicateLikeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public DuplicateLikeException(ErrorCode errorCode, String description) {
+        super(errorCode, description);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/post/exception/IllegalLikeStatusException.java
+++ b/src/main/java/com/konggogi/veganlife/post/exception/IllegalLikeStatusException.java
@@ -4,12 +4,12 @@ package com.konggogi.veganlife.post.exception;
 import com.konggogi.veganlife.global.exception.ApiException;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 
-public class DuplicateLikeException extends ApiException {
-    public DuplicateLikeException(ErrorCode errorCode) {
+public class IllegalLikeStatusException extends ApiException {
+    public IllegalLikeStatusException(ErrorCode errorCode) {
         super(errorCode);
     }
 
-    public DuplicateLikeException(ErrorCode errorCode, String description) {
+    public IllegalLikeStatusException(ErrorCode errorCode, String description) {
         super(errorCode, description);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/post/repository/PostLikeRepository.java
@@ -1,0 +1,10 @@
+package com.konggogi.veganlife.post.repository;
+
+
+import com.konggogi.veganlife.post.domain.PostLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findByMemberIdAndId(Long postId, Long memberId);
+}

--- a/src/main/java/com/konggogi/veganlife/post/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/LikeService.java
@@ -25,4 +25,11 @@ public class LikeService {
         PostLike postLike = postLikeMapper.toEntity(member, post);
         post.addPostLike(postLike);
     }
+
+    public void removePostLike(Long memberId, Long postId) {
+        memberQueryService.search(memberId);
+        Post post = postQueryService.search(postId);
+        PostLike postLike = postQueryService.validatePostLikeIsNotExist(memberId, postId);
+        post.removePostLike(postLike);
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/post/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/LikeService.java
@@ -1,0 +1,28 @@
+package com.konggogi.veganlife.post.service;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.PostLike;
+import com.konggogi.veganlife.post.domain.mapper.PostLikeMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class LikeService {
+    private final MemberQueryService memberQueryService;
+    private final PostQueryService postQueryService;
+    private final PostLikeMapper postLikeMapper;
+
+    public void addPostLike(Long memberId, Long postId) {
+        Member member = memberQueryService.search(memberId);
+        Post post = postQueryService.search(postId);
+        postQueryService.validatePostLikeIsExist(memberId, postId);
+        PostLike postLike = postLikeMapper.toEntity(member, post);
+        post.addPostLike(postLike);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -4,6 +4,7 @@ package com.konggogi.veganlife.post.service;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.PostLike;
 import com.konggogi.veganlife.post.exception.DuplicateLikeException;
 import com.konggogi.veganlife.post.repository.PostLikeRepository;
 import com.konggogi.veganlife.post.repository.PostRepository;
@@ -28,8 +29,17 @@ public class PostQueryService {
         postLikeRepository
                 .findByMemberIdAndId(memberId, postId)
                 .ifPresent(
-                        (postLike) -> {
+                        postLike -> {
                             throw new DuplicateLikeException(ErrorCode.ALREADY_LIKED);
+                        });
+    }
+
+    public PostLike validatePostLikeIsNotExist(Long memberId, Long postId) {
+        return postLikeRepository
+                .findByMemberIdAndId(memberId, postId)
+                .orElseThrow(
+                        () -> {
+                            throw new DuplicateLikeException(ErrorCode.ALREADY_UNLIKED);
                         });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -5,7 +5,7 @@ import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.domain.PostLike;
-import com.konggogi.veganlife.post.exception.DuplicateLikeException;
+import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
 import com.konggogi.veganlife.post.repository.PostLikeRepository;
 import com.konggogi.veganlife.post.repository.PostRepository;
 import java.util.Optional;
@@ -34,7 +34,7 @@ public class PostQueryService {
         searchPostLike(memberId, postId)
                 .ifPresent(
                         postLike -> {
-                            throw new DuplicateLikeException(ErrorCode.ALREADY_LIKED);
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED);
                         });
     }
 
@@ -42,7 +42,7 @@ public class PostQueryService {
         return searchPostLike(memberId, postId)
                 .orElseThrow(
                         () -> {
-                            throw new DuplicateLikeException(ErrorCode.ALREADY_UNLIKED);
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_UNLIKED);
                         });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -4,10 +4,9 @@ package com.konggogi.veganlife.post.service;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.domain.PostLike;
+import com.konggogi.veganlife.post.exception.DuplicateLikeException;
 import com.konggogi.veganlife.post.repository.PostLikeRepository;
 import com.konggogi.veganlife.post.repository.PostRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +24,12 @@ public class PostQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_POST));
     }
 
-    public Optional<PostLike> searchPostLike(Long memberId, Long postId) {
-        return postLikeRepository.findByMemberIdAndId(memberId, postId);
+    public void validatePostLikeIsExist(Long memberId, Long postId) {
+        postLikeRepository
+                .findByMemberIdAndId(memberId, postId)
+                .ifPresent(
+                        (postLike) -> {
+                            throw new DuplicateLikeException(ErrorCode.ALREADY_LIKED);
+                        });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -8,6 +8,7 @@ import com.konggogi.veganlife.post.domain.PostLike;
 import com.konggogi.veganlife.post.exception.DuplicateLikeException;
 import com.konggogi.veganlife.post.repository.PostLikeRepository;
 import com.konggogi.veganlife.post.repository.PostRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,9 +26,12 @@ public class PostQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_POST));
     }
 
+    public Optional<PostLike> searchPostLike(Long memberId, Long postId) {
+        return postLikeRepository.findByMemberIdAndId(memberId, postId);
+    }
+
     public void validatePostLikeIsExist(Long memberId, Long postId) {
-        postLikeRepository
-                .findByMemberIdAndId(memberId, postId)
+        searchPostLike(memberId, postId)
                 .ifPresent(
                         postLike -> {
                             throw new DuplicateLikeException(ErrorCode.ALREADY_LIKED);
@@ -35,8 +39,7 @@ public class PostQueryService {
     }
 
     public PostLike validatePostLikeIsNotExist(Long memberId, Long postId) {
-        return postLikeRepository
-                .findByMemberIdAndId(memberId, postId)
+        return searchPostLike(memberId, postId)
                 .orElseThrow(
                         () -> {
                             throw new DuplicateLikeException(ErrorCode.ALREADY_UNLIKED);

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -1,0 +1,31 @@
+package com.konggogi.veganlife.post.service;
+
+
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.PostLike;
+import com.konggogi.veganlife.post.repository.PostLikeRepository;
+import com.konggogi.veganlife.post.repository.PostRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostQueryService {
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    public Post search(Long postId) {
+        return postRepository
+                .findById(postId)
+                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_POST));
+    }
+
+    public Optional<PostLike> searchPostLike(Long memberId, Long postId) {
+        return postLikeRepository.findByMemberIdAndId(memberId, postId);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -20,7 +20,7 @@ import com.konggogi.veganlife.member.controller.dto.request.MemberProfileRequest
 import com.konggogi.veganlife.member.domain.Gender;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.VegetarianType;
-import com.konggogi.veganlife.member.exception.DuplicateNicknameException;
+import com.konggogi.veganlife.member.exception.DuplicatedNicknameException;
 import com.konggogi.veganlife.member.fixture.CaloriesOfMealTypeFixture;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.service.MemberQueryService;
@@ -82,7 +82,7 @@ class MemberControllerTest extends RestDocsTest {
         MemberInfoRequest request =
                 new MemberInfoRequest("테스트유저", Gender.M, VegetarianType.LACTO, 1990, 180, 83);
         given(memberService.modifyMemberInfo(anyLong(), any(MemberInfoRequest.class)))
-                .willThrow(new DuplicateNicknameException(ErrorCode.DUPLICATED_NICKNAME));
+                .willThrow(new DuplicatedNicknameException(ErrorCode.DUPLICATED_NICKNAME));
         // when
         ResultActions perform =
                 mockMvc.perform(
@@ -219,7 +219,7 @@ class MemberControllerTest extends RestDocsTest {
                 new MemberProfileRequest(
                         "nickname", "imageUrl", VegetarianType.LACTO, Gender.M, 1993, 190, 90);
         given(memberService.modifyMemberProfile(anyLong(), any(MemberProfileRequest.class)))
-                .willThrow(new DuplicateNicknameException(ErrorCode.DUPLICATED_NICKNAME));
+                .willThrow(new DuplicatedNicknameException(ErrorCode.DUPLICATED_NICKNAME));
         // when
         ResultActions perform =
                 mockMvc.perform(

--- a/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
@@ -17,7 +17,7 @@ import com.konggogi.veganlife.member.controller.dto.request.MemberProfileRequest
 import com.konggogi.veganlife.member.domain.Gender;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.VegetarianType;
-import com.konggogi.veganlife.member.exception.DuplicateNicknameException;
+import com.konggogi.veganlife.member.exception.DuplicatedNicknameException;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
@@ -109,7 +109,7 @@ class MemberServiceTest {
         given(memberRepository.findByNickname(nickname)).willReturn(Optional.of(existingMember));
         // when, then
         assertThatThrownBy(() -> memberService.modifyMemberInfo(memberId, request))
-                .isInstanceOf(DuplicateNicknameException.class);
+                .isInstanceOf(DuplicatedNicknameException.class);
         then(memberRepository).should().findByNickname(nickname);
         then(memberRepository).should(never()).save(any(Member.class));
     }
@@ -190,7 +190,7 @@ class MemberServiceTest {
                 .willReturn(Optional.of(existingMember));
         // when, then
         assertThatThrownBy(() -> memberService.modifyMemberProfile(memberId, profileRequest))
-                .isInstanceOf(DuplicateNicknameException.class)
+                .isInstanceOf(DuplicatedNicknameException.class)
                 .hasMessageContaining(ErrorCode.DUPLICATED_NICKNAME.getDescription());
         then(memberRepository).should().findByNickname(anyString());
         then(memberQueryService).should(never()).search(anyLong());

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -18,6 +18,7 @@ import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.fixture.PostFixture;
 import com.konggogi.veganlife.post.fixture.PostImageFixture;
+import com.konggogi.veganlife.post.service.LikeService;
 import com.konggogi.veganlife.post.service.PostService;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.springframework.test.web.servlet.ResultActions;
 @WebMvcTest(PostController.class)
 class PostControllerTest extends RestDocsTest {
     @MockBean PostService postService;
+    @MockBean LikeService likeService;
 
     @Test
     @DisplayName("게시글 등록 API")


### PR DESCRIPTION
## 이슈 번호 (#128 )

## 요약
게시글 좋아요/좋아요 취소 API 구현

## 코멘트
Q1.
case1. 게시글을 좋아요 할 때, 이미 게시글에 좋아요가 되어 있다면 에러 발생
case2. 게시글의 좋아요를 취소할 때, 이미 게시글에 좋아요가 되어있지 않으면 에러 발생
이때 ```DuplicateLikeException``` 커스텀 에러를 발생시킵니다.
우선, 더 좋은 클래스명이 있는지 의견을 구하고 싶습니다.


Q2. 
회원 정보 수정 시, 닉네임 중복이면 ```DuplicateNicknameException```이 발생합니다.
이는 ```DuplicateLikeException```와 유사하다고 여겨집니다.

만약, ```DuplicateLikeException```을 계속 사용하게 된다면 ```DuplicateException```으로 통일 시키는 것도 좋을 것 같은데 어떻게 생각하시나요?

Q3. 
ErrorCode에 좋아요 관련은 ```POST_LIKE_001```과 같이 되어 있습니다. 세부적으로 분리하지 않고 ```POST_00x```를 사용하는 것이 좋을지 의견을 묻고 싶습니다.

테스트는 위 사항을 반영한 뒤 작성하려고 합니다.😉
