### PR TITLE
월간 섭취량 조회 API

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -138,7 +138,7 @@ include::{snippets}/today-nutrients/http-request.adoc[]
 
 include::{snippets}/today-nutrients/http-response.adoc[]
 
-==== 400 NOT FOUND
+==== 404 NOT FOUND
 
 include::{snippets}/today-nutrients-not-found/http-response.adoc[]
 
@@ -159,9 +159,35 @@ include::{snippets}/weekly-intake/http-request.adoc[]
 === Response
 
 ==== 200 OK
+각 요일별 합산된 칼로리 값
 
 include::{snippets}/weekly-intake/http-response.adoc[]
 
-==== 400 NOT FOUND
+==== 404 NOT FOUND
 
 include::{snippets}/weekly-intake-not-found/http-response.adoc[]
+
+== 월간 섭취량 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/monthly-intake/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/monthly-intake/query-parameters.adoc[]
+
+include::{snippets}/monthly-intake/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+각 주차별 합산된 칼로리 값
+
+include::{snippets}/monthly-intake/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/monthly-intake-not-found/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
@@ -89,4 +89,16 @@ public class MemberController {
         return ResponseEntity.ok(
                 nutrientsMapper.toCalorieIntakeResponse(totalCalorie, mealCalories));
     }
+
+    @GetMapping("/nutrients/month")
+    public ResponseEntity<CalorieIntakeResponse> getMonthlyIntakeCalorie(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd")
+                    LocalDate startDate) {
+        List<CaloriesOfMealType> mealCalories =
+                nutrientsQueryService.searchMonthlyIntakeCalories(userDetails.id(), startDate);
+        int totalCalorie = nutrientsQueryService.calcTotalCalorie(mealCalories);
+        return ResponseEntity.ok(
+                nutrientsMapper.toCalorieIntakeResponse(totalCalorie, mealCalories));
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/dto/response/CalorieIntakeResponse.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/dto/response/CalorieIntakeResponse.java
@@ -4,4 +4,5 @@ package com.konggogi.veganlife.member.controller.dto.response;
 import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
 import java.util.List;
 
-public record CalorieIntakeResponse(Integer totalCalorie, List<CaloriesOfMealType> weekly) {}
+public record CalorieIntakeResponse(
+        Integer totalCalorie, List<CaloriesOfMealType> periodicCalorie) {}

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/NutrientsMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/NutrientsMapper.java
@@ -13,7 +13,7 @@ import org.mapstruct.Mapping;
 public interface NutrientsMapper {
     TodayIntakeResponse toTodayIntakeResponse(IntakeNutrients intakeNutrients);
 
-    @Mapping(source = "caloriesOfMealTypes", target = "weekly")
+    @Mapping(source = "caloriesOfMealTypes", target = "periodicCalorie")
     CalorieIntakeResponse toCalorieIntakeResponse(
             int totalCalorie, List<CaloriesOfMealType> caloriesOfMealTypes);
 }

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -372,10 +372,10 @@ class MemberControllerTest extends RestDocsTest {
         // then
         perform.andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCalorie").value(totalCalorie))
-                .andExpect(jsonPath("$.weekly[0].breakfast").value(caloriePerMealType))
-                .andExpect(jsonPath("$.weekly[0].lunch").value(caloriePerMealType))
-                .andExpect(jsonPath("$.weekly[0].dinner").value(caloriePerMealType))
-                .andExpect(jsonPath("$.weekly[0].snack").value(caloriePerMealType));
+                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(caloriePerMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(caloriePerMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(caloriePerMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(caloriePerMealType));
 
         perform.andDo(print())
                 .andDo(

--- a/src/test/java/com/konggogi/veganlife/member/fixture/CaloriesOfMealTypeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/member/fixture/CaloriesOfMealTypeFixture.java
@@ -20,4 +20,8 @@ public enum CaloriesOfMealTypeFixture {
     public CaloriesOfMealType get() {
         return new CaloriesOfMealType(breakfast, lunch, dinner, snack);
     }
+
+    public CaloriesOfMealType getWithIntake(int intake) {
+        return new CaloriesOfMealType(intake, intake, intake, intake);
+    }
 }


### PR DESCRIPTION
## 이슈 번호 (#132 )

## 요약
월간 섭취량 조회 API 및 테스트 구현

## 코멘트
클라이언트에서 startDate ex) 2023-12-01와 같이 월의 시작 날짜가 주어지게 되면 다음 과정을 거칩니다.

1. ```startDate```로 달의 마지막 날 ```endDate```를 구합니다.
2. ```startDate```로 ```startDayOfFirstWeek```를 구합니다. startDayOfFirstWeek = 2023-11-26
    ```endDate```로 ```lastDayOfLastWeek```를 구합니다. lastDayOfLastWeek = 2024-01-06
   (한 주는 일요일부터 토요일이며 지난 달 또는 다음 달의 일부 기간을 포함할 수 있습니다.)
3. ```startDayOfFirstWeek``` 부터 ```lastDayOfLastWeek``` 까지 매주의 시작 날짜(일요일)을 구하여 그 주차의 섭취량을 ```MealType```별로 합산합니다.

