### PR TITLE
식사 기록 목록 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/meal-log.adoc
+++ b/src/docs/asciidoc/meal-log.adoc
@@ -33,3 +33,27 @@ include::{snippets}/meal-log-add-meal-data-not-found/http-response.adoc[]
 ==== 404 NOT FOUND
 include::{snippets}/meal-log-add-member-not-found/http-response.adoc[]
 
+
+== 식사 기록 목록 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/meal-log-get-meal-log-list/request-headers.adoc[]
+
+==== Request
+
+include::{snippets}/meal-log-get-meal-log-list/query-parameters.adoc[]
+
+==== Parameter
+
+include::{snippets}/meal-log-get-meal-log-list/http-request.adoc[]
+
+
+=== Response
+
+==== 200 OK
+thumbnailUrl이 존재하지 않을 경우 null 전달
+include::{snippets}/meal-log-get-meal-log-list/http-response.adoc[]
+

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MealLogRepository extends JpaRepository<MealLog, Long> {
-    List<MealLog> findAllByMemberIdAndModifiedAtBetween(
+    List<MealLog> findAllByMemberIdAndCreatedAtBetween(
             Long memberId, LocalDateTime startDate, LocalDateTime endDate);
 
     @Query(

--- a/src/main/java/com/konggogi/veganlife/member/service/NutrientsQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/NutrientsQueryService.java
@@ -70,8 +70,7 @@ public class NutrientsQueryService {
 
     private List<MealLog> findMealLog(
             Long memberId, LocalDateTime startDate, LocalDateTime endDate) {
-        return mealLogRepository.findAllByMemberIdAndModifiedAtBetween(
-                memberId, startDate, endDate);
+        return mealLogRepository.findAllByMemberIdAndCreatedAtBetween(memberId, startDate, endDate);
     }
 
     private IntakeNutrients sumIntakeNutrients(List<Meal> meals) {

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -4,27 +4,46 @@ import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRe
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapperImpl;
+import com.konggogi.veganlife.meallog.fixture.MealFixture;
+import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
+import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.meallog.service.MealLogQueryService;
 import com.konggogi.veganlife.meallog.service.MealLogService;
+import com.konggogi.veganlife.meallog.service.dto.MealLogList;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Spy;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -35,8 +54,14 @@ public class MealLogControllerTest extends RestDocsTest {
 
     @MockBean MealLogService mealLogService;
     @MockBean MealLogQueryService mealLogQueryService;
+    @Spy MealLogMapper mealLogMapper = new MealLogMapperImpl();
 
     Member member = Member.builder().id(1L).email("test123@test.com").build();
+    List<MealData> mealData =
+            List.of(
+                    MealDataFixture.MEAL.get(member),
+                    MealDataFixture.MEAL.get(member),
+                    MealDataFixture.MEAL.get(member));
 
     List<MealAddRequest> mealAddRequests =
             List.of(
@@ -132,5 +157,53 @@ public class MealLogControllerTest extends RestDocsTest {
 
         perform.andDo(print())
                 .andDo(document("meal-log-add-meal-data-not-found", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("식사 기록 목록 조회 API")
+    void getMealLogListTest() throws Exception {
+
+        LocalDate date = LocalDate.of(2023, 12, 22);
+        List<MealLogList> mealLogs = IntStream.of(0, 3, 6).mapToObj(this::getMealLogList).toList();
+
+        given(mealLogQueryService.searchByDate(date, member.getId())).willReturn(mealLogs);
+
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/api/v1/meal-log")
+                                .headers(authorizationHeader())
+                                .queryParam("date", LocalDate.of(2023, 12, 22).toString()));
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[1].id").value(4))
+                .andExpect(jsonPath("$[2].id").value(7));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "meal-log-get-meal-log-list",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                queryParameters(parameterWithName("date").description("조회 날짜"))));
+    }
+
+    private MealLogList getMealLogList(long v) {
+        List<Meal> meals =
+                LongStream.range(v, v + 3)
+                        .mapToObj(
+                                idx ->
+                                        MealFixture.DEFAULT.get(
+                                                idx + 1, mealData.get((int) idx % 3)))
+                        .toList();
+        List<MealImage> mealImages =
+                LongStream.range(v, v + 3)
+                        .mapToObj(idx -> MealImageFixture.DEFAULT.get(idx + 1))
+                        .toList();
+        MealLog mealLog =
+                MealLogFixture.BREAKFAST.getWithDate(
+                        v + 1, LocalDate.of(2022, 12, 22), meals, mealImages, member);
+        return new MealLogList(mealLog, "image" + (v + 1) + ".png", 300);
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealFixture.java
@@ -47,7 +47,7 @@ public enum MealFixture {
                 .build();
     }
 
-    public Meal getWithId(Long id, MealData mealData) {
+    public Meal get(Long id, MealData mealData) {
 
         return Meal.builder()
                 .id(id)

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
@@ -39,16 +39,26 @@ public enum MealLogFixture {
         return mealLog;
     }
 
-    public MealLog getWithDate(List<Meal> meals, Member member, LocalDate date) {
+    public MealLog getWithDate(
+            LocalDate date, List<Meal> meals, List<MealImage> mealImages, Member member) {
         MealLog mealLog = MealLog.builder().mealType(mealType).member(member).build();
         meals.forEach(mealLog::addMeal);
-        return setModifiedAt(mealLog, date);
+        mealImages.forEach(mealLog::addMealImage);
+        return setCreatedAt(mealLog, date);
     }
 
-    private MealLog setModifiedAt(MealLog mealLog, LocalDate date) {
-        Field modifiedAt = ReflectionUtils.findField(MealLog.class, "modifiedAt");
-        ReflectionUtils.makeAccessible(modifiedAt);
-        ReflectionUtils.setField(modifiedAt, mealLog, date.atStartOfDay());
+    public MealLog getWithDate(
+            Long id, LocalDate date, List<Meal> meals, List<MealImage> mealImages, Member member) {
+        MealLog mealLog = MealLog.builder().id(id).mealType(mealType).member(member).build();
+        meals.forEach(mealLog::addMeal);
+        mealImages.forEach(mealLog::addMealImage);
+        return setCreatedAt(mealLog, date);
+    }
+
+    private MealLog setCreatedAt(MealLog mealLog, LocalDate date) {
+        Field createdAt = ReflectionUtils.findField(MealLog.class, "createdAt");
+        ReflectionUtils.makeAccessible(createdAt);
+        ReflectionUtils.setField(createdAt, mealLog, date.atStartOfDay());
         return mealLog;
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
@@ -1,0 +1,85 @@
+package com.konggogi.veganlife.meallog.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.fixture.MealFixture;
+import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
+import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
+import com.konggogi.veganlife.meallog.repository.MealLogRepository;
+import com.konggogi.veganlife.meallog.service.dto.MealLogList;
+import com.konggogi.veganlife.member.domain.Member;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MealLogQueryServiceTest {
+
+    @Mock MealLogRepository mealLogRepository;
+    @InjectMocks MealLogQueryService mealLogQueryService;
+
+    Member member = Member.builder().email("test123@test.com").build();
+    List<MealData> mealData =
+            List.of(
+                    MealDataFixture.MEAL.get(member),
+                    MealDataFixture.MEAL.get(member),
+                    MealDataFixture.MEAL.get(member));
+
+    @Test
+    @DisplayName("해당 날짜의 MealLog 목록 조회 - 이미지가 있는 경우")
+    void searchByDateTest() {
+
+        List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
+        List<MealImage> mealImages =
+                IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
+        LocalDate date = LocalDate.of(2023, 12, 22);
+        List<MealLog> mealLogs =
+                List.of(MealLogFixture.BREAKFAST.getWithDate(date, meals, mealImages, member));
+        String expectedThumbnailUrl = mealLogs.get(0).getMealImages().get(0).getImageUrl();
+        int expectedTotalCalorie =
+                mealLogs.get(0).getMeals().stream().mapToInt(Meal::getCalorie).sum();
+        given(mealLogRepository.findAllByDate(date, member.getId())).willReturn(mealLogs);
+
+        List<MealLogList> mealLogList = mealLogQueryService.searchByDate(date, member.getId());
+
+        assertThat(mealLogList.size()).isEqualTo(1);
+        assertThat(mealLogList.get(0).mealLog()).isEqualTo(mealLogs.get(0));
+        assertThat(mealLogList.get(0).thumbnailUrl()).isEqualTo(expectedThumbnailUrl);
+        assertThat(mealLogList.get(0).totalCalorie()).isEqualTo(expectedTotalCalorie);
+    }
+
+    @Test
+    @DisplayName("해당 날짜의 MealLog 목록 조회 - 이미지가 없는 경우")
+    void searchByDateWithoutImageTest() {
+
+        List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
+        LocalDate date = LocalDate.of(2023, 12, 22);
+        List<MealLog> mealLogs =
+                List.of(
+                        MealLogFixture.BREAKFAST.getWithDate(
+                                date, meals, new ArrayList<>(), member));
+        int expectedTotalCalorie =
+                mealLogs.get(0).getMeals().stream().mapToInt(Meal::getCalorie).sum();
+        given(mealLogRepository.findAllByDate(date, member.getId())).willReturn(mealLogs);
+
+        List<MealLogList> mealLogList = mealLogQueryService.searchByDate(date, member.getId());
+
+        assertThat(mealLogList.size()).isEqualTo(1);
+        assertThat(mealLogList.get(0).mealLog()).isEqualTo(mealLogs.get(0));
+        assertThat(mealLogList.get(0).thumbnailUrl()).isEqualTo(null);
+        assertThat(mealLogList.get(0).totalCalorie()).isEqualTo(expectedTotalCalorie);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/member/service/NutrientsQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/NutrientsQueryServiceTest.java
@@ -11,8 +11,10 @@ import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.fixture.MealFixture;
+import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
 import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
@@ -24,6 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +43,8 @@ class NutrientsQueryServiceTest {
     private final List<MealData> mealData =
             List.of(MealDataFixture.MEAL.get(member), MealDataFixture.MEAL.get(member));
     private List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
+    private List<MealImage> mealImages =
+            IntStream.range(0, 2).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
     private List<MealLog> mealLogs;
 
     @Test
@@ -50,15 +55,17 @@ class NutrientsQueryServiceTest {
         Meal meal = meals.get(0);
         mealLogs =
                 List.of(
-                        MealLogFixture.BREAKFAST.getWithDate(meals, member, LocalDate.now()),
-                        MealLogFixture.LUNCH.getWithDate(meals, member, LocalDate.now()));
+                        MealLogFixture.BREAKFAST.getWithDate(
+                                LocalDate.now(), meals, mealImages, member),
+                        MealLogFixture.LUNCH.getWithDate(
+                                LocalDate.now(), meals, mealImages, member));
         int expectedSize = meals.size() * mealLogs.size();
-        LocalDate date = mealLogs.get(0).getModifiedAt().toLocalDate();
+        LocalDate date = mealLogs.get(0).getCreatedAt().toLocalDate();
         LocalDateTime startDate = date.atStartOfDay();
         LocalDateTime endDate = date.atTime(LocalTime.MAX);
 
         given(memberQueryService.search(memberId)).willReturn(member);
-        given(mealLogRepository.findAllByMemberIdAndModifiedAtBetween(memberId, startDate, endDate))
+        given(mealLogRepository.findAllByMemberIdAndCreatedAtBetween(memberId, startDate, endDate))
                 .willReturn(mealLogs);
         // when
         IntakeNutrients intakeNutrients =
@@ -97,7 +104,7 @@ class NutrientsQueryServiceTest {
         List<MealLog> mealLogs = createMealLogs(startDate);
         given(memberQueryService.search(memberId)).willReturn(member);
         given(
-                        mealLogRepository.findAllByMemberIdAndModifiedAtBetween(
+                        mealLogRepository.findAllByMemberIdAndCreatedAtBetween(
                                 anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
                 .willReturn(mealLogs);
         // when
@@ -149,11 +156,11 @@ class NutrientsQueryServiceTest {
 
     private List<MealLog> createMealLogs(LocalDate date) {
         return List.of(
-                MealLogFixture.BREAKFAST.getWithDate(meals, member, date),
-                MealLogFixture.LUNCH.getWithDate(meals, member, date),
-                MealLogFixture.DINNER.getWithDate(meals, member, date),
-                MealLogFixture.BREAKFAST_SNACK.getWithDate(meals, member, date),
-                MealLogFixture.LUNCH_SNACK.getWithDate(meals, member, date),
-                MealLogFixture.DINNER_SNACK.getWithDate(meals, member, date));
+                MealLogFixture.BREAKFAST.getWithDate(date, meals, mealImages, member),
+                MealLogFixture.LUNCH.getWithDate(date, meals, mealImages, member),
+                MealLogFixture.DINNER.getWithDate(date, meals, mealImages, member),
+                MealLogFixture.BREAKFAST_SNACK.getWithDate(date, meals, mealImages, member),
+                MealLogFixture.LUNCH_SNACK.getWithDate(date, meals, mealImages, member),
+                MealLogFixture.DINNER_SNACK.getWithDate(date, meals, mealImages, member));
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#133)

## 요약
- modifiedAt -> createdAt 기반 MealLog 조회로 수정했습니다.
- 특정 날짜의 식사 기록 목록 조회 기능에 대한 단위 테스트를 수행했습니다.
- API를 문서화했습니다.

## 확인 필요

repository 단위 테스트 시, 날짜 관련 테스트를 진행하기 위해서는 createdAt을 변경해야 합니다.
그러나 전체 테스트를 돌릴 때, `@SpringBootTest`를 실행하는 과정에서 `JpaAuditingConfig` 클래스를 빈으로 등록하고 이를 캐싱하기 때문에 repository 테스트를 돌릴 때에도 JpaAuditing이 적용되어버립니다.

JpaAuditing에 영향을 받지 않고 repository 테스트를 하기 위해서는 다음과 같이 설정해주어야 합니다.

```java
@DataJpaTest
@EnableJpaAuditing(setDates = false)
public class MealLogRepositoryTest {
...
```

