### PR TITLE
식품 데이터 검색 기능 수정 및 테스트

### DIFF
--- a/src/main/java/com/konggogi/veganlife/mealdata/controller/MealDataController.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/controller/MealDataController.java
@@ -5,12 +5,13 @@ import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
 import com.konggogi.veganlife.mealdata.controller.dto.request.MealDataAddRequest;
 import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataDetailsResponse;
 import com.konggogi.veganlife.mealdata.controller.dto.response.MealDataListResponse;
+import com.konggogi.veganlife.mealdata.domain.OwnerType;
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
 import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
 import com.konggogi.veganlife.mealdata.service.MealDataService;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -32,13 +34,13 @@ public class MealDataController {
     private final MealDataMapper mealDataMapper;
 
     @GetMapping
-    public ResponseEntity<List<MealDataListResponse>> getMealDataList(
-            String keyword, Pageable pageable) {
+    public ResponseEntity<Page<MealDataListResponse>> getMealDataList(
+            String keyword, @RequestParam OwnerType ownerType, Pageable pageable) {
 
         return ResponseEntity.ok(
-                mealDataQueryService.searchByKeyword(keyword, pageable).stream()
-                        .map(mealDataMapper::toMealDataListResponse)
-                        .toList());
+                mealDataQueryService
+                        .searchByKeyword(keyword, ownerType, pageable)
+                        .map(mealDataMapper::toMealDataListResponse));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/konggogi/veganlife/mealdata/repository/MealDataRepository.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/repository/MealDataRepository.java
@@ -2,7 +2,8 @@ package com.konggogi.veganlife.mealdata.repository;
 
 
 import com.konggogi.veganlife.mealdata.domain.MealData;
-import java.util.List;
+import com.konggogi.veganlife.mealdata.domain.OwnerType;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,5 +11,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MealDataRepository extends JpaRepository<MealData, Long> {
 
-    List<MealData> findByNameContaining(String Keyword, Pageable pageable);
+    Page<MealData> findByNameContainingAndOwnerType(
+            String keyword, OwnerType ownerType, Pageable pageable);
 }

--- a/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataQueryService.java
@@ -4,9 +4,10 @@ package com.konggogi.veganlife.mealdata.service;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.domain.OwnerType;
 import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,9 +19,9 @@ public class MealDataQueryService {
 
     private final MealDataRepository mealDataRepository;
 
-    public List<MealData> searchByKeyword(String keyword, Pageable pageable) {
+    public Page<MealData> searchByKeyword(String keyword, OwnerType type, Pageable pageable) {
 
-        return mealDataRepository.findByNameContaining(keyword, pageable);
+        return mealDataRepository.findByNameContainingAndOwnerType(keyword, type, pageable);
     }
 
     public MealData search(Long id) {

--- a/src/test/java/com/konggogi/veganlife/mealdata/fixture/MealDataFixture.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/fixture/MealDataFixture.java
@@ -8,7 +8,7 @@ import com.konggogi.veganlife.mealdata.domain.OwnerType;
 import com.konggogi.veganlife.member.domain.Member;
 
 public enum MealDataFixture {
-    MEAL(
+    TOTAL_AMOUNT(
             "디폴트 음식",
             MealDataType.TOTAL_AMOUNT,
             100,
@@ -19,7 +19,7 @@ public enum MealDataFixture {
             1D,
             IntakeUnit.G,
             OwnerType.ALL),
-    PROCESSED(
+    AMOUNT_PER_SERVE(
             "디폴트 가공식품",
             MealDataType.AMOUNT_PER_SERVE,
             100,
@@ -121,6 +121,23 @@ public enum MealDataFixture {
 
         return MealData.builder()
                 .id(id)
+                .name(name)
+                .type(type)
+                .amount(amount)
+                .amountPerServe(amountPerServe)
+                .caloriePerUnit(caloriePerUnit)
+                .proteinPerUnit(proteinPerUnit)
+                .fatPerUnit(fatPerUnit)
+                .carbsPerUnit(carbsPerUnit)
+                .intakeUnit(intakeUnit)
+                .ownerType(ownerType)
+                .member(member)
+                .build();
+    }
+
+    public MealData getWithNameAndOwnerType(String name, OwnerType ownerType, Member member) {
+
+        return MealData.builder()
                 .name(name)
                 .type(type)
                 .amount(amount)

--- a/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataQueryServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.domain.OwnerType;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
 import com.konggogi.veganlife.member.domain.Member;
@@ -20,7 +21,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class MealDataQueryServiceTest {
@@ -34,26 +37,35 @@ public class MealDataQueryServiceTest {
     @DisplayName("키워드를 포함하는 이름을 가진 식품 데이터들을 조회")
     void searchByKeywordTest() {
         // given
-        List<String> valid = List.of("통밀빵", "통밀크래커");
-        List<MealData> found =
-                valid.stream().map(name -> MealDataFixture.MEAL.getWithName(name, member)).toList();
-        given(mealDataRepository.findByNameContaining(anyString(), any(Pageable.class)))
+        List<MealData> mealDataList =
+                List.of(
+                        MealDataFixture.TOTAL_AMOUNT.getWithNameAndOwnerType(
+                                "통밀빵", OwnerType.ALL, member),
+                        MealDataFixture.TOTAL_AMOUNT.getWithNameAndOwnerType(
+                                "통밀크래커", OwnerType.ALL, member));
+        Page<MealData> found =
+                PageableExecutionUtils.getPage(
+                        mealDataList, Pageable.ofSize(20), mealDataList::size);
+        given(
+                        mealDataRepository.findByNameContainingAndOwnerType(
+                                anyString(), any(OwnerType.class), any(Pageable.class)))
                 .willReturn(found);
-        String keyword = "통";
-        Pageable pageable = Pageable.ofSize(12);
         // when
-        List<MealData> result = mealDataQueryService.searchByKeyword(keyword, pageable);
+        Page<MealData> result =
+                mealDataQueryService.searchByKeyword("통", OwnerType.ALL, Pageable.ofSize(12));
         // then
         assertThat(result).hasSize(2);
-        assertThat(result).allMatch(r -> valid.contains(r.getName()));
+        assertThat(result.map(MealData::getName)).allMatch(name -> name.contains("통"));
+        assertThat(result.map(MealData::getOwnerType))
+                .allMatch(ownerType -> ownerType.equals(OwnerType.ALL));
     }
 
     @Test
     @DisplayName("식품 데이터 ID에 해당하는 식품 데이터 상세 조회")
     void searchTest() {
         // given
-        MealData found = MealDataFixture.MEAL.getWithName(1L, "통밀빵", member);
-        given(mealDataRepository.findById(anyLong())).willReturn(Optional.ofNullable(found));
+        MealData found = MealDataFixture.TOTAL_AMOUNT.getWithName(1L, "통밀빵", member);
+        given(mealDataRepository.findById(anyLong())).willReturn(Optional.of(found));
         // when
         MealData result = mealDataQueryService.search(found.getId());
         // then

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -60,9 +60,9 @@ public class MealLogControllerTest extends RestDocsTest {
     Member member = Member.builder().id(1L).email("test123@test.com").build();
     List<MealData> mealData =
             List.of(
-                    MealDataFixture.MEAL.get(1L, member),
-                    MealDataFixture.PROCESSED.get(2L, member),
-                    MealDataFixture.MEAL.get(3L, member));
+                    MealDataFixture.TOTAL_AMOUNT.get(1L, member),
+                    MealDataFixture.AMOUNT_PER_SERVE.get(2L, member),
+                    MealDataFixture.TOTAL_AMOUNT.get(3L, member));
 
     List<MealAddRequest> mealAddRequests =
             List.of(
@@ -72,14 +72,16 @@ public class MealLogControllerTest extends RestDocsTest {
                             10,
                             10,
                             10,
-                            MealDataFixture.MEAL.getWithName(1L, "통밀빵", member).getId()),
+                            MealDataFixture.TOTAL_AMOUNT.getWithName(1L, "통밀빵", member).getId()),
                     new MealAddRequest(
                             100,
                             100,
                             10,
                             10,
                             10,
-                            MealDataFixture.PROCESSED.getWithName(2L, "통밀크래커", member).getId()));
+                            MealDataFixture.AMOUNT_PER_SERVE
+                                    .getWithName(2L, "통밀크래커", member)
+                                    .getId()));
 
     List<MealModifyRequest> mealModifyRequests =
             List.of(
@@ -89,14 +91,16 @@ public class MealLogControllerTest extends RestDocsTest {
                             10,
                             10,
                             10,
-                            MealDataFixture.MEAL.getWithName(1L, "통밀빵", member).getId()),
+                            MealDataFixture.TOTAL_AMOUNT.getWithName(1L, "통밀빵", member).getId()),
                     new MealModifyRequest(
                             100,
                             100,
                             10,
                             10,
                             10,
-                            MealDataFixture.PROCESSED.getWithName(2L, "통밀크래커", member).getId()));
+                            MealDataFixture.AMOUNT_PER_SERVE
+                                    .getWithName(2L, "통밀크래커", member)
+                                    .getId()));
 
     List<String> imageUrls = List.of("image1.png", "image2.png", "image3.png");
 

--- a/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
@@ -41,9 +41,9 @@ public class MealLogRepositoryTest {
     Member member = Member.builder().email("test123@test.com").build();
     List<MealData> mealData =
             List.of(
-                    MealDataFixture.MEAL.get(member),
-                    MealDataFixture.MEAL.get(member),
-                    MealDataFixture.MEAL.get(member));
+                    MealDataFixture.TOTAL_AMOUNT.get(member),
+                    MealDataFixture.TOTAL_AMOUNT.get(member),
+                    MealDataFixture.TOTAL_AMOUNT.get(member));
 
     @BeforeEach
     void setup() {

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
@@ -37,9 +37,9 @@ public class MealLogQueryServiceTest {
     Member member = Member.builder().email("test123@test.com").build();
     List<MealData> mealData =
             List.of(
-                    MealDataFixture.MEAL.get(1L, member),
-                    MealDataFixture.MEAL.get(2L, member),
-                    MealDataFixture.MEAL.get(3L, member));
+                    MealDataFixture.TOTAL_AMOUNT.get(1L, member),
+                    MealDataFixture.TOTAL_AMOUNT.get(2L, member),
+                    MealDataFixture.TOTAL_AMOUNT.get(3L, member));
 
     @Test
     @DisplayName("해당 날짜의 MealLog 목록 조회")

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -53,9 +53,9 @@ public class MealLogServiceTest {
     Member member = Member.builder().id(1L).email("test123@test.com").build();
     List<MealData> mealData =
             List.of(
-                    MealDataFixture.MEAL.get(1L, member),
-                    MealDataFixture.MEAL.get(2L, member),
-                    MealDataFixture.MEAL.get(3L, member));
+                    MealDataFixture.TOTAL_AMOUNT.get(1L, member),
+                    MealDataFixture.TOTAL_AMOUNT.get(2L, member),
+                    MealDataFixture.TOTAL_AMOUNT.get(3L, member));
     List<MealAddRequest> mealAddRequests =
             mealData.stream()
                     .map(m -> new MealAddRequest(100, 100, 10, 10, 10, m.getId()))

--- a/src/test/java/com/konggogi/veganlife/member/service/NutrientsQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/NutrientsQueryServiceTest.java
@@ -39,7 +39,9 @@ class NutrientsQueryServiceTest {
     @InjectMocks NutrientsQueryService nutrientsQueryService;
     private final Member member = MemberFixture.DEFAULT_M.getMember();
     private final List<MealData> mealData =
-            List.of(MealDataFixture.MEAL.get(member), MealDataFixture.MEAL.get(member));
+            List.of(
+                    MealDataFixture.TOTAL_AMOUNT.get(member),
+                    MealDataFixture.TOTAL_AMOUNT.get(member));
     private List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
     private List<MealImage> mealImages =
             IntStream.range(0, 2).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();


### PR DESCRIPTION
## 이슈 번호 (#137)

## 요약
- `MealLog` 검색 시 반환되는 타입을 수정했습니다. (`List` -> `Page`)
- `MealLog` 검색 조건에 `ownerType`을 추가했습니다.
  - 데이터셋 내에서 검색할 건지 사용자 추가 데이터 내에서 검색할 것인지 구분하기 위함입니다.
- 수정한 기능이 제대로 동작하는지 테스트하였습니다.