### PR TITLE
SSE 재연결 요청 예외 핸들링 + Security 예외 핸들링

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/advice/common/GlobalControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/common/GlobalControllerAdvice.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
@@ -72,5 +73,17 @@ public class GlobalControllerAdvice {
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
                 .body(ErrorResponse.from(exception.getErrorCode()));
+    }
+
+    @ExceptionHandler(AsyncRequestTimeoutException.class)
+    public ResponseEntity<Void> handleAsyncRequestTimeoutException(
+            HandlerMethod handlerMethod, AsyncRequestTimeoutException exception) {
+
+        LoggingUtils.exceptionLog(
+                AopUtils.extractMethodSignature(handlerMethod),
+                HttpStatus.REQUEST_TIMEOUT,
+                exception);
+
+        return ResponseEntity.status(HttpStatus.REQUEST_TIMEOUT).build();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/global/config/SecurityConfig.java
+++ b/src/main/java/com/konggogi/veganlife/global/config/SecurityConfig.java
@@ -3,7 +3,7 @@ package com.konggogi.veganlife.global.config;
 
 import com.konggogi.veganlife.global.security.filter.JwtAuthenticationFilter;
 import com.konggogi.veganlife.global.security.handler.JwtAuthenticationEntryPoint;
-import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -63,8 +63,9 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(Arrays.asList("*")); // TODO Url 변경
+        config.setAllowedOrigins(List.of("*")); // TODO Url 변경
         config.addAllowedMethod("*");
+        config.setAllowedHeaders(List.of("*"));
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);
         return source;

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     NOT_FOUND_USER_INFO_TOKEN("AUTH_006", "JWT 사용자 정보를 가져올 수 없습니다."),
     NOT_FOUND_REFRESH_TOKEN("AUTH_007", "RefreshToken이 존재하지 않습니다."),
     MISMATCH_REFRESH_TOKEN("AUTH_008", "RefreshToken이 일치하지 않습니다."),
+    NOT_FOUND_AUTHORIZATION_HEADER("AUTH_009", "Authorization 헤더가 존재하지 않습니다."),
 
     // oauth
     UNSUPPORTED_PROVIDER("OAUTH_001", "지원되지 않는 provider입니다."),

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
+    // global
+    INTERNAL_SERVER_ERROR("GLOBAL_999", "Handling 되지 않은 Server Error입니다."),
+
     // validation
     INVALID_INPUT_VALUE("GLOBAL_001", "RequestBody Validation에 실패했습니다."),
 

--- a/src/main/java/com/konggogi/veganlife/global/security/handler/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/konggogi/veganlife/global/security/handler/JwtAuthenticationEntryPoint.java
@@ -27,6 +27,14 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
             AuthenticationException authException)
             throws IOException, ServletException {
         ErrorCode errorCode = (ErrorCode) request.getAttribute(JwtUtils.EXCEPTION_ATTRIBUTE);
+        if (errorCode == null) {
+            log.error(
+                    "[Exception] - JwtAuthenticationEntryPoint.commence - uri: {} - {}",
+                    request.getRequestURI(),
+                    ErrorCode.INTERNAL_SERVER_ERROR);
+            setErrorResponse(response);
+            return;
+        }
         log.error(
                 "[Exception] - JwtAuthenticationEntryPoint.commence - uri: {} - {}",
                 request.getRequestURI(),
@@ -40,6 +48,15 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("utf-8");
         ErrorResponse errorResponse = ErrorResponse.from(errorCode);
+        String result = new ObjectMapper().writeValueAsString(errorResponse);
+        response.getWriter().write(result);
+    }
+
+    private void setErrorResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("utf-8");
+        ErrorResponse errorResponse = ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR);
         String result = new ObjectMapper().writeValueAsString(errorResponse);
         response.getWriter().write(result);
     }

--- a/src/main/java/com/konggogi/veganlife/global/util/AopUtils.java
+++ b/src/main/java/com/konggogi/veganlife/global/util/AopUtils.java
@@ -13,7 +13,7 @@ public class AopUtils {
     }
 
     public static MethodSignature extractMethodSignature(HandlerMethod handlerMethod) {
-        String className = handlerMethod.getClass().getSimpleName();
+        String className = handlerMethod.getBeanType().getSimpleName();
         String methodName = handlerMethod.getMethod().getName();
         return new MethodSignature(className, methodName);
     }


### PR DESCRIPTION
## 이슈 번호 (#184)

## 요약
- SSE 재연결 요청 예외 처리
- `JwtAuthenticationFilter`에서 누락된 Authroization Header가 null일 경우 예외 처리
- 비동기 상황에도 `JwtAuthenticationFilter`가 동작하도록 `shouldNotFilterAsyncDispatch` 메서드 오버라이딩
- 출처 불분명의 예외, Authorization Header가 null일 경우 ErrorCode 정의 -> 구체화가 필요하다면 따로 핸들링

## 문제 상황

SSE 재연결 요청을 처리하는 과정에서 예외가 발생했다.
예외를 핸들링하기 위한 메서드를 구현했지만 해결하기 쉽지 않았다.
- 연관이 없어보이는 여러 예외가 중첩되어 발생했다.

**핸들링 되지 않은 예외**
- `AccessDeniedException` - `AuthroizationFilter`에서 발생
- `NullPointerException` - `JwtAuthenticationEntryPoint`의 `commence` 를 수행하는 도중 ErrorCode가 null이기 때문에 발생

**Security 필터 체인**
```
Security filter chain: [
  DisableEncodeUrlFilter
  WebAsyncManagerIntegrationFilter
  SecurityContextHolderFilter
  HeaderWriterFilter
  CorsFilter
  LogoutFilter
  JwtAuthenticationFilter
  RequestCacheAwareFilter
  SecurityContextHolderAwareRequestFilter
  AnonymousAuthenticationFilter
  SessionManagementFilter
  ExceptionTranslationFilter
  AuthorizationFilter
]
```

## 발생 이유

### 인증 예외 처리 과정
1. `JwtAuthenticationFilter`에서 인증 처리를 시도한다.
	1. Authorization 헤더가 유효하지 않다면 request에 ErrorCode를 저장하고 필터를 진행시킨다.
	2. 계속 필터를 타고 내려간다.
	3. `AuthorizationFilter`에 도착, security context가 존재하지 않으므로 `AccessDeniedException` 발생
	4. 인증되지 않은 사용자는 곧 Anonymous 사용자이기 때문에 `ExceptionTranslationFilter` 필터에서 security context를 생성하고, `JwtAuthenticationEntryPoint`의 `commence`를 호출한다.
	5. `JwtAuthenticationEntryPoint`의 `commence`에서 request 내의 `ErrorCode`를 바탕으로 error response를 commit한다.
	6. 필터 단에서 예외가 발생하였으므로 Dispatcher Servlet으로 넘어가지 않고 필터를 타고 올라간다.
			1. 최종적으로 error를 담은 response를 응답한다.

디버깅 로그를 찍어본 결과, Authorization 헤더는 SSE 재연결 요청에도 제대로 들어가는 것을 확인했다
그렇다면 security context 또한 존재해야 하는데 왜 `JwtAuthenticationEntryPoint`의 `commence`가 실행되는 것일까?

### SSE 재연결 요청일 경우

`JwtAuthenticationFilter`를 거치지 않음을 확인했다.
때문에 Anonymous 사용자로 인식이 되고, 위의 인증 예외 처리 과정을 거친다.

그러나 `JwtAuthenticationEntryPoint`의 `commence`는 `ErrorCode`가 있는 상황에만 정상 작동한다. `JwtAuthenticationFilter`를 거치지 않아 request에 `ErrorCode`가 없기 때문에 `commence`를 실행하는 과정에서 `NullPointerException`이 발생한다.

결국 `/error`로 에러 요청을 보내지만 해당 페이지가 없으므로 무조건 403 에러로 응답하게 된다.


## 해결 방법

### `JwtAuthenticationFilter`를 거치도록

해당 필터를 거치지 않는 이유는 다음과 같다.
- 재연결 요청은 비동기적으로 수행된다. (언제 Timeout 되어 재연결 요청이 올 지 모르므로)
- `JwtAuthenticationFilter`는 `OncePerRequestFilter`를 implement하였다.
- `OncePerRequestFilter`에서 비동기 요청은 기본적으로 무시된다.

```java
// OncePerRequestFilter.java

@Override  
public final void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain)  
       throws ServletException, IOException {  
	...
    if (skipDispatch(httpRequest) || shouldNotFilter(httpRequest)) {  
       // Proceed without invoking this filter...  
       filterChain.doFilter(request, response);  
    }
    ...
```

`OncePerRequestFilter` 클래스의 `doFilter` 메서드에는 `skipDispatch`와 `shouldNotFilter` 메서드가 존재한다.
둘 중 하나라도 충족하게 되면 해당 필터를 무시한다.

```java
private boolean skipDispatch(HttpServletRequest request) {  
    if (isAsyncDispatch(request) && shouldNotFilterAsyncDispatch()) {  
       return true;  
    }  
    if (request.getAttribute(WebUtils.ERROR_REQUEST_URI_ATTRIBUTE) != null && shouldNotFilterErrorDispatch()) {  
       return true;  
    }  
    return false;  
}
```

`skipDispatch` 메서드를 확인해보면 요청이 비동기이고, 비동기 요청은 필터링하지 않겠다는 옵션이 켜져있으면== 해당 필터를 거치지 않는다.


```java
// JwtAuthenticationFilter.java
...
@Override
protected boolean shouldNotFilterAsyncDispatch() {  
    return false;  
}
...
```

비동기 요청 또한 필터링하도록 `protected` 메서드를 오버라이딩 해주었다.


## 그래도 예외는 계속된다...

### AsyncRequestTimeoutException 핸들링

SSE 연결이 timeout되면 클라이언트는 재연결을 서버에게 요청한다.
필터 단은 무사히 통과하지만, Dispatcher Servlet으로 넘어가면서 `AsyncRequestTimeoutException`이 발생한다. (Controller에 넘어가기도 전이다, 어떤 로직으로 발생하는지는 아직 모르겠다.)

Dispatcher Servlet에서 발생하기 때문에 `@ExceptionHandler(AsyncRequestTimeoutException.class)`로 처리해주었다.

**대략적인 예외 핸들링은 처리 완료!**
