### PR TITLE
IntakeNotifyService 테스트 구현

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/advice/common/GlobalControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/common/GlobalControllerAdvice.java
@@ -6,7 +6,6 @@ import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.global.exception.dto.response.ErrorResponse;
 import com.konggogi.veganlife.global.util.AopUtils;
 import com.konggogi.veganlife.global.util.LoggingUtils;
-import com.konggogi.veganlife.notification.exception.SseConnectionException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -72,19 +71,6 @@ public class GlobalControllerAdvice {
                 AopUtils.extractMethodSignature(handlerMethod), HttpStatus.NOT_FOUND, exception);
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                .body(ErrorResponse.from(exception.getErrorCode()));
-    }
-
-    @ExceptionHandler(SseConnectionException.class)
-    public ResponseEntity<ErrorResponse> handleSseConnectionException(
-            HandlerMethod handlerMethod, SseConnectionException exception) {
-
-        LoggingUtils.exceptionLog(
-                AopUtils.extractMethodSignature(handlerMethod),
-                HttpStatus.SERVICE_UNAVAILABLE,
-                exception);
-
-        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
                 .body(ErrorResponse.from(exception.getErrorCode()));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/global/advice/notification/SseControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/notification/SseControllerAdvice.java
@@ -1,0 +1,28 @@
+package com.konggogi.veganlife.global.advice.notification;
+
+
+import com.konggogi.veganlife.global.exception.dto.response.ErrorResponse;
+import com.konggogi.veganlife.global.util.AopUtils;
+import com.konggogi.veganlife.global.util.LoggingUtils;
+import com.konggogi.veganlife.notification.exception.SseConnectionException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.HandlerMethod;
+
+@RestControllerAdvice
+public class SseControllerAdvice {
+    @ExceptionHandler(SseConnectionException.class)
+    public ResponseEntity<ErrorResponse> handleSseConnectionException(
+            HandlerMethod handlerMethod, SseConnectionException exception) {
+
+        LoggingUtils.exceptionLog(
+                AopUtils.extractMethodSignature(handlerMethod),
+                HttpStatus.SERVICE_UNAVAILABLE,
+                exception);
+
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                .body(ErrorResponse.from(exception.getErrorCode()));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/member/service/dto/IntakeNutrients.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/dto/IntakeNutrients.java
@@ -1,11 +1,3 @@
 package com.konggogi.veganlife.member.service.dto;
 
-public record IntakeNutrients(Integer calorie, Integer carbs, Integer protein, Integer fat) {
-    public static IntakeNutrients combine(IntakeNutrients a, IntakeNutrients b) {
-        return new IntakeNutrients(
-                a.calorie() + b.calorie(),
-                a.carbs() + b.carbs(),
-                a.protein() + b.protein(),
-                a.fat() + b.fat());
-    }
-}
+public record IntakeNutrients(Integer calorie, Integer carbs, Integer protein, Integer fat) {}

--- a/src/test/java/com/konggogi/veganlife/member/fixture/IntakeNutrientsFixture.java
+++ b/src/test/java/com/konggogi/veganlife/member/fixture/IntakeNutrientsFixture.java
@@ -1,0 +1,29 @@
+package com.konggogi.veganlife.member.fixture;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
+
+public enum IntakeNutrientsFixture {
+    DEFAULT(10, 10, 10, 10);
+    private final int calorie;
+    private final int carbs;
+    private final int protein;
+    private final int fat;
+
+    IntakeNutrientsFixture(int calorie, int carbs, int protein, int fat) {
+        this.calorie = calorie;
+        this.carbs = carbs;
+        this.protein = protein;
+        this.fat = fat;
+    }
+
+    public IntakeNutrients get() {
+        return new IntakeNutrients(calorie, carbs, protein, fat);
+    }
+
+    public IntakeNutrients getOverCalorieOfMember(Member member, float percentage) {
+        int calorie = (int) (member.getAMR() * percentage);
+        return new IntakeNutrients(calorie, carbs, protein, fat);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/member/service/IntakeNotifyServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/IntakeNotifyServiceTest.java
@@ -1,0 +1,133 @@
+package com.konggogi.veganlife.member.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.IntakeNutrientsFixture;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
+import com.konggogi.veganlife.notification.domain.Notification;
+import com.konggogi.veganlife.notification.domain.NotificationType;
+import com.konggogi.veganlife.notification.fixture.NotificationFixture;
+import com.konggogi.veganlife.notification.repository.NotificationRepository;
+import com.konggogi.veganlife.notification.service.NotificationService;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IntakeNotifyServiceTest {
+    @Mock NotificationService notificationService;
+    @Mock MemberQueryService memberQueryService;
+    @Mock NutrientsQueryService nutrientsQueryService;
+    @Mock NotificationRepository notificationRepository;
+    @InjectMocks IntakeNotifyService intakeNotifyService;
+
+    private final Member member = MemberFixture.DEFAULT_M.getMember();
+
+    @Test
+    @DisplayName("권장 섭취량 대비 금일 섭취 칼로리 30% 초과시 알림")
+    void notifyIfOverIntake30PercentageTest() {
+        // given
+        Long memberId = member.getId();
+        IntakeNutrients intakeNutrients =
+                IntakeNutrientsFixture.DEFAULT.getOverCalorieOfMember(member, 1.3f);
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(nutrientsQueryService.searchDailyIntakeNutrients(memberId, LocalDate.now()))
+                .willReturn(intakeNutrients);
+        given(
+                        notificationRepository.findByDateAndType(
+                                anyLong(), any(LocalDate.class), any(NotificationType.class)))
+                .willReturn(Optional.empty());
+        doNothing()
+                .when(notificationService)
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+        // when, then
+        assertDoesNotThrow(() -> intakeNotifyService.notifyIfOverIntake(memberId));
+        then(notificationRepository)
+                .should()
+                .findByDateAndType(anyLong(), any(LocalDate.class), any(NotificationType.class));
+        then(notificationService)
+                .should()
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+    }
+
+    @Test
+    @DisplayName("권장 섭취량 대비 금일 섭취 칼로리 60% 초과시 알림")
+    void notifyIfOverIntake60PercentageTest() {
+        // given
+        Long memberId = member.getId();
+        IntakeNutrients intakeNutrients =
+                IntakeNutrientsFixture.DEFAULT.getOverCalorieOfMember(member, 1.6f);
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(nutrientsQueryService.searchDailyIntakeNutrients(memberId, LocalDate.now()))
+                .willReturn(intakeNutrients);
+        given(
+                        notificationRepository.findByDateAndType(
+                                anyLong(), any(LocalDate.class), any(NotificationType.class)))
+                .willReturn(Optional.empty());
+        doNothing()
+                .when(notificationService)
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+        // when, then
+        assertDoesNotThrow(() -> intakeNotifyService.notifyIfOverIntake(memberId));
+        then(notificationRepository)
+                .should()
+                .findByDateAndType(anyLong(), any(LocalDate.class), any(NotificationType.class));
+        then(notificationService)
+                .should()
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+    }
+
+    @Test
+    @DisplayName("권장 섭취량 대비 금일 섭취 칼로리 초과시 알림 - 이미 알림을 보낸 경우 보내지 않는다")
+    void notifyIfOverIntake60PercentageAlreadySendTest() {
+        // given
+        Long memberId = member.getId();
+        IntakeNutrients intakeNutrients =
+                IntakeNutrientsFixture.DEFAULT.getOverCalorieOfMember(member, 1.6f);
+        Notification notification = NotificationFixture.INTAKE_OVER_60.get(member);
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(nutrientsQueryService.searchDailyIntakeNutrients(memberId, LocalDate.now()))
+                .willReturn(intakeNutrients);
+        given(
+                        notificationRepository.findByDateAndType(
+                                anyLong(), any(LocalDate.class), any(NotificationType.class)))
+                .willReturn(Optional.of(notification));
+        // when, then
+        assertDoesNotThrow(() -> intakeNotifyService.notifyIfOverIntake(memberId));
+        then(notificationRepository)
+                .should()
+                .findByDateAndType(anyLong(), any(LocalDate.class), any(NotificationType.class));
+        then(notificationService)
+                .should(never())
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+    }
+
+    @Test
+    @DisplayName("금일 섭취 칼로리가 초과되지 않으면 알림을 보내지 않는다")
+    void notNotifyOverIntakeTest() {
+        // given
+        Long memberId = member.getId();
+        IntakeNutrients intakeNutrients =
+                IntakeNutrientsFixture.DEFAULT.getOverCalorieOfMember(member, 1f);
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(nutrientsQueryService.searchDailyIntakeNutrients(memberId, LocalDate.now()))
+                .willReturn(intakeNutrients);
+        // when, then
+        assertDoesNotThrow(() -> intakeNotifyService.notifyIfOverIntake(memberId));
+        then(notificationRepository)
+                .should(never())
+                .findByDateAndType(anyLong(), any(LocalDate.class), any(NotificationType.class));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/notification/service/NotificationServiceTest.java
@@ -1,11 +1,13 @@
 package com.konggogi.veganlife.notification.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
@@ -74,11 +76,10 @@ class NotificationServiceTest {
         // given
         given(emitterRepository.findById(anyLong())).willReturn(Optional.of(sseEmitter));
         // when, then
-        assertThatNoException()
-                .isThrownBy(
-                        () ->
-                                notificationService.sendNotification(
-                                        member, notification.getType(), notification.getMessage()));
+        assertDoesNotThrow(
+                () ->
+                        notificationService.sendNotification(
+                                member, notification.getType(), notification.getMessage()));
         then(emitterRepository).should().findById(anyLong());
     }
 


### PR DESCRIPTION
## 이슈 번호 (#182 )

## 요약
IntakeNotifyService 테스트 구현

## 변경 내용
GlobalControllerAdvice에서 핸들링하던 SseConnectionException을 SseControllerAdvice를 생성하여 이동
IntakeNutrients Dto의 사용하지 않는 combine 메서드 삭제