### PR TITLE
식사 기록 상세 조회 API 테스트

### DIFF
--- a/src/docs/asciidoc/meal-log.adoc
+++ b/src/docs/asciidoc/meal-log.adoc
@@ -18,8 +18,6 @@ endif::[]
 
 include::{snippets}/meal-log-add/request-headers.adoc[]
 
-==== Parameter
-
 include::{snippets}/meal-log-add/http-request.adoc[]
 
 === Response
@@ -42,11 +40,9 @@ include::{snippets}/meal-log-add-member-not-found/http-response.adoc[]
 
 include::{snippets}/meal-log-get-meal-log-list/request-headers.adoc[]
 
-==== Request
+==== Parameter
 
 include::{snippets}/meal-log-get-meal-log-list/query-parameters.adoc[]
-
-==== Parameter
 
 include::{snippets}/meal-log-get-meal-log-list/http-request.adoc[]
 
@@ -56,4 +52,29 @@ include::{snippets}/meal-log-get-meal-log-list/http-request.adoc[]
 ==== 200 OK
 thumbnailUrl이 존재하지 않을 경우 null 전달
 include::{snippets}/meal-log-get-meal-log-list/http-response.adoc[]
+
+== 식사 기록 상세 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/meal-log-get-meal-details/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/meal-log-get-meal-details/path-parameters.adoc[]
+
+include::{snippets}/meal-log-get-meal-details/http-request.adoc[]
+
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/meal-log-get-meal-details/http-response.adoc[]
+
+==== 404 Not Found
+
+include::{snippets}/meal-log-get-meal-details-not-found/http-response.adoc[]
 

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -10,6 +10,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -34,8 +35,10 @@ import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
 import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.meallog.service.MealLogQueryService;
 import com.konggogi.veganlife.meallog.service.MealLogService;
+import com.konggogi.veganlife.meallog.service.dto.MealLogDetails;
 import com.konggogi.veganlife.meallog.service.dto.MealLogList;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
 import java.time.LocalDate;
 import java.util.List;
@@ -60,7 +63,7 @@ public class MealLogControllerTest extends RestDocsTest {
     List<MealData> mealData =
             List.of(
                     MealDataFixture.MEAL.get(member),
-                    MealDataFixture.MEAL.get(member),
+                    MealDataFixture.PROCESSED.get(member),
                     MealDataFixture.MEAL.get(member));
 
     List<MealAddRequest> mealAddRequests =
@@ -189,6 +192,57 @@ public class MealLogControllerTest extends RestDocsTest {
                                 queryParameters(parameterWithName("date").description("조회 날짜"))));
     }
 
+    @Test
+    @DisplayName("식사 기록 상세 조회 API")
+    void getMealLogDetailsTest() throws Exception {
+
+        MealLogDetails mealLogDetails = getMealLogDetails();
+
+        given(mealLogQueryService.search(1L)).willReturn(mealLogDetails);
+
+        ResultActions perform =
+                mockMvc.perform(get("/api/v1/meal-log/{id}", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.mealLogId").value(1))
+                .andExpect(jsonPath("$.mealType").value(MealType.BREAKFAST.name()))
+                .andExpect(jsonPath("$.intakeNutrients.calorie").value(300))
+                .andExpect(jsonPath("$.intakeNutrients.carbs").value(30))
+                .andExpect(jsonPath("$.intakeNutrients.protein").value(30))
+                .andExpect(jsonPath("$.intakeNutrients.fat").value(30))
+                .andExpect(jsonPath("$.imageUrls.size()").value(3))
+                .andExpect(jsonPath("$.meals.size()").value(3));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "meal-log-get-meal-details",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("id").description("식단 기록 id"))));
+    }
+
+    @Test
+    @DisplayName("식사 기록 상세 조회 API - MealLog Not Found")
+    void getMealLogDetailsNotFoundTest() throws Exception {
+
+        given(mealLogQueryService.search(1L))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEAL_LOG));
+
+        ResultActions perform =
+                mockMvc.perform(get("/api/v1/meal-log/{id}", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "meal-log-get-meal-details-not-found",
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc())));
+    }
+
     private MealLogList getMealLogList(long v) {
         List<Meal> meals =
                 LongStream.range(v, v + 3)
@@ -205,5 +259,25 @@ public class MealLogControllerTest extends RestDocsTest {
                 MealLogFixture.BREAKFAST.getWithDate(
                         v + 1, LocalDate.of(2022, 12, 22), meals, mealImages, member);
         return new MealLogList(mealLog, "image" + (v + 1) + ".png", 300);
+    }
+
+    private MealLogDetails getMealLogDetails() {
+        List<Meal> meals =
+                List.of(
+                        MealFixture.DEFAULT.get(1L, mealData.get(0)),
+                        MealFixture.DEFAULT.get(2L, mealData.get(1)),
+                        MealFixture.DEFAULT.get(3L, mealData.get(2)));
+        IntakeNutrients intakeNutrients =
+                new IntakeNutrients(
+                        meals.stream().mapToInt(Meal::getCalorie).sum(),
+                        meals.stream().mapToInt(Meal::getCarbs).sum(),
+                        meals.stream().mapToInt(Meal::getProtein).sum(),
+                        meals.stream().mapToInt(Meal::getFat).sum());
+        List<MealImage> mealImages =
+                LongStream.range(1, 4).mapToObj(MealImageFixture.DEFAULT::get).toList();
+        MealLog mealLog =
+                MealLogFixture.BREAKFAST.getWithDate(
+                        1L, LocalDate.of(2023, 12, 22), meals, mealImages, member);
+        return new MealLogDetails(mealLog, intakeNutrients, mealImages, meals);
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
@@ -1,8 +1,11 @@
 package com.konggogi.veganlife.meallog.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.meallog.domain.Meal;
@@ -12,12 +15,15 @@ import com.konggogi.veganlife.meallog.fixture.MealFixture;
 import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
 import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
+import com.konggogi.veganlife.meallog.service.dto.MealLogDetails;
 import com.konggogi.veganlife.meallog.service.dto.MealLogList;
 import com.konggogi.veganlife.member.domain.Member;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,9 +40,9 @@ public class MealLogQueryServiceTest {
     Member member = Member.builder().email("test123@test.com").build();
     List<MealData> mealData =
             List.of(
-                    MealDataFixture.MEAL.get(member),
-                    MealDataFixture.MEAL.get(member),
-                    MealDataFixture.MEAL.get(member));
+                    MealDataFixture.MEAL.get(1L, member),
+                    MealDataFixture.MEAL.get(2L, member),
+                    MealDataFixture.MEAL.get(3L, member));
 
     @Test
     @DisplayName("해당 날짜의 MealLog 목록 조회 - 이미지가 있는 경우")
@@ -81,5 +87,42 @@ public class MealLogQueryServiceTest {
         assertThat(mealLogList.get(0).mealLog()).isEqualTo(mealLogs.get(0));
         assertThat(mealLogList.get(0).thumbnailUrl()).isEqualTo(null);
         assertThat(mealLogList.get(0).totalCalorie()).isEqualTo(expectedTotalCalorie);
+    }
+
+    @Test
+    @DisplayName("해당 id의 MealLog 상세 조회")
+    void searchTest() {
+
+        List<Meal> meals =
+                List.of(
+                        MealFixture.DEFAULT.get(1L, mealData.get(0)),
+                        MealFixture.DEFAULT.get(2L, mealData.get(1)),
+                        MealFixture.DEFAULT.get(3L, mealData.get(2)));
+        List<MealImage> mealImages =
+                LongStream.range(1, 4).mapToObj(MealImageFixture.DEFAULT::get).toList();
+        MealLog mealLog = MealLogFixture.BREAKFAST.get(1L, meals, mealImages, member);
+
+        given(mealLogRepository.findById(1L)).willReturn(Optional.ofNullable(mealLog));
+
+        MealLogDetails mealLogDetails = mealLogQueryService.search(1L);
+
+        assertThat(mealLogDetails.mealLog()).isEqualTo(mealLog);
+        assertThat(mealLogDetails.meals().size()).isEqualTo(3);
+        assertThat(mealLogDetails.mealImages().size()).isEqualTo(3);
+        assertThat(mealLogDetails.intakeNutrients().calorie()).isEqualTo(300);
+        assertThat(mealLogDetails.intakeNutrients().carbs()).isEqualTo(30);
+        assertThat(mealLogDetails.intakeNutrients().protein()).isEqualTo(30);
+        assertThat(mealLogDetails.intakeNutrients().fat()).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("해당 id의 MealLog 상세 조회 실패 - Not Found")
+    void searchNotFoundExceptionTest() {
+
+        given(mealLogRepository.findById(1L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> mealLogQueryService.search(1L))
+                .isInstanceOf(NotFoundEntityException.class)
+                .hasMessage(ErrorCode.NOT_FOUND_MEAL_LOG.getDescription());
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#135 )

## 요약
- 식사 기록 상세 조회 기능을 레이어 별로 단위 테스트하였습니다.
- 식사 기록 상세 조회 API를 문서화하였습니다.
