### PR TITLE
MemberQueryServiceTest, AuthControllerTest 테스트 추가 및 수정

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -28,6 +28,8 @@ include::{snippets}/reissue-token/http-response.adoc[]
 
 include::{snippets}/reissue-token-invalid-token/http-response.adoc[]
 
+include::{snippets}/reissue-token-not-found-user-info/http-response.adoc[]
+
 ==== 404 NOT FOUND
 
 include::{snippets}/reissue-token-not-found-member/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
@@ -3,6 +3,7 @@ package com.konggogi.veganlife.member.service;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.global.security.exception.InvalidJwtException;
 import com.konggogi.veganlife.global.security.exception.MismatchTokenException;
 import com.konggogi.veganlife.global.security.jwt.JwtProvider;
 import com.konggogi.veganlife.global.util.JwtUtils;
@@ -28,6 +29,12 @@ public class MemberQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
+    public Member searchByEmail(String userEmail) {
+        return memberRepository
+                .findByEmail(userEmail)
+                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+
     public String reissueToken(String refreshToken) {
         jwtUtils.validateToken(refreshToken);
         Member member = findMemberByToken(refreshToken);
@@ -46,9 +53,9 @@ public class MemberQueryService {
                         });
     }
 
-    private Member findMemberByToken(String token) {
+    public Member findMemberByToken(String token) {
         return jwtUtils.extractUserEmail(token)
-                .flatMap(memberRepository::findByEmail)
-                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
+                .map(this::searchByEmail)
+                .orElseThrow(() -> new InvalidJwtException(ErrorCode.NOT_FOUND_USER_INFO_TOKEN));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/AuthControllerTest.java
@@ -10,7 +10,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
-import com.konggogi.veganlife.global.security.exception.InvalidJwtException;
 import com.konggogi.veganlife.global.security.exception.MismatchTokenException;
 import com.konggogi.veganlife.global.util.JwtUtils;
 import com.konggogi.veganlife.member.controller.dto.request.ReissueRequest;
@@ -57,8 +56,7 @@ class AuthControllerTest extends RestDocsTest {
     void reissueTokenInvalidTest() throws Exception {
         // given
         ReissueRequest request = new ReissueRequest(refreshToken);
-        given(jwtUtils.extractBearerToken(refreshToken))
-                .willThrow(new InvalidJwtException(ErrorCode.INVALID_TOKEN));
+        given(jwtUtils.extractBearerToken(refreshToken)).willReturn(Optional.empty());
         // when
         ResultActions perform =
                 mockMvc.perform(

--- a/src/test/java/com/konggogi/veganlife/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/MemberQueryServiceTest.java
@@ -80,8 +80,7 @@ class MemberQueryServiceTest {
     void searchByEmailNotFoundTest() {
         // given
         String email = member.getEmail();
-        given(memberRepository.findByEmail(anyString()))
-                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
         // when, then
         assertThatThrownBy(() -> memberQueryService.searchByEmail(email))
                 .isInstanceOf(NotFoundEntityException.class)

--- a/src/test/java/com/konggogi/veganlife/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/MemberQueryServiceTest.java
@@ -64,6 +64,32 @@ class MemberQueryServiceTest {
     }
 
     @Test
+    @DisplayName("이메일로 회원 조회")
+    void searchByEmailTest() {
+        // given
+        String email = member.getEmail();
+        given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
+        // when
+        Member foundMember = memberQueryService.searchByEmail(email);
+        // then
+        assertThat(foundMember).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("이메일로 회원 조회 실패")
+    void searchByEmailNotFoundTest() {
+        // given
+        String email = member.getEmail();
+        given(memberRepository.findByEmail(anyString()))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
+        // when, then
+        assertThatThrownBy(() -> memberQueryService.searchByEmail(email))
+                .isInstanceOf(NotFoundEntityException.class)
+                .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
+        then(memberRepository).should().findByEmail(anyString());
+    }
+
+    @Test
     @DisplayName("AccessToken 재발급")
     void reissueTokenTest() {
         // given


### PR DESCRIPTION
## 이슈 번호 (#63 )

## 요약
MemberQueryServiceTest, AuthControllerTest 테스트 추가 및 수정

## 변경 내용
`MemberQueryService`의 `findMemberByToken`에서 `searchByEmail` 호출하도록 변경
