### PR TITLE
SSE 연결 API 및 알림 기능 구현

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/advice/common/GlobalControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/common/GlobalControllerAdvice.java
@@ -6,6 +6,7 @@ import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.global.exception.dto.response.ErrorResponse;
 import com.konggogi.veganlife.global.util.AopUtils;
 import com.konggogi.veganlife.global.util.LoggingUtils;
+import com.konggogi.veganlife.sse.exception.SseConnectionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -71,6 +72,19 @@ public class GlobalControllerAdvice {
                 AopUtils.extractMethodSignature(handlerMethod), HttpStatus.NOT_FOUND, exception);
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.from(exception.getErrorCode()));
+    }
+
+    @ExceptionHandler(SseConnectionException.class)
+    public ResponseEntity<ErrorResponse> handleSseConnectionException(
+            HandlerMethod handlerMethod, SseConnectionException exception) {
+
+        LoggingUtils.exceptionLog(
+                AopUtils.extractMethodSignature(handlerMethod),
+                HttpStatus.SERVICE_UNAVAILABLE,
+                exception);
+
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .body(ErrorResponse.from(exception.getErrorCode()));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -37,7 +37,10 @@ public enum ErrorCode {
 
     // post-like
     ALREADY_LIKED("POST_LIKE_001", "좋아요가 되어 있는 게시글입니다."),
-    ALREADY_UNLIKED("POST_LIKE_002", "좋아요가 되어 있지 않은 게시글입니다.");
+    ALREADY_UNLIKED("POST_LIKE_002", "좋아요가 되어 있지 않은 게시글입니다."),
+
+    // sse
+    SSE_CONNECTION_ERROR("SSE_001", "SSE 연결 오류가 발생했습니다");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -40,7 +40,7 @@ public enum ErrorCode {
     ALREADY_UNLIKED("POST_LIKE_002", "좋아요가 되어 있지 않은 게시글입니다."),
 
     // sse
-    SSE_CONNECTION_ERROR("SSE_001", "SSE 연결 오류가 발생했습니다");
+    SSE_CONNECTION_ERROR("SSE_001", "SSE 연결이 실패했습니다. 재연결이 필요합니다.");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/konggogi/veganlife/sse/controller/SseController.java
+++ b/src/main/java/com/konggogi/veganlife/sse/controller/SseController.java
@@ -1,0 +1,25 @@
+package com.konggogi.veganlife.sse.controller;
+
+
+import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import com.konggogi.veganlife.sse.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/sse")
+public class SseController {
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> subscribe(
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        SseEmitter emitter = notificationService.subscribe(userDetails.id());
+        return ResponseEntity.ok(emitter);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/domain/MessageFormatter.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/MessageFormatter.java
@@ -1,0 +1,11 @@
+package com.konggogi.veganlife.sse.domain;
+
+public interface MessageFormatter {
+    default String getMessage() {
+        return "";
+    }
+
+    default String getMessage(int data) {
+        return getMessage();
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/domain/Notification.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/Notification.java
@@ -1,0 +1,38 @@
+package com.konggogi.veganlife.sse.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import com.konggogi.veganlife.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends TimeStamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NotificationType type;
+
+    private String message;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public Notification(Long id, Member member, NotificationType type, String message) {
+        this.id = id;
+        this.member = member;
+        this.type = type;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/domain/NotificationMessage.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/NotificationMessage.java
@@ -6,11 +6,21 @@ import lombok.Getter;
 @Getter
 public enum NotificationMessage {
     // sse
-    SSE_CONNECTION("SSE 연결이 완료되었습니다.");
+    SSE_CONNECTION("SSE 연결이 완료되었습니다."),
+
+    // intake
+    OVER_INTAKE("오늘의 칼로리 섭취량이 %dKcal 초과되었습니다.");
 
     private final String message;
 
     NotificationMessage(String message) {
         this.message = message;
+    }
+
+    public String setCalorie(int calorie) {
+        if (this == OVER_INTAKE) {
+            return String.format(this.message, calorie);
+        }
+        return this.message;
     }
 }

--- a/src/main/java/com/konggogi/veganlife/sse/domain/NotificationMessage.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/NotificationMessage.java
@@ -1,15 +1,15 @@
 package com.konggogi.veganlife.sse.domain;
 
-
-import lombok.Getter;
-
-@Getter
-public enum NotificationMessage {
+public enum NotificationMessage implements MessageFormatter {
     // sse
     SSE_CONNECTION("SSE 연결이 완료되었습니다."),
-
     // intake
-    OVER_INTAKE("오늘의 칼로리 섭취량이 %dKcal 초과되었습니다.");
+    OVER_INTAKE("오늘의 칼로리 섭취량이 %dKcal 초과되었습니다.") {
+        @Override
+        public String getMessage(int calorie) {
+            return String.format(this.getMessage(), calorie);
+        }
+    };
 
     private final String message;
 
@@ -17,10 +17,8 @@ public enum NotificationMessage {
         this.message = message;
     }
 
-    public String setCalorie(int calorie) {
-        if (this == OVER_INTAKE) {
-            return String.format(this.message, calorie);
-        }
+    @Override
+    public String getMessage() {
         return this.message;
     }
 }

--- a/src/main/java/com/konggogi/veganlife/sse/domain/NotificationMessage.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/NotificationMessage.java
@@ -1,0 +1,16 @@
+package com.konggogi.veganlife.sse.domain;
+
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationMessage {
+    // sse
+    SSE_CONNECTION("SSE 연결이 완료되었습니다.");
+
+    private final String message;
+
+    NotificationMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/domain/NotificationType.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/NotificationType.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.sse.domain;
 
 public enum NotificationType {
-    SSE
+    SSE,
+    INTAKE
 }

--- a/src/main/java/com/konggogi/veganlife/sse/domain/NotificationType.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/NotificationType.java
@@ -1,0 +1,5 @@
+package com.konggogi.veganlife.sse.domain;
+
+public enum NotificationType {
+    SSE
+}

--- a/src/main/java/com/konggogi/veganlife/sse/domain/mapper/NotificationMapper.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/mapper/NotificationMapper.java
@@ -1,0 +1,17 @@
+package com.konggogi.veganlife.sse.domain.mapper;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.sse.domain.Notification;
+import com.konggogi.veganlife.sse.domain.NotificationType;
+import com.konggogi.veganlife.sse.service.dto.NotificationData;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface NotificationMapper {
+    @Mapping(target = "id", ignore = true)
+    Notification toEntity(Member member, NotificationType type, String message);
+
+    NotificationData toNotificationData(Notification notification);
+}

--- a/src/main/java/com/konggogi/veganlife/sse/exception/SseConnectionException.java
+++ b/src/main/java/com/konggogi/veganlife/sse/exception/SseConnectionException.java
@@ -1,0 +1,15 @@
+package com.konggogi.veganlife.sse.exception;
+
+
+import com.konggogi.veganlife.global.exception.ApiException;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+
+public class SseConnectionException extends ApiException {
+    public SseConnectionException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public SseConnectionException(ErrorCode errorCode, String description) {
+        super(errorCode, description);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/repository/EmitterRepository.java
+++ b/src/main/java/com/konggogi/veganlife/sse/repository/EmitterRepository.java
@@ -1,0 +1,27 @@
+package com.konggogi.veganlife.sse.repository;
+
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+@RequiredArgsConstructor
+public class EmitterRepository {
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public void save(Long memberId, SseEmitter emitter) {
+        emitters.put(memberId, emitter);
+    }
+
+    public void deleteById(Long memberId) {
+        emitters.remove(memberId);
+    }
+
+    public Optional<SseEmitter> findById(Long memberId) {
+        return Optional.ofNullable(emitters.get(memberId));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/repository/EmitterRepository.java
+++ b/src/main/java/com/konggogi/veganlife/sse/repository/EmitterRepository.java
@@ -1,27 +1,13 @@
 package com.konggogi.veganlife.sse.repository;
 
 
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-@Repository
-@RequiredArgsConstructor
-public class EmitterRepository {
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+public interface EmitterRepository {
+    void save(Long memberId, SseEmitter emitter);
 
-    public void save(Long memberId, SseEmitter emitter) {
-        emitters.put(memberId, emitter);
-    }
+    void deleteById(Long memberId);
 
-    public void deleteById(Long memberId) {
-        emitters.remove(memberId);
-    }
-
-    public Optional<SseEmitter> findById(Long memberId) {
-        return Optional.ofNullable(emitters.get(memberId));
-    }
+    Optional<SseEmitter> findById(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/sse/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/konggogi/veganlife/sse/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.konggogi.veganlife.sse.repository;
+
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+@RequiredArgsConstructor
+public class EmitterRepositoryImpl implements EmitterRepository {
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(Long memberId, SseEmitter emitter) {
+        emitters.put(memberId, emitter);
+    }
+
+    @Override
+    public void deleteById(Long memberId) {
+        emitters.remove(memberId);
+    }
+
+    @Override
+    public Optional<SseEmitter> findById(Long memberId) {
+        return Optional.ofNullable(emitters.get(memberId));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/repository/NotificationRepository.java
+++ b/src/main/java/com/konggogi/veganlife/sse/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.konggogi.veganlife.sse.repository;
+
+
+import com.konggogi.veganlife.sse.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {}

--- a/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
+++ b/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
@@ -14,10 +14,10 @@ import com.konggogi.veganlife.sse.repository.NotificationRepository;
 import com.konggogi.veganlife.sse.service.dto.NotificationData;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-@RestController
+@Service
 @RequiredArgsConstructor
 public class NotificationService {
     private static final Long DEFAULT_TIMEOUT = 60 * 1000L;

--- a/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
+++ b/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
@@ -2,11 +2,16 @@ package com.konggogi.veganlife.sse.service;
 
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.sse.domain.Notification;
 import com.konggogi.veganlife.sse.domain.NotificationMessage;
 import com.konggogi.veganlife.sse.domain.NotificationType;
+import com.konggogi.veganlife.sse.domain.mapper.NotificationMapper;
 import com.konggogi.veganlife.sse.exception.SseConnectionException;
 import com.konggogi.veganlife.sse.repository.EmitterRepository;
+import com.konggogi.veganlife.sse.repository.NotificationRepository;
+import com.konggogi.veganlife.sse.service.dto.NotificationData;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,27 +22,36 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class NotificationService {
     private static final Long DEFAULT_TIMEOUT = 60 * 1000L;
     private static final Long RECONNECTION_TIME = 1000L;
+    private final NotificationRepository notificationRepository;
     private final EmitterRepository emitterRepository;
-
     private final MemberQueryService memberQueryService;
+    private final NotificationMapper notificationMapper;
 
     public SseEmitter subscribe(Long memberId) {
-        memberQueryService.search(memberId);
+        Member member = memberQueryService.search(memberId);
         SseEmitter emitter = createEmitter(memberId);
-
-        sendToClient(memberId, NotificationType.SSE, NotificationMessage.SSE_CONNECTION);
+        sendNotification(
+                member, NotificationType.SSE, NotificationMessage.SSE_CONNECTION.getMessage());
         return emitter;
     }
 
-    private void sendToClient(Long memberId, NotificationType type, Object data) {
+    public void sendNotification(Member member, NotificationType type, String message) {
+        Notification notification =
+                notificationRepository.save(notificationMapper.toEntity(member, type, message));
+        NotificationData notificationData = notificationMapper.toNotificationData(notification);
+        sendToClient(member.getId(), notificationData);
+    }
+
+    private void sendToClient(Long memberId, Object data) {
         emitterRepository
                 .findById(memberId)
                 .ifPresent(
                         emitter -> {
                             try {
-                                emitter.send(createSseEvent(memberId, type, data));
+                                emitter.send(createSseEvent(memberId, data));
                             } catch (IOException exception) {
                                 emitterRepository.deleteById(memberId);
+                                // TODO 에러 핸들링
                                 throw new SseConnectionException(ErrorCode.SSE_CONNECTION_ERROR);
                             }
                         });
@@ -52,11 +66,9 @@ public class NotificationService {
         return emitter;
     }
 
-    private SseEmitter.SseEventBuilder createSseEvent(
-            Long memberId, NotificationType type, Object data) {
+    private SseEmitter.SseEventBuilder createSseEvent(Long memberId, Object data) {
         return SseEmitter.event()
                 .id(String.valueOf(memberId))
-                .name(type.name())
                 .data(data)
                 .reconnectTime(RECONNECTION_TIME);
     }

--- a/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
+++ b/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
@@ -1,0 +1,63 @@
+package com.konggogi.veganlife.sse.service;
+
+
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.sse.domain.NotificationMessage;
+import com.konggogi.veganlife.sse.domain.NotificationType;
+import com.konggogi.veganlife.sse.exception.SseConnectionException;
+import com.konggogi.veganlife.sse.repository.EmitterRepository;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationService {
+    private static final Long DEFAULT_TIMEOUT = 60 * 1000L;
+    private static final Long RECONNECTION_TIME = 1000L;
+    private final EmitterRepository emitterRepository;
+
+    private final MemberQueryService memberQueryService;
+
+    public SseEmitter subscribe(Long memberId) {
+        memberQueryService.search(memberId);
+        SseEmitter emitter = createEmitter(memberId);
+
+        sendToClient(memberId, NotificationType.SSE, NotificationMessage.SSE_CONNECTION);
+        return emitter;
+    }
+
+    private void sendToClient(Long memberId, NotificationType type, Object data) {
+        emitterRepository
+                .findById(memberId)
+                .ifPresent(
+                        emitter -> {
+                            try {
+                                emitter.send(createSseEvent(memberId, type, data));
+                            } catch (IOException exception) {
+                                emitterRepository.deleteById(memberId);
+                                throw new SseConnectionException(ErrorCode.SSE_CONNECTION_ERROR);
+                            }
+                        });
+    }
+
+    private SseEmitter createEmitter(Long memberId) {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        emitterRepository.save(memberId, emitter);
+
+        emitter.onCompletion(() -> emitterRepository.deleteById(memberId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(memberId));
+        return emitter;
+    }
+
+    private SseEmitter.SseEventBuilder createSseEvent(
+            Long memberId, NotificationType type, Object data) {
+        return SseEmitter.event()
+                .id(String.valueOf(memberId))
+                .name(type.name())
+                .data(data)
+                .reconnectTime(RECONNECTION_TIME);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
+++ b/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
@@ -51,7 +51,6 @@ public class NotificationService {
                                 emitter.send(createSseEvent(memberId, data));
                             } catch (IOException exception) {
                                 emitterRepository.deleteById(memberId);
-                                // TODO 에러 핸들링
                                 throw new SseConnectionException(ErrorCode.SSE_CONNECTION_ERROR);
                             }
                         });

--- a/src/main/java/com/konggogi/veganlife/sse/service/dto/NotificationData.java
+++ b/src/main/java/com/konggogi/veganlife/sse/service/dto/NotificationData.java
@@ -1,0 +1,6 @@
+package com.konggogi.veganlife.sse.service.dto;
+
+
+import com.konggogi.veganlife.sse.domain.NotificationType;
+
+public record NotificationData(NotificationType type, String message) {}

--- a/src/test/java/com/konggogi/veganlife/sse/repository/EmitterRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/sse/repository/EmitterRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.konggogi.veganlife.sse.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class EmitterRepositoryTest {
+    private EmitterRepository emitterRepository;
+    private final SseEmitter emitter = new SseEmitter();
+    private final Long memberId = 1L;
+
+    @BeforeEach
+    void setup() {
+        emitterRepository = new EmitterRepositoryImpl();
+    }
+
+    @Test
+    @DisplayName("SseEmitter 저장")
+    void saveTest() {
+        // when, then
+        assertThatNoException().isThrownBy(() -> emitterRepository.save(memberId, emitter));
+    }
+
+    @Test
+    @DisplayName("회원 ID로 SseEmitter 조회")
+    void findByIdTest() {
+        // given
+        emitterRepository.save(memberId, emitter);
+        // when
+        Optional<SseEmitter> foundEmitter = emitterRepository.findById(memberId);
+        // then
+        assertThat(foundEmitter).isPresent();
+    }
+
+    @Test
+    @DisplayName("회원 ID로 SseEmitter 삭제")
+    void deleteByIdTest() {
+        // given
+        emitterRepository.save(memberId, emitter);
+        // when, then
+        assertThatNoException().isThrownBy(() -> emitterRepository.deleteById(memberId));
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#164 )

## 요약
SSE 연결 API 구현
Notification 엔티티 및 레포지토리 생성
클라이언트에게 알림 전송 기능 구현

## 코멘트
추후 Redis나 Kafaka로 변경될 수 있어 EmitterRepository 인터페이스를 통해 구현했습니다.
SseController, NotificationService Test는 추후 진행 예정입니다.
