### PR TITLE
금일 칼로리 섭취량에 따른 알림 기능 구현

### DIFF
--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -13,6 +13,7 @@ import com.konggogi.veganlife.meallog.domain.mapper.MealImageMapper;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
 import com.konggogi.veganlife.meallog.domain.mapper.MealMapper;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
+import com.konggogi.veganlife.member.service.IntakeNotifyService;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -26,8 +27,8 @@ public class MealLogService {
 
     private final MemberQueryService memberQueryService;
     private final MealDataQueryService mealDataQueryService;
-
     private final MealLogQueryService mealLogQueryService;
+    private final IntakeNotifyService intakeNotifyService;
     private final MealLogRepository mealLogRepository;
 
     private final MealLogMapper mealLogMapper;
@@ -35,19 +36,19 @@ public class MealLogService {
     private final MealImageMapper mealImageMapper;
 
     public void add(MealLogAddRequest request, Long memberId) {
-
         MealLog mealLog =
                 mealLogMapper.toEntity(request.mealType(), memberQueryService.search(memberId));
         addMeals(request.meals(), mealLog);
         addMealImages(request.imageUrls(), mealLog);
         mealLogRepository.save(mealLog);
+        intakeNotifyService.notifyIfOverIntake(memberId);
     }
 
     public void modify(Long mealLogId, MealLogModifyRequest request) {
-
         MealLog mealLog = mealLogQueryService.searchById(mealLogId);
         modifyMeals(request.meals(), mealLog);
         modifyMealImages(request.imageUrls(), mealLog);
+        intakeNotifyService.notifyIfOverIntake(mealLog.getMember().getId());
     }
 
     public void remove(Long mealLogId) {

--- a/src/main/java/com/konggogi/veganlife/member/service/IntakeNotifyService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/IntakeNotifyService.java
@@ -1,0 +1,61 @@
+package com.konggogi.veganlife.member.service;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
+import com.konggogi.veganlife.sse.domain.NotificationMessage;
+import com.konggogi.veganlife.sse.domain.NotificationType;
+import com.konggogi.veganlife.sse.repository.NotificationRepository;
+import com.konggogi.veganlife.sse.service.NotificationService;
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class IntakeNotifyService {
+    private final NotificationService notificationService;
+    private final MemberQueryService memberQueryService;
+    private final NutrientsQueryService nutrientsQueryService;
+    private final NotificationRepository notificationRepository;
+
+    public void notifyIfOverIntake(Long memberId) {
+        Member member = memberQueryService.search(memberId);
+        IntakeNutrients intakeNutrients =
+                nutrientsQueryService.searchDailyIntakeNutrients(memberId, LocalDate.now());
+        int dailyAMR = member.getAMR();
+        int todayIntakeCalorie = intakeNutrients.calorie();
+        int overCalorie = todayIntakeCalorie - dailyAMR;
+
+        getNotificationType(dailyAMR, todayIntakeCalorie)
+                .ifPresent(type -> sendOverIntakeNotificationIfNotSend(member, type, overCalorie));
+    }
+
+    private Optional<NotificationType> getNotificationType(int dailyAMR, int todayIntakeCalorie) {
+        int over30PercentageOfAMR = (int) (dailyAMR * 1.3);
+        int over60PercentageOfAMR = (int) (dailyAMR * 1.6);
+
+        if (todayIntakeCalorie >= over60PercentageOfAMR) {
+            return Optional.of(NotificationType.INTAKE_OVER_60);
+        } else if (todayIntakeCalorie >= over30PercentageOfAMR) {
+            return Optional.of(NotificationType.INTAKE_OVER_30);
+        }
+        return Optional.empty();
+    }
+
+    private void sendOverIntakeNotificationIfNotSend(
+            Member member, NotificationType type, int overCalorie) {
+        notificationRepository
+                .findByDateAndType(member.getId(), LocalDate.now(), type)
+                .ifPresentOrElse(
+                        notification -> {},
+                        () ->
+                                notificationService.sendNotification(
+                                        member,
+                                        type,
+                                        NotificationMessage.OVER_INTAKE.getMessage(overCalorie)));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/sse/domain/NotificationType.java
+++ b/src/main/java/com/konggogi/veganlife/sse/domain/NotificationType.java
@@ -2,5 +2,6 @@ package com.konggogi.veganlife.sse.domain;
 
 public enum NotificationType {
     SSE,
-    INTAKE
+    INTAKE_OVER_30,
+    INTAKE_OVER_60
 }

--- a/src/main/java/com/konggogi/veganlife/sse/repository/NotificationRepository.java
+++ b/src/main/java/com/konggogi/veganlife/sse/repository/NotificationRepository.java
@@ -2,6 +2,15 @@ package com.konggogi.veganlife.sse.repository;
 
 
 import com.konggogi.veganlife.sse.domain.Notification;
+import com.konggogi.veganlife.sse.domain.NotificationType;
+import java.time.LocalDate;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {}
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query(
+            "select n from Notification n where n.member.id = :memberId and cast(n.createdAt as localdate) = :date and n.type = :type")
+    Optional<Notification> findByDateAndType(Long memberId, LocalDate date, NotificationType type);
+}

--- a/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
+++ b/src/main/java/com/konggogi/veganlife/sse/service/NotificationService.java
@@ -15,12 +15,14 @@ import com.konggogi.veganlife.sse.service.dto.NotificationData;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class NotificationService {
-    private static final Long DEFAULT_TIMEOUT = 60 * 1000L;
+    private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60 * 2;
     private static final Long RECONNECTION_TIME = 1000L;
     private final NotificationRepository notificationRepository;
     private final EmitterRepository emitterRepository;

--- a/src/main/java/com/konggogi/veganlife/sse/service/dto/NotificationData.java
+++ b/src/main/java/com/konggogi/veganlife/sse/service/dto/NotificationData.java
@@ -2,5 +2,6 @@ package com.konggogi.veganlife.sse.service.dto;
 
 
 import com.konggogi.veganlife.sse.domain.NotificationType;
+import java.time.LocalDateTime;
 
-public record NotificationData(NotificationType type, String message) {}
+public record NotificationData(NotificationType type, String message, LocalDateTime createdAt) {}

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -3,6 +3,7 @@ package com.konggogi.veganlife.meallog.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 
 import com.konggogi.veganlife.mealdata.domain.MealData;
@@ -27,6 +28,7 @@ import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
 import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.IntakeNotifyService;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -45,6 +47,7 @@ public class MealLogServiceTest {
     @Mock MealDataQueryService mealDataQueryService;
     @Mock MealLogQueryService mealLogQueryService;
     @Mock MealLogRepository mealLogRepository;
+    @Mock IntakeNotifyService intakeNotifyService;
     @Spy MealLogMapper mealLogMapper = new MealLogMapperImpl();
     @Spy MealMapper mealMapper = new MealMapperImpl();
     @Spy MealImageMapper mealImageMapper = new MealImageMapperImpl();
@@ -75,6 +78,7 @@ public class MealLogServiceTest {
         MealLogAddRequest mealLogAddRequest =
                 new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests, imageUrls);
         given(memberQueryService.search(1L)).willReturn(member);
+        doNothing().when(intakeNotifyService).notifyIfOverIntake(1L);
         mealData.forEach(m -> given(mealDataQueryService.search(m.getId())).willReturn(m));
         // when
         mealLogService.add(mealLogAddRequest, member.getId());
@@ -95,6 +99,7 @@ public class MealLogServiceTest {
                 IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
         MealLog mealLog = MealLogFixture.BREAKFAST.get(meals, mealImages, member);
         given(mealLogQueryService.searchById(1L)).willReturn(mealLog);
+        doNothing().when(intakeNotifyService).notifyIfOverIntake(1L);
         mealData.forEach(m -> given(mealDataQueryService.search(m.getId())).willReturn(m));
         // when
         mealLogService.modify(1L, mealLogModifyRequest);


### PR DESCRIPTION
## 이슈 번호 (#170 )

## 요약
사용자의 금일 칼로리 섭취량이 권장 섭취량의 130%, 160%를 초과하면 알림 보내는 기능 구현
각각 한 번씩만 알림을 전송해야 하므로, `notificationRepository`에서 notification에서 오늘 전송한 `INTAKE_OVER_30` 또는 `INTAKE_OVER_60` 관련한 `Notification`이 없다면 알림을 전송

## 변경 내용
`MealLogService`의 `add()`와 `modify()` 메서드에서 섭취량 알림 기능을 호출하도록 변경
SSE Timeout 시간 2시간으로 변경, 너무 짧은 Timeout 시간은 서버 부하를 가져올 수 있기 때문