### PR TITLE
REST-assured 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,8 @@ dependencies {
 
     // jwt
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
-    compileOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
-    compileOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // spring actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -83,6 +83,9 @@ dependencies {
 
     // thymeleaf (for restdocs)
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
+    // rest assured
+    testImplementation 'io.rest-assured:rest-assured:5.3.2'
 }
 
 test {

--- a/src/test/java/com/konggogi/veganlife/mealdata/MealDataIntegrationTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/MealDataIntegrationTest.java
@@ -1,0 +1,41 @@
+package com.konggogi.veganlife.mealdata;
+
+import static io.restassured.RestAssured.given;
+
+import com.konggogi.veganlife.mealdata.controller.dto.request.MealDataAddRequest;
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
+import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
+import com.konggogi.veganlife.mealdata.service.MealDataService;
+import com.konggogi.veganlife.support.restassured.IntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class MealDataIntegrationTest extends IntegrationTest {
+
+    @Autowired MealDataQueryService mealDataQueryService;
+    @Autowired MealDataService mealDataService;
+    @Autowired MealDataMapper mealDataMapper;
+
+    @Test
+    @DisplayName("식품 데이터 등록")
+    void getMealDataListTest() throws Exception {
+
+        MealDataAddRequest request =
+                new MealDataAddRequest("통밀빵", 300, 100, 200, 40, 7, 3, IntakeUnit.G);
+        given().log()
+                .all()
+                .header(AUTHORIZATION, getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(toJson(request))
+                .when()
+                .post("/api/v1/meal-data")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/support/restassured/DatabaseCleaner.java
+++ b/src/test/java/com/konggogi/veganlife/support/restassured/DatabaseCleaner.java
@@ -30,16 +30,14 @@ public class DatabaseCleaner {
 
     private void truncate() {
         // 제약조건 무효화
-        entityManager
-                .createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE")
-                .executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
         // truncate 명령 실행
-        tableNames.forEach(tableName -> entityManager
-                .createNativeQuery(String.format("TRUNCATE TABLE %s", tableName))
-                .executeUpdate());
+        tableNames.forEach(
+                tableName ->
+                        entityManager
+                                .createNativeQuery(String.format("TRUNCATE TABLE %s", tableName))
+                                .executeUpdate());
         // 제약조건 무효화 해제
-        entityManager
-                .createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE")
-                .executeUpdate();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/support/restassured/DatabaseCleaner.java
+++ b/src/test/java/com/konggogi/veganlife/support/restassured/DatabaseCleaner.java
@@ -1,0 +1,45 @@
+package com.konggogi.veganlife.support.restassured;
+
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+
+    @PersistenceContext private EntityManager entityManager;
+    private final List<String> tableNames = new ArrayList<>();
+
+    @PostConstruct
+    @SuppressWarnings("unchecked")
+    private void findDatabaseTableNames() {
+        List<Object[]> tableInfos = entityManager.createNativeQuery("SHOW TABLES").getResultList();
+        tableInfos.forEach(tableInfo -> tableNames.add((String) tableInfo[0]));
+    }
+
+    @Transactional
+    public void clear() {
+        entityManager.clear();
+        truncate();
+    }
+
+    private void truncate() {
+        // 제약조건 무효화
+        entityManager
+                .createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE")
+                .executeUpdate();
+        // truncate 명령 실행
+        tableNames.forEach(tableName -> entityManager
+                .createNativeQuery(String.format("TRUNCATE TABLE %s", tableName))
+                .executeUpdate());
+        // 제약조건 무효화 해제
+        entityManager
+                .createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE")
+                .executeUpdate();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/support/restassured/DatabaseClearExtension.java
+++ b/src/test/java/com/konggogi/veganlife/support/restassured/DatabaseClearExtension.java
@@ -1,0 +1,21 @@
+package com.konggogi.veganlife.support.restassured;
+
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseClearExtension implements BeforeEachCallback {
+
+    @Override
+    public void beforeEach(ExtensionContext extensionContext) throws Exception {
+        DatabaseCleaner databaseCleaner = getDatabaseCleaner(extensionContext);
+        databaseCleaner.clear();
+    }
+
+    private DatabaseCleaner getDatabaseCleaner(ExtensionContext extensionContext) {
+
+        return SpringExtension.getApplicationContext(extensionContext)
+                .getBean(DatabaseCleaner.class);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/support/restassured/IntegrationTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/restassured/IntegrationTest.java
@@ -1,0 +1,39 @@
+package com.konggogi.veganlife.support.restassured;
+
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.konggogi.veganlife.global.security.jwt.JwtProvider;
+import com.konggogi.veganlife.member.domain.Gender;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.member.service.MemberService;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+
+@ExtendWith(DatabaseClearExtension.class)
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+public class IntegrationTest {
+
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private MemberService memberService;
+    @Autowired private JwtProvider jwtProvider;
+
+    protected static final String AUTHORIZATION = "Authorization";
+
+    protected Member member;
+
+    protected String toJson(Object object) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(object);
+    }
+
+    protected String getAccessToken() {
+        member = Member.builder().email("test123@test.com").build();
+        member.updateMemberInfo("비건라이프", Gender.F, VegetarianType.VEGAN, 2000, 160, 50);
+        memberService.addMember(member.getEmail());
+
+        return jwtProvider.createToken(member.getEmail());
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#175)

## 요약
- E2E 테스트를 위해 REST-assured dependency를 추가하였습니다.
- 테스트 격리를 위해 `DatabaseCleaner` 클래스를 구현하였습니다.
- 예시 E2E 테스트(식품 데이터 등록)를 진행하였습니다.

## Trouble Shooting

테스트를 진행하는 도중, `Jwt.parseBuilder()`가 런타임에 제대로 동작하지 않음을 확인했습니다.
```
Unable to load class named [io.jsonwebtoken.impl.DefaultJwtBuilder] from the thread context, current, or system/application ClassLoaders.  All heuristics have been exhausted.  Class could not be found.  Have you remembered to include the jjwt-impl.jar in your runtime classpath?
```

오류 메세지를 보면 알 수 있듯이, gradle 설정에 대한 오류였습니다.

```groovy
// jwt  
implementation 'io.jsonwebtoken:jjwt-api:0.11.5'  
compileOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'  
compileOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
```

Dependency Option을 `compileOnly`로 설정하였기 때문에 build 파일에 해당 클래스가 포함되지 않아 발생한 오류였습니다.
- `compileOnly`는 lombok과 같이 compile 시점에 코드를 생성(Getter, Setter)하는 경우에 사용합니다.

런타임일 때 사용하기 위해 Dependency Option을 `runtimeOnly`로 수정하였습니다.

```groovy
// jwt  
implementation 'io.jsonwebtoken:jjwt-api:0.11.5'  
runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'  
runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
```