### PR TITLE
식품 데이터 등록 API 구현 및 테스트

### DIFF
--- a/src/docs/asciidoc/meal-data.adoc
+++ b/src/docs/asciidoc/meal-data.adoc
@@ -10,6 +10,26 @@ ifndef::snippets[]
 :snippets: ./build/generated-snippets
 endif::[]
 
+== 식품 데이터 등록 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/meal-data-add/request-headers.adoc[]
+
+include::{snippets}/meal-data-add/http-request.adoc[]
+
+=== Response
+
+==== 201 CREATED
+
+include::{snippets}/meal-data-add/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/meal-data-add-member-not-found/http-response.adoc[]
+
 == 키워드 기반 식품 데이터 목록 검색 API
 
 === Request

--- a/src/main/java/com/konggogi/veganlife/mealdata/controller/MealDataController.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/controller/MealDataController.java
@@ -1,16 +1,24 @@
 package com.konggogi.veganlife.mealdata.controller;
 
 
+import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import com.konggogi.veganlife.mealdata.controller.dto.request.MealDataAddRequest;
 import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataDetailsResponse;
 import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataListResponse;
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
 import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
+import com.konggogi.veganlife.mealdata.service.MealDataService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MealDataController {
 
     private final MealDataQueryService mealDataQueryService;
+    private final MealDataService mealDataService;
     private final MealDataMapper mealDataMapper;
 
     @GetMapping
@@ -37,5 +46,14 @@ public class MealDataController {
 
         return ResponseEntity.ok(
                 mealDataMapper.toMealDataDetailsResponse(mealDataQueryService.search(id)));
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> addMealData(
+            @Valid @RequestBody MealDataAddRequest request,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        mealDataService.add(request, userDetails.id());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/mealdata/controller/dto/request/MealDataAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/controller/dto/request/MealDataAddRequest.java
@@ -1,0 +1,16 @@
+package com.konggogi.veganlife.mealdata.controller.dto.request;
+
+
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record MealDataAddRequest(
+        @NotBlank String name,
+        @NotNull Integer amount,
+        @NotNull Integer amountPerServe,
+        @NotNull Integer caloriePerServe,
+        @NotNull Integer carbsPerServe,
+        @NotNull Integer proteinPerServe,
+        @NotNull Integer fatPerServe,
+        @NotNull IntakeUnit intakeUnit) {}

--- a/src/main/java/com/konggogi/veganlife/mealdata/domain/MealData.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/domain/MealData.java
@@ -92,4 +92,17 @@ public class MealData extends TimeStamped {
         this.ownerType = ownerType;
         this.member = member;
     }
+
+    public void setNutrientsPerUnit(Integer calorie, Integer carbs, Integer protein, Integer fat) {
+
+        caloriePerUnit = calculateNutrientsPerUnit(calorie);
+        carbsPerUnit = calculateNutrientsPerUnit(carbs);
+        proteinPerUnit = calculateNutrientsPerUnit(protein);
+        fatPerUnit = calculateNutrientsPerUnit(fat);
+    }
+
+    private Double calculateNutrientsPerUnit(Integer nutrients) {
+
+        return (double) nutrients / amountPerServe;
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/mealdata/domain/MealDataType.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/domain/MealDataType.java
@@ -1,6 +1,6 @@
 package com.konggogi.veganlife.mealdata.domain;
 
 public enum MealDataType {
-    MEAL,
-    PROCESSED;
+    TOTAL_AMOUNT,
+    AMOUNT_PER_SERVE;
 }

--- a/src/main/java/com/konggogi/veganlife/mealdata/domain/mapper/MealDataMapper.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/domain/mapper/MealDataMapper.java
@@ -1,9 +1,13 @@
 package com.konggogi.veganlife.mealdata.domain.mapper;
 
 
+import com.konggogi.veganlife.mealdata.controller.dto.request.MealDataAddRequest;
 import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataDetailsResponse;
 import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataListResponse;
 import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.domain.MealDataType;
+import com.konggogi.veganlife.mealdata.domain.OwnerType;
+import com.konggogi.veganlife.member.domain.Member;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
@@ -12,4 +16,24 @@ public interface MealDataMapper {
     MealDataListResponse toMealDataListResponse(MealData mealData);
 
     MealDataDetailsResponse toMealDataDetailsResponse(MealData mealData);
+
+    default MealData toEntity(MealDataAddRequest request, Member member) {
+
+        MealData mealData =
+                MealData.builder()
+                        .name(request.name())
+                        .type(MealDataType.AMOUNT_PER_SERVE)
+                        .amount(request.amount())
+                        .amountPerServe(request.amountPerServe())
+                        .intakeUnit(request.intakeUnit())
+                        .ownerType(OwnerType.MEMBER)
+                        .member(member)
+                        .build();
+        mealData.setNutrientsPerUnit(
+                request.caloriePerServe(),
+                request.carbsPerServe(),
+                request.proteinPerServe(),
+                request.fatPerServe());
+        return mealData;
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataService.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataService.java
@@ -1,0 +1,27 @@
+package com.konggogi.veganlife.mealdata.service;
+
+
+import com.konggogi.veganlife.mealdata.controller.dto.request.MealDataAddRequest;
+import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
+import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MealDataService {
+
+    private final MemberQueryService memberQueryService;
+    private final MealDataRepository mealDataRepository;
+
+    private final MealDataMapper mealDataMapper;
+
+    public void add(MealDataAddRequest request, Long memberId) {
+
+        mealDataRepository.save(
+                mealDataMapper.toEntity(request, memberQueryService.search(memberId)));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/mealdata/fixture/MealDataFixture.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/fixture/MealDataFixture.java
@@ -8,12 +8,22 @@ import com.konggogi.veganlife.mealdata.domain.OwnerType;
 import com.konggogi.veganlife.member.domain.Member;
 
 public enum MealDataFixture {
-    MEAL("디폴트 음식", MealDataType.MEAL, 100, 100, 10D, 1D, 1D, 1D, IntakeUnit.G, OwnerType.ALL),
+    MEAL(
+            "디폴트 음식",
+            MealDataType.TOTAL_AMOUNT,
+            100,
+            100,
+            10D,
+            1D,
+            1D,
+            1D,
+            IntakeUnit.G,
+            OwnerType.ALL),
     PROCESSED(
             "디폴트 가공식품",
-            MealDataType.PROCESSED,
+            MealDataType.AMOUNT_PER_SERVE,
             100,
-            100,
+            50,
             10D,
             1D,
             1D,

--- a/src/test/java/com/konggogi/veganlife/mealdata/repository/MealDataRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/repository/MealDataRepositoryTest.java
@@ -7,6 +7,7 @@ import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -63,5 +64,14 @@ public class MealDataRepositoryTest {
         // then
         assertThat(result1.isEmpty()).isEqualTo(false);
         assertThat(result2.isEmpty()).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("MealData 저장")
+    void saveTest() {
+        MealData mealData = MealDataFixture.MEAL.get(member);
+        mealDataRepository.save(mealData);
+
+        assertThat(mealData.getId()).matches(Objects::nonNull);
     }
 }

--- a/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataServiceTest.java
@@ -1,0 +1,55 @@
+package com.konggogi.veganlife.mealdata.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.konggogi.veganlife.mealdata.controller.dto.request.MealDataAddRequest;
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
+import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapperImpl;
+import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class MealDataServiceTest {
+
+    @Mock MemberQueryService memberQueryService;
+    @Mock MealDataRepository mealDataRepository;
+    @Spy MealDataMapper mealDataMapper = new MealDataMapperImpl();
+    @InjectMocks MealDataService mealDataService;
+
+    Member member = Member.builder().email("test123@test.com").build();
+
+    @Test
+    @DisplayName("식품 데이터를 등록")
+    void addTest() {
+
+        MealDataAddRequest request =
+                new MealDataAddRequest("통밀빵", 300, 100, 210, 30, 5, 3, IntakeUnit.G);
+
+        given(memberQueryService.search(anyLong())).willReturn(member);
+
+        mealDataService.add(request, 1L);
+        MealData mealData = mealDataMapper.toEntity(request, member);
+
+        then(memberQueryService).should(times(1)).search(anyLong());
+        then(mealDataRepository).should(times(1)).save(any(MealData.class));
+        assertThat(mealData.getCaloriePerUnit()).isEqualTo((double) 210 / 100);
+        assertThat(mealData.getCarbsPerUnit()).isEqualTo((double) 30 / 100);
+        assertThat(mealData.getProteinPerUnit()).isEqualTo((double) 5 / 100);
+        assertThat(mealData.getFatPerUnit()).isEqualTo((double) 3 / 100);
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#145, #147)

## 요약
- MealData 등록 request dto를 구현하고 MealData 엔티티와 mapping 하였습니다.
- MealData  등록 기능을 구현하였습니다.
- MealData  등록 API를 구현하였습니다.
- MealData 등록 API에 대한 단위 테스트를 진행하였습니다.
- API를 문서화하였습니다.

## 변경 내용
MealDataType enum 클래스의 데이터 명을 변경하였습니다.
