### PR TITLE
Meal 엔티티 불필요한 필드 삭제, MealLog 상세 조회 관련 dto 수정

### DIFF
--- a/src/main/java/com/konggogi/veganlife/mealdata/controller/dto/response/MealDataDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/controller/dto/response/MealDataDetailsResponse.java
@@ -5,6 +5,7 @@ import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
 import com.konggogi.veganlife.mealdata.domain.MealDataType;
 
 public record MealDataDetailsResponse(
+        Long id,
         String name,
         MealDataType type,
         Integer amount,

--- a/src/main/java/com/konggogi/veganlife/mealdata/domain/mapper/MealDataMapper.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/domain/mapper/MealDataMapper.java
@@ -9,7 +9,7 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface MealDataMapper {
 
-    MealDataListResponse toMealDataListResponse(MealData mealDataListDto);
+    MealDataListResponse toMealDataListResponse(MealData mealData);
 
-    MealDataDetailsResponse toMealDataDetailsResponse(MealData mealDataDetailsDto);
+    MealDataDetailsResponse toMealDataDetailsResponse(MealData mealData);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealAddRequest.java
@@ -1,15 +1,11 @@
 package com.konggogi.veganlife.meallog.controller.dto.request;
 
 
-import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record MealAddRequest(
-        @NotBlank String name,
         @NotNull @Min(0) Integer intake,
-        @NotNull IntakeUnit intakeUnit,
         @NotNull @Min(0) Integer calorie,
         @NotNull @Min(0) Integer carbs,
         @NotNull @Min(0) Integer protein,

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealDetailsResponse.java
@@ -1,13 +1,6 @@
 package com.konggogi.veganlife.meallog.controller.dto.response;
 
 
-import com.konggogi.veganlife.mealdata.domain.MealDataType;
-import lombok.Builder;
+import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataDetailsResponse;
 
-@Builder
-public record MealDetailsResponse(
-        String name,
-        Integer intake,
-        MealDataType mealDataType,
-        Integer amount,
-        Integer amountPerServe) {}
+public record MealDetailsResponse(Long id, Integer intake, MealDataDetailsResponse mealData) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealImageDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealImageDetailsResponse.java
@@ -1,0 +1,3 @@
+package com.konggogi.veganlife.meallog.controller.dto.response;
+
+public record MealImageDetailsResponse(Long id, String imageUrl) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealLogDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealLogDetailsResponse.java
@@ -6,8 +6,8 @@ import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import java.util.List;
 
 public record MealLogDetailsResponse(
-        Long mealLogId,
+        Long id,
         MealType mealType,
         IntakeNutrients intakeNutrients,
-        List<String> imageUrls,
+        List<MealImageDetailsResponse> mealImages,
         List<MealDetailsResponse> meals) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/Meal.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/Meal.java
@@ -2,12 +2,9 @@ package com.konggogi.veganlife.meallog.domain;
 
 
 import com.konggogi.veganlife.global.domain.TimeStamped;
-import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -30,14 +27,7 @@ public class Meal extends TimeStamped {
     private Long id;
 
     @Column(nullable = false)
-    private String name;
-
-    @Column(nullable = false)
     private Integer intake;
-
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private IntakeUnit intakeUnit;
 
     @Column(nullable = false)
     private Integer calorie;
@@ -62,9 +52,7 @@ public class Meal extends TimeStamped {
     @Builder
     public Meal(
             Long id,
-            String name,
             Integer intake,
-            IntakeUnit intakeUnit,
             Integer calorie,
             Integer carbs,
             Integer protein,
@@ -72,9 +60,7 @@ public class Meal extends TimeStamped {
             MealLog mealLog,
             MealData mealData) {
         this.id = id;
-        this.name = name;
         this.intake = intake;
-        this.intakeUnit = intakeUnit;
         this.calorie = calorie;
         this.carbs = carbs;
         this.protein = protein;

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -3,7 +3,6 @@ package com.konggogi.veganlife.meallog.domain.mapper;
 
 import com.konggogi.veganlife.meallog.controller.dto.response.MealLogDetailsResponse;
 import com.konggogi.veganlife.meallog.controller.dto.response.MealLogListResponse;
-import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.meallog.service.dto.MealLogDetails;
@@ -11,7 +10,6 @@ import com.konggogi.veganlife.meallog.service.dto.MealLogList;
 import com.konggogi.veganlife.member.domain.Member;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring", uses = MealMapper.class)
 public interface MealLogMapper {
@@ -23,18 +21,7 @@ public interface MealLogMapper {
     @Mapping(source = "mealLogList.mealLog.mealType", target = "mealType")
     MealLogListResponse toMealLogListResponse(MealLogList mealLogList);
 
-    @Mapping(source = "mealLogDetails.mealLog.id", target = "mealLogId")
+    @Mapping(source = "mealLogDetails.mealLog.id", target = "id")
     @Mapping(source = "mealLogDetails.mealLog.mealType", target = "mealType")
-    @Mapping(source = "mealLogDetails.intakeNutrients", target = "intakeNutrients")
-    @Mapping(
-            source = "mealLogDetails.mealImages",
-            target = "imageUrls",
-            qualifiedByName = "mealImageToImageUrl")
     MealLogDetailsResponse toMealLogDetailsResponse(MealLogDetails mealLogDetails);
-
-    @Named("mealImageToImageUrl")
-    static String mealImageToImageUrl(MealImage mealImage) {
-
-        return mealImage.getImageUrl();
-    }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
@@ -13,12 +13,7 @@ public interface MealMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "mealLog", ignore = true)
-    @Mapping(source = "mealAddRequest.name", target = "name")
-    @Mapping(source = "mealAddRequest.intakeUnit", target = "intakeUnit")
     Meal toEntity(MealAddRequest mealAddRequest, MealData mealData);
 
-    @Mapping(source = "meal.mealData.type", target = "mealDataType")
-    @Mapping(source = "meal.mealData.amount", target = "amount")
-    @Mapping(source = "meal.mealData.amountPerServe", target = "amountPerServe")
     MealDetailsResponse toMealDetailsResponse(Meal meal);
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -19,7 +19,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
-import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
@@ -69,18 +68,14 @@ public class MealLogControllerTest extends RestDocsTest {
     List<MealAddRequest> mealAddRequests =
             List.of(
                     new MealAddRequest(
-                            "통밀빵",
                             100,
-                            IntakeUnit.G,
                             100,
                             10,
                             10,
                             10,
                             MealDataFixture.MEAL.getWithName(1L, "통밀빵", member).getId()),
                     new MealAddRequest(
-                            "통밀크래커",
                             100,
-                            IntakeUnit.G,
                             100,
                             10,
                             10,
@@ -204,13 +199,13 @@ public class MealLogControllerTest extends RestDocsTest {
                 mockMvc.perform(get("/api/v1/meal-log/{id}", 1L).headers(authorizationHeader()));
 
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.mealLogId").value(1))
+                .andExpect(jsonPath("$.id").value(1))
                 .andExpect(jsonPath("$.mealType").value(MealType.BREAKFAST.name()))
                 .andExpect(jsonPath("$.intakeNutrients.calorie").value(300))
                 .andExpect(jsonPath("$.intakeNutrients.carbs").value(30))
                 .andExpect(jsonPath("$.intakeNutrients.protein").value(30))
                 .andExpect(jsonPath("$.intakeNutrients.fat").value(30))
-                .andExpect(jsonPath("$.imageUrls.size()").value(3))
+                .andExpect(jsonPath("$.mealImages.size()").value(3))
                 .andExpect(jsonPath("$.meals.size()").value(3));
 
         perform.andDo(print())

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealFixture.java
@@ -1,32 +1,20 @@
 package com.konggogi.veganlife.meallog.fixture;
 
 
-import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.meallog.domain.Meal;
 
 public enum MealFixture {
-    DEFAULT("디폴트 음식", 100, IntakeUnit.G, 100, 10, 10, 10);
+    DEFAULT(100, 100, 10, 10, 10);
 
-    private String name;
     private Integer intake;
-    private IntakeUnit intakeUnit;
     private Integer calorie;
     private Integer carbs;
     private Integer protein;
     private Integer fat;
 
-    MealFixture(
-            String name,
-            Integer intake,
-            IntakeUnit intakeUnit,
-            Integer calorie,
-            Integer carbs,
-            Integer protein,
-            Integer fat) {
-        this.name = name;
+    MealFixture(Integer intake, Integer calorie, Integer carbs, Integer protein, Integer fat) {
         this.intake = intake;
-        this.intakeUnit = intakeUnit;
         this.calorie = calorie;
         this.carbs = carbs;
         this.protein = protein;
@@ -36,9 +24,7 @@ public enum MealFixture {
     public Meal get(MealData mealData) {
 
         return Meal.builder()
-                .name(name)
                 .intake(intake)
-                .intakeUnit(intakeUnit)
                 .calorie(calorie)
                 .carbs(carbs)
                 .protein(protein)
@@ -51,9 +37,7 @@ public enum MealFixture {
 
         return Meal.builder()
                 .id(id)
-                .name(name)
                 .intake(intake)
-                .intakeUnit(intakeUnit)
                 .calorie(calorie)
                 .carbs(carbs)
                 .protein(protein)

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
-import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
@@ -50,10 +49,7 @@ public class MealLogServiceTest {
                     MealDataFixture.MEAL.get(3L, member));
     List<MealAddRequest> mealAddRequests =
             mealData.stream()
-                    .map(
-                            m ->
-                                    new MealAddRequest(
-                                            "테스트", 100, IntakeUnit.G, 100, 10, 10, 10, m.getId()))
+                    .map(m -> new MealAddRequest(100, 100, 10, 10, 10, m.getId()))
                     .toList();
 
     List<String> imageUrls = List.of("image1.png", "image2.png", "image3.png");


### PR DESCRIPTION
## 이슈 번호 (#151)

## 요약
- Meal 엔티티에서 불필요한 필드(name, intakeUnit)를 삭제했습니다.
- MealLogDetailsResponse의 imageUrls 컬럼을 MealImageDetailsResponse 레코드로 분리하였습니다.
- MealDetailsResponse의 MealData 관련 컬럼을 MealDataDetailsResponse 레코드로 분리하였습니다.
- 변경 사항과 연관된 코드를 수정하였습니다.
