### PR TITLE
식단 기록 삭제 API 구현 & 단위 테스트

### DIFF
--- a/src/docs/asciidoc/meal-log.adoc
+++ b/src/docs/asciidoc/meal-log.adoc
@@ -47,7 +47,7 @@ include::{snippets}/meal-log-modify/http-request.adoc[]
 
 === Response
 
-==== 204 NO CONTENT
+==== 201 CREATED
 include::{snippets}/meal-log-modify/http-response.adoc[]
 
 ==== 404 NOT FOUND
@@ -55,6 +55,25 @@ include::{snippets}/meal-log-modify-meal-log-not-found/http-response.adoc[]
 
 ==== 404 NOT FOUND
 include::{snippets}/meal-log-modify-meal-data-not-found/http-response.adoc[]
+
+== 식사 기록 삭제 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/meal-log-modify/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/meal-log-delete/path-parameters.adoc[]
+
+include::{snippets}/meal-log-delete/http-request.adoc[]
+
+=== Response
+
+==== 204 NO CONTENT
+include::{snippets}/meal-log-delete/http-response.adoc[]
 
 == 식사 기록 목록 조회 API
 

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -65,6 +66,13 @@ public class MealLogController {
             @PathVariable Long id, @Valid @RequestBody MealLogModifyRequest request) {
 
         mealLogService.modify(id, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> removeMealLog(@PathVariable Long id) {
+
+        mealLogService.remove(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealImage.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealImage.java
@@ -3,6 +3,7 @@ package com.konggogi.veganlife.meallog.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,7 +26,7 @@ public class MealImage {
     @Column(nullable = false)
     private String imageUrl;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "meal_log_id")
     private MealLog mealLog;
 

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -50,6 +50,11 @@ public class MealLogService {
         modifyMealImages(request.imageUrls(), mealLog);
     }
 
+    public void remove(Long mealLogId) {
+
+        mealLogRepository.deleteById(mealLogId);
+    }
+
     private void addMeals(List<MealAddRequest> requests, MealLog mealLog) {
         List<Meal> meals =
                 requests.stream()

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -277,7 +278,7 @@ public class MealLogControllerTest extends RestDocsTest {
                                 .content(toJson(mealLogModifyRequest))
                                 .contentType(MediaType.APPLICATION_JSON));
 
-        perform.andExpect(status().isNoContent());
+        perform.andExpect(status().isCreated());
 
         perform.andDo(print())
                 .andDo(
@@ -335,5 +336,24 @@ public class MealLogControllerTest extends RestDocsTest {
 
         perform.andDo(print())
                 .andDo(document("meal-log-modify-meal-data-not-found", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("식사 기록 삭제 API")
+    void removeMealLogTest() throws Exception {
+
+        ResultActions perform =
+                mockMvc.perform(delete("/api/v1/meal-log/{id}", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isNoContent());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "meal-log-delete",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("id").description("식단 기록 id"))));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -102,4 +102,13 @@ public class MealLogServiceTest {
         then(mealLogQueryService).should(times(1)).searchById(1L);
         mealData.forEach(m -> then(mealDataQueryService).should(times(1)).search(m.getId()));
     }
+
+    @Test
+    @DisplayName("식사 기록 삭제")
+    void mealLogRemoveTest() {
+        // when
+        mealLogService.remove(1L);
+        // then
+        then(mealLogRepository).should(times(1)).deleteById(1L);
+    }
 }


### PR DESCRIPTION
## 이슈 번호 (#166, #167)

## 요약
- MealLog 삭제 기능을 구현하였습니다.
- MealLog 삭제 API를 구현하였습니다.
- MealLog 삭제 시 연관된 엔티티도 함께 삭제가 되는지 단위테스트하였습니다.
- API를 문서화하였습니다.
