### PR TITLE
식단 기록 수정 API 구현

### DIFF
--- a/src/docs/asciidoc/meal-log.adoc
+++ b/src/docs/asciidoc/meal-log.adoc
@@ -31,6 +31,30 @@ include::{snippets}/meal-log-add-meal-data-not-found/http-response.adoc[]
 ==== 404 NOT FOUND
 include::{snippets}/meal-log-add-member-not-found/http-response.adoc[]
 
+== 식사 기록 수정 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/meal-log-modify/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/meal-log-modify/path-parameters.adoc[]
+
+include::{snippets}/meal-log-modify/http-request.adoc[]
+
+=== Response
+
+==== 204 NO CONTENT
+include::{snippets}/meal-log-modify/http-response.adoc[]
+
+==== 404 NOT FOUND
+include::{snippets}/meal-log-modify-meal-log-not-found/http-response.adoc[]
+
+==== 404 NOT FOUND
+include::{snippets}/meal-log-modify-meal-data-not-found/http-response.adoc[]
 
 == 식사 기록 목록 조회 API
 

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
@@ -3,6 +3,7 @@ package com.konggogi.veganlife.meallog.controller;
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogModifyRequest;
 import com.konggogi.veganlife.meallog.controller.dto.response.MealLogDetailsResponse;
 import com.konggogi.veganlife.meallog.controller.dto.response.MealLogListResponse;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
@@ -18,6 +19,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -56,5 +58,13 @@ public class MealLogController {
 
         return ResponseEntity.ok(
                 mealLogMapper.toMealLogDetailsResponse(mealLogQueryService.search(id)));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> modifyMealLog(
+            @PathVariable Long id, @Valid @RequestBody MealLogModifyRequest request) {
+
+        mealLogService.modify(id, request);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogModifyRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogModifyRequest.java
@@ -1,0 +1,11 @@
+package com.konggogi.veganlife.meallog.controller.dto.request;
+
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record MealLogModifyRequest(
+        @Valid @NotNull @Size(min = 1, max = 5) List<MealModifyRequest> meals,
+        @NotNull @Size(max = 5) List<String> imageUrls) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealModifyRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealModifyRequest.java
@@ -4,7 +4,7 @@ package com.konggogi.veganlife.meallog.controller.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
-public record MealAddRequest(
+public record MealModifyRequest(
         @NotNull @Min(0) Integer intake,
         @NotNull @Min(0) Integer calorie,
         @NotNull @Min(0) Integer carbs,

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealDetailsResponse.java
@@ -3,4 +3,4 @@ package com.konggogi.veganlife.meallog.controller.dto.response;
 
 import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataDetailsResponse;
 
-public record MealDetailsResponse(Long id, Integer intake, MealDataDetailsResponse mealData) {}
+public record MealDetailsResponse(Integer intake, MealDataDetailsResponse mealData) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealImageDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealImageDetailsResponse.java
@@ -1,3 +1,0 @@
-package com.konggogi.veganlife.meallog.controller.dto.response;
-
-public record MealImageDetailsResponse(Long id, String imageUrl) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealLogDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealLogDetailsResponse.java
@@ -9,5 +9,5 @@ public record MealLogDetailsResponse(
         Long id,
         MealType mealType,
         IntakeNutrients intakeNutrients,
-        List<MealImageDetailsResponse> mealImages,
+        List<String> imageUrls,
         List<MealDetailsResponse> meals) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/Meal.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/Meal.java
@@ -68,8 +68,4 @@ public class Meal extends TimeStamped {
         this.mealLog = mealLog;
         this.mealData = mealData;
     }
-
-    public void setMealLog(MealLog mealLog) {
-        this.mealLog = mealLog;
-    }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealImage.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealImage.java
@@ -35,8 +35,4 @@ public class MealImage {
         this.imageUrl = imageUrl;
         this.mealLog = mealLog;
     }
-
-    public void setMealLog(MealLog mealLog) {
-        this.mealLog = mealLog;
-    }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -52,13 +52,21 @@ public class MealLog extends TimeStamped {
         this.member = member;
     }
 
-    public void addMeal(Meal meal) {
-        meals.add(meal);
-        meal.setMealLog(this);
+    public void addMeals(List<Meal> meals) {
+        this.meals.addAll(meals);
     }
 
-    public void addMealImage(MealImage mealImage) {
-        mealImages.add(mealImage);
-        mealImage.setMealLog(this);
+    public void addMealImages(List<MealImage> mealImages) {
+        this.mealImages.addAll(mealImages);
+    }
+
+    public void updateMeals(List<Meal> meals) {
+        this.meals.clear();
+        this.meals.addAll(meals);
+    }
+
+    public void updateMealImages(List<MealImage> mealImages) {
+        this.mealImages.clear();
+        this.mealImages.addAll(mealImages);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealImageMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealImageMapper.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.meallog.domain.mapper;
 
 
 import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealLog;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -9,6 +10,5 @@ import org.mapstruct.Mapping;
 public interface MealImageMapper {
 
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "mealLog", ignore = true)
-    MealImage toEntity(String imageUrl);
+    MealImage toEntity(String imageUrl, MealLog mealLog);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -3,6 +3,7 @@ package com.konggogi.veganlife.meallog.domain.mapper;
 
 import com.konggogi.veganlife.meallog.controller.dto.response.MealLogDetailsResponse;
 import com.konggogi.veganlife.meallog.controller.dto.response.MealLogListResponse;
+import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.meallog.service.dto.MealLogDetails;
@@ -10,6 +11,7 @@ import com.konggogi.veganlife.meallog.service.dto.MealLogList;
 import com.konggogi.veganlife.member.domain.Member;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring", uses = MealMapper.class)
 public interface MealLogMapper {
@@ -17,11 +19,21 @@ public interface MealLogMapper {
     @Mapping(target = "id", ignore = true)
     MealLog toEntity(MealType mealType, Member member);
 
-    @Mapping(source = "mealLogList.mealLog.id", target = "id")
-    @Mapping(source = "mealLogList.mealLog.mealType", target = "mealType")
-    MealLogListResponse toMealLogListResponse(MealLogList mealLogList);
+    @Mapping(source = "dto.mealLog.id", target = "id")
+    @Mapping(source = "dto.mealLog.mealType", target = "mealType")
+    MealLogListResponse toMealLogListResponse(MealLogList dto);
 
-    @Mapping(source = "mealLogDetails.mealLog.id", target = "id")
-    @Mapping(source = "mealLogDetails.mealLog.mealType", target = "mealType")
-    MealLogDetailsResponse toMealLogDetailsResponse(MealLogDetails mealLogDetails);
+    @Mapping(source = "dto.mealLog.id", target = "id")
+    @Mapping(source = "dto.mealLog.mealType", target = "mealType")
+    @Mapping(
+            source = "dto.mealImages",
+            target = "imageUrls",
+            qualifiedByName = "mealImageToImageUrl")
+    MealLogDetailsResponse toMealLogDetailsResponse(MealLogDetails dto);
+
+    @Named("mealImageToImageUrl")
+    static String mealImageToImageUrl(MealImage mealImage) {
+
+        return mealImage.getImageUrl();
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
@@ -3,8 +3,10 @@ package com.konggogi.veganlife.meallog.domain.mapper;
 
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealModifyRequest;
 import com.konggogi.veganlife.meallog.controller.dto.response.MealDetailsResponse;
 import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealLog;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -12,8 +14,10 @@ import org.mapstruct.Mapping;
 public interface MealMapper {
 
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "mealLog", ignore = true)
-    Meal toEntity(MealAddRequest mealAddRequest, MealData mealData);
+    Meal toEntity(MealAddRequest request, MealLog mealLog, MealData mealData);
+
+    @Mapping(target = "id", ignore = true)
+    Meal toEntity(MealModifyRequest request, MealLog mealLog, MealData mealData);
 
     MealDetailsResponse toMealDetailsResponse(Meal meal);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -1,9 +1,15 @@
 package com.konggogi.veganlife.meallog.service;
 
 
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogModifyRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealModifyRequest;
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.mapper.MealImageMapper;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
@@ -27,26 +33,65 @@ public class MealLogService {
     private final MealMapper mealMapper;
     private final MealImageMapper mealImageMapper;
 
-    public void add(MealLogAddRequest mealLogAddRequest, Long memberId) {
+    public void add(MealLogAddRequest request, Long memberId) {
 
         MealLog mealLog =
-                mealLogMapper.toEntity(
-                        mealLogAddRequest.mealType(), memberQueryService.search(memberId));
-        addMeals(mealLogAddRequest.meals(), mealLog);
-        addMealImages(mealLogAddRequest.imageUrls(), mealLog);
+                mealLogMapper.toEntity(request.mealType(), memberQueryService.search(memberId));
+        addMeals(request.meals(), mealLog);
+        addMealImages(request.imageUrls(), mealLog);
         mealLogRepository.save(mealLog);
     }
 
-    private void addMeals(List<MealAddRequest> mealAddRequests, MealLog mealLog) {
-        mealAddRequests.stream()
-                .map(
-                        request ->
-                                mealMapper.toEntity(
-                                        request, mealDataQueryService.search(request.mealDataId())))
-                .forEach(mealLog::addMeal);
+    public void modify(Long mealLogId, MealLogModifyRequest request) {
+
+        MealLog mealLog =
+                mealLogRepository
+                        .findById(mealLogId)
+                        .orElseThrow(
+                                () -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEAL_LOG));
+        modifyMeals(request.meals(), mealLog);
+        modifyMealImages(request.imageUrls(), mealLog);
     }
 
-    private void addMealImages(List<String> mealImages, MealLog mealLog) {
-        mealImages.stream().map(mealImageMapper::toEntity).forEach(mealLog::addMealImage);
+    private void addMeals(List<? extends MealAddRequest> requests, MealLog mealLog) {
+        List<Meal> meals =
+                requests.stream()
+                        .map(
+                                request ->
+                                        mealMapper.toEntity(
+                                                request,
+                                                mealLog,
+                                                mealDataQueryService.search(request.mealDataId())))
+                        .toList();
+        mealLog.addMeals(meals);
+    }
+
+    private void addMealImages(List<String> requests, MealLog mealLog) {
+        List<MealImage> mealImages =
+                requests.stream()
+                        .map(request -> mealImageMapper.toEntity(request, mealLog))
+                        .toList();
+        mealLog.addMealImages(mealImages);
+    }
+
+    private void modifyMeals(List<MealModifyRequest> requests, MealLog mealLog) {
+        List<Meal> meals =
+                requests.stream()
+                        .map(
+                                request ->
+                                        mealMapper.toEntity(
+                                                request,
+                                                mealLog,
+                                                mealDataQueryService.search(request.mealDataId())))
+                        .toList();
+        mealLog.updateMeals(meals);
+    }
+
+    private void modifyMealImages(List<String> requests, MealLog mealLog) {
+        List<MealImage> mealImages =
+                requests.stream()
+                        .map(request -> mealImageMapper.toEntity(request, mealLog))
+                        .toList();
+        mealLog.updateMealImages(mealImages);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -53,7 +53,7 @@ public class MealLogService {
         modifyMealImages(request.imageUrls(), mealLog);
     }
 
-    private void addMeals(List<? extends MealAddRequest> requests, MealLog mealLog) {
+    private void addMeals(List<MealAddRequest> requests, MealLog mealLog) {
         List<Meal> meals =
                 requests.stream()
                         .map(

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealFixture.java
@@ -3,6 +3,7 @@ package com.konggogi.veganlife.meallog.fixture;
 
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealLog;
 
 public enum MealFixture {
     DEFAULT(100, 100, 10, 10, 10);
@@ -42,6 +43,19 @@ public enum MealFixture {
                 .carbs(carbs)
                 .protein(protein)
                 .fat(fat)
+                .mealData(mealData)
+                .build();
+    }
+
+    public Meal getWithMealLog(MealLog mealLog, MealData mealData) {
+
+        return Meal.builder()
+                .intake(intake)
+                .calorie(calorie)
+                .carbs(carbs)
+                .protein(protein)
+                .fat(fat)
+                .mealLog(mealLog)
                 .mealData(mealData)
                 .build();
     }

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealImageFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealImageFixture.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.meallog.fixture;
 
 
 import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealLog;
 
 public enum MealImageFixture {
     DEFAULT("default.png");
@@ -26,5 +27,9 @@ public enum MealImageFixture {
 
     public MealImage getWithImageUrl(Long id, String imageUrl) {
         return MealImage.builder().imageUrl(imageUrl).build();
+    }
+
+    public MealImage getWithMealLog(MealLog mealLog) {
+        return MealImage.builder().imageUrl(imageUrl).mealLog(mealLog).build();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
@@ -27,31 +27,39 @@ public enum MealLogFixture {
 
     public MealLog get(List<Meal> meals, List<MealImage> mealImages, Member member) {
         MealLog mealLog = MealLog.builder().mealType(mealType).member(member).build();
-        meals.forEach(mealLog::addMeal);
-        mealImages.forEach(mealLog::addMealImage);
+        meals.forEach(meal -> setMealLog(meal, mealLog));
+        mealImages.forEach(mealImage -> setMealLog(mealImage, mealLog));
+        mealLog.getMeals().addAll(meals);
+        mealLog.getMealImages().addAll(mealImages);
         return mealLog;
     }
 
     public MealLog get(Long id, List<Meal> meals, List<MealImage> mealImages, Member member) {
         MealLog mealLog = MealLog.builder().id(id).mealType(mealType).member(member).build();
-        meals.forEach(mealLog::addMeal);
-        mealImages.forEach(mealLog::addMealImage);
+        meals.forEach(meal -> setMealLog(meal, mealLog));
+        mealImages.forEach(mealImage -> setMealLog(mealImage, mealLog));
+        mealLog.getMeals().addAll(meals);
+        mealLog.getMealImages().addAll(mealImages);
         return mealLog;
     }
 
     public MealLog getWithDate(
             LocalDate date, List<Meal> meals, List<MealImage> mealImages, Member member) {
         MealLog mealLog = MealLog.builder().mealType(mealType).member(member).build();
-        meals.forEach(mealLog::addMeal);
-        mealImages.forEach(mealLog::addMealImage);
+        meals.forEach(meal -> setMealLog(meal, mealLog));
+        mealImages.forEach(mealImage -> setMealLog(mealImage, mealLog));
+        mealLog.getMeals().addAll(meals);
+        mealLog.getMealImages().addAll(mealImages);
         return setCreatedAt(mealLog, date);
     }
 
     public MealLog getWithDate(
             Long id, LocalDate date, List<Meal> meals, List<MealImage> mealImages, Member member) {
         MealLog mealLog = MealLog.builder().id(id).mealType(mealType).member(member).build();
-        meals.forEach(mealLog::addMeal);
-        mealImages.forEach(mealLog::addMealImage);
+        meals.forEach(meal -> setMealLog(meal, mealLog));
+        mealImages.forEach(mealImage -> setMealLog(mealImage, mealLog));
+        mealLog.getMeals().addAll(meals);
+        mealLog.getMealImages().addAll(mealImages);
         return setCreatedAt(mealLog, date);
     }
 
@@ -60,5 +68,17 @@ public enum MealLogFixture {
         ReflectionUtils.makeAccessible(createdAt);
         ReflectionUtils.setField(createdAt, mealLog, date.atStartOfDay());
         return mealLog;
+    }
+
+    private void setMealLog(Meal meal, MealLog mealLog) {
+        Field mealLogField = ReflectionUtils.findField(Meal.class, "mealLog");
+        ReflectionUtils.makeAccessible(mealLogField);
+        ReflectionUtils.setField(mealLogField, meal, mealLog);
+    }
+
+    private void setMealLog(MealImage mealImage, MealLog mealLog) {
+        Field mealLogField = ReflectionUtils.findField(MealImage.class, "mealLog");
+        ReflectionUtils.makeAccessible(mealLogField);
+        ReflectionUtils.setField(mealLogField, mealImage, mealLog);
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
@@ -16,6 +16,7 @@ import com.konggogi.veganlife.member.repository.MemberRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.IntStream;
@@ -119,5 +120,29 @@ public class MealLogRepositoryTest {
         // then
         assertThat(mealLogs.size()).isEqualTo(1);
         assertThat(mealLogs.get(0)).isEqualTo(mealLog1);
+    }
+
+    @Test
+    @DisplayName("MealLog 업데이트 테스트")
+    void mealLogUpdateTest() {
+        // given
+        List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
+        List<MealImage> mealImages =
+                IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
+        MealLog mealLog = MealLogFixture.BREAKFAST.get(meals, mealImages, member);
+        mealLogRepository.saveAndFlush(mealLog);
+        // when
+        List<Meal> modifiedMeals = new ArrayList<>();
+        modifiedMeals.add(MealFixture.DEFAULT.getWithMealLog(mealLog, mealData.get(0))); // 추가
+        List<MealImage> modifiedMealImages = new ArrayList<>();
+        modifiedMealImages.add(MealImageFixture.DEFAULT.getWithMealLog(mealLog));
+        mealLog.updateMeals(modifiedMeals);
+        mealLog.updateMealImages(modifiedMealImages);
+        mealLogRepository.flush();
+        // then
+        assertThat(mealLog.getMeals().size()).isEqualTo(1);
+        assertThat(mealLog.getMeals().get(0).getMealLog()).isEqualTo(mealLog);
+        assertThat(mealLog.getMealImages().size()).isEqualTo(1);
+        assertThat(mealLog.getMealImages().get(0).getMealLog()).isEqualTo(mealLog);
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -10,6 +10,10 @@ import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogModifyRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealModifyRequest;
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.meallog.domain.mapper.MealImageMapper;
@@ -18,10 +22,15 @@ import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapperImpl;
 import com.konggogi.veganlife.meallog.domain.mapper.MealMapper;
 import com.konggogi.veganlife.meallog.domain.mapper.MealMapperImpl;
+import com.konggogi.veganlife.meallog.fixture.MealFixture;
+import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
+import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,6 +61,11 @@ public class MealLogServiceTest {
                     .map(m -> new MealAddRequest(100, 100, 10, 10, 10, m.getId()))
                     .toList();
 
+    List<MealModifyRequest> mealModifyRequests =
+            mealData.stream()
+                    .map(m -> new MealModifyRequest(100, 100, 10, 10, 10, m.getId()))
+                    .toList();
+
     List<String> imageUrls = List.of("image1.png", "image2.png", "image3.png");
 
     @Test
@@ -68,5 +82,24 @@ public class MealLogServiceTest {
         then(memberQueryService).should(times(1)).search(member.getId());
         mealData.forEach(m -> then(mealDataQueryService).should(times(1)).search(m.getId()));
         then(mealLogRepository).should(times(1)).save(any(MealLog.class));
+    }
+
+    @Test
+    @DisplayName("식사 기록 저장")
+    void mealLogModifyTest() {
+        // given
+        MealLogModifyRequest mealLogModifyRequest =
+                new MealLogModifyRequest(mealModifyRequests, imageUrls);
+        List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
+        List<MealImage> mealImages =
+                IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
+        MealLog mealLog = MealLogFixture.BREAKFAST.get(meals, mealImages, member);
+        given(mealLogRepository.findById(1L)).willReturn(Optional.ofNullable(mealLog));
+        mealData.forEach(m -> given(mealDataQueryService.search(m.getId())).willReturn(m));
+        // when
+        mealLogService.modify(1L, mealLogModifyRequest);
+        // then
+        then(mealLogRepository).should(times(1)).findById(1L);
+        mealData.forEach(m -> then(mealDataQueryService).should(times(1)).search(m.getId()));
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#146, #148)

## 요약
- 식단 기록을 수정하는 기능을 구현하였습니다.
- 식단 기록을 수정하는 API를 구현하였습니다.
- 식단 기록 등록 방식을 변경했습니다. (service에서 Meal 엔티티에 MealLog 연관관계 설정해주도록)
- 식단 기록 수정 API를 단위 테스트 하였습니다.
- 구현한 API를 문서화 하였습니다.

## ETC

update와 delete&insert 엔티티 수정 전략 중에서 delete&insert 수정 전략을 채택했습니다.
추후 update 전략을 사용했을 때와의 성능 차이 비교가 필요할 것 같습니다.

