### PR TITLE
댓글 등록 API 구현

### DIFF
--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -1,0 +1,49 @@
+= Comment API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== 댓글 등록 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/add-comment/request-headers.adoc[]
+
+==== Body
+
+최상위 댓글 등록
+
+include::{snippets}/add-comment/http-request.adoc[]
+
+대댓글 등록
+
+include::{snippets}/add-sub-comment/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/add-comment/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/add-comment-not-found-member/http-response.adoc[]
+
+include::{snippets}/add-comment-not-found-post/http-response.adoc[]
+
+include::{snippets}/add-comment-not-found-comment/http-response.adoc[]
+
+==== 400 BAD REQUEST
+
+include::{snippets}/add-comment-illegal/http-response.adoc[]
+
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -19,3 +19,5 @@ include::{docdir}/src/docs/asciidoc/meal-data.adoc[]
 include::{docdir}/src/docs/asciidoc/meal-log.adoc[]
 
 include::{docdir}/src/docs/asciidoc/post.adoc[]
+
+include::{docdir}/src/docs/asciidoc/comment.adoc[]

--- a/src/main/java/com/konggogi/veganlife/comment/controller/CommentController.java
+++ b/src/main/java/com/konggogi/veganlife/comment/controller/CommentController.java
@@ -1,0 +1,31 @@
+package com.konggogi.veganlife.comment.controller;
+
+
+import com.konggogi.veganlife.comment.controller.dto.request.CommentAddRequest;
+import com.konggogi.veganlife.comment.controller.dto.response.CommentAddResponse;
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
+import com.konggogi.veganlife.comment.service.CommentService;
+import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/posts")
+public class CommentController {
+    private final CommentService commentService;
+    private final CommentMapper commentMapper;
+
+    @PostMapping("/{postId}/comments")
+    public ResponseEntity<CommentAddResponse> addComment(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @RequestBody @Valid CommentAddRequest commentAddRequest) {
+        Comment comment = commentService.add(userDetails.id(), postId, commentAddRequest);
+        return ResponseEntity.ok(commentMapper.toCommentAddResponse(comment));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/comment/controller/dto/request/CommentAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/comment/controller/dto/request/CommentAddRequest.java
@@ -1,0 +1,7 @@
+package com.konggogi.veganlife.comment.controller.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
+
+public record CommentAddRequest(Long parentId, @NotBlank @Length(max = 100) String content) {}

--- a/src/main/java/com/konggogi/veganlife/comment/controller/dto/response/CommentAddResponse.java
+++ b/src/main/java/com/konggogi/veganlife/comment/controller/dto/response/CommentAddResponse.java
@@ -1,3 +1,6 @@
 package com.konggogi.veganlife.comment.controller.dto.response;
 
-public record CommentAddResponse(Long commentId) {}
+
+import java.time.LocalDateTime;
+
+public record CommentAddResponse(Long commentId, LocalDateTime createdAt) {}

--- a/src/main/java/com/konggogi/veganlife/comment/controller/dto/response/CommentAddResponse.java
+++ b/src/main/java/com/konggogi/veganlife/comment/controller/dto/response/CommentAddResponse.java
@@ -1,0 +1,3 @@
+package com.konggogi.veganlife.comment.controller.dto.response;
+
+public record CommentAddResponse(Long commentId) {}

--- a/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
@@ -1,0 +1,69 @@
+package com.konggogi.veganlife.comment.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.post.domain.Post;
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends TimeStamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    // If comment is null, parent comment
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parentComment;
+
+    @OneToMany(mappedBy = "parentComment", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<Comment> subComments = new ArrayList<>();
+
+    @Builder
+    public Comment(Long id, String content, Member member, Post post, Comment parentComment) {
+        this.id = id;
+        this.content = content;
+        this.member = member;
+        this.post = post;
+        this.parentComment = parentComment;
+    }
+
+    public void setPost(Post post) {
+        this.post = post;
+    }
+
+    public void setParentComment(Comment comment) {
+        this.parentComment = comment;
+    }
+
+    public void addSubComment(Comment comment) {
+        subComments.add(comment);
+        comment.setParentComment(this);
+    }
+
+    public Optional<Comment> getParent() {
+        return Optional.ofNullable(parentComment);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/comment/domain/mapper/CommentMapper.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/mapper/CommentMapper.java
@@ -1,0 +1,18 @@
+package com.konggogi.veganlife.comment.domain.mapper;
+
+
+import com.konggogi.veganlife.comment.controller.dto.request.CommentAddRequest;
+import com.konggogi.veganlife.comment.controller.dto.response.CommentAddResponse;
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.member.domain.Member;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface CommentMapper {
+    @Mapping(target = "id", ignore = true)
+    Comment toEntity(Member member, CommentAddRequest commentAddRequest);
+
+    @Mapping(target = "commentId", source = "comment.id")
+    CommentAddResponse toCommentAddResponse(Comment comment);
+}

--- a/src/main/java/com/konggogi/veganlife/comment/exception/IllegalCommentException.java
+++ b/src/main/java/com/konggogi/veganlife/comment/exception/IllegalCommentException.java
@@ -1,0 +1,15 @@
+package com.konggogi.veganlife.comment.exception;
+
+
+import com.konggogi.veganlife.global.exception.ApiException;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+
+public class IllegalCommentException extends ApiException {
+    public IllegalCommentException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public IllegalCommentException(ErrorCode errorCode, String description) {
+        super(errorCode, description);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/comment/repository/CommentRepository.java
+++ b/src/main/java/com/konggogi/veganlife/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.konggogi.veganlife.comment.repository;
+
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Optional<Comment> findById(Long commentId);
+}

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentQueryService.java
@@ -1,0 +1,23 @@
+package com.konggogi.veganlife.comment.service;
+
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.repository.CommentRepository;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentQueryService {
+    private final CommentRepository commentRepository;
+
+    public Comment search(Long commentId) {
+        return commentRepository
+                .findById(commentId)
+                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_COMMENT));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
@@ -1,0 +1,52 @@
+package com.konggogi.veganlife.comment.service;
+
+
+import com.konggogi.veganlife.comment.controller.dto.request.CommentAddRequest;
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
+import com.konggogi.veganlife.comment.exception.IllegalCommentException;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.service.PostQueryService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CommentService {
+    private final MemberQueryService memberQueryService;
+    private final PostQueryService postQueryService;
+    private final CommentQueryService commentQueryService;
+    private final CommentMapper commentMapper;
+
+    public Comment add(Long memberId, Long postId, CommentAddRequest commentAddRequest) {
+        Member member = memberQueryService.search(memberId);
+        Post post = postQueryService.search(postId);
+        Comment comment = commentMapper.toEntity(member, commentAddRequest);
+
+        getParentCommentId(commentAddRequest)
+                .ifPresent(
+                        parentId -> {
+                            Comment parentComment = commentQueryService.search(parentId);
+                            parentComment
+                                    .getParent()
+                                    .ifPresent(
+                                            parent -> {
+                                                throw new IllegalCommentException(
+                                                        ErrorCode.IS_NOT_PARENT_COMMENT);
+                                            });
+                            parentComment.addSubComment(comment);
+                        });
+        post.addComment(comment);
+        return comment;
+    }
+
+    private Optional<Long> getParentCommentId(CommentAddRequest commentAddRequest) {
+        return Optional.ofNullable(commentAddRequest.parentId());
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
@@ -26,9 +26,7 @@ public class CommentService {
 
     public Comment add(Long memberId, Long postId, CommentAddRequest commentAddRequest) {
         Member member = memberQueryService.search(memberId);
-        Post post = postQueryService.search(postId);
         Comment comment = commentMapper.toEntity(member, commentAddRequest);
-
         getParentCommentId(commentAddRequest)
                 .ifPresent(
                         parentId -> {
@@ -36,6 +34,7 @@ public class CommentService {
                             validateParentComment(parentComment);
                             parentComment.addSubComment(comment);
                         });
+        Post post = postQueryService.search(postId);
         post.addComment(comment);
         return comment;
     }

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
@@ -33,13 +33,7 @@ public class CommentService {
                 .ifPresent(
                         parentId -> {
                             Comment parentComment = commentQueryService.search(parentId);
-                            parentComment
-                                    .getParent()
-                                    .ifPresent(
-                                            parent -> {
-                                                throw new IllegalCommentException(
-                                                        ErrorCode.IS_NOT_PARENT_COMMENT);
-                                            });
+                            validateParentComment(parentComment);
                             parentComment.addSubComment(comment);
                         });
         post.addComment(comment);
@@ -48,5 +42,14 @@ public class CommentService {
 
     private Optional<Long> getParentCommentId(CommentAddRequest commentAddRequest) {
         return Optional.ofNullable(commentAddRequest.parentId());
+    }
+
+    private void validateParentComment(Comment parentComment) {
+        parentComment
+                .getParent()
+                .ifPresent(
+                        parent -> {
+                            throw new IllegalCommentException(ErrorCode.IS_NOT_PARENT_COMMENT);
+                        });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/global/advice/post/PostAdvisor.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/post/PostAdvisor.java
@@ -1,6 +1,7 @@
 package com.konggogi.veganlife.global.advice.post;
 
 
+import com.konggogi.veganlife.comment.exception.IllegalCommentException;
 import com.konggogi.veganlife.global.exception.dto.response.ErrorResponse;
 import com.konggogi.veganlife.global.util.AopUtils;
 import com.konggogi.veganlife.global.util.LoggingUtils;
@@ -12,13 +13,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.HandlerMethod;
 
 @RestControllerAdvice
-public class PostControllerAdvice {
+public class PostAdvisor {
     @ExceptionHandler(IllegalLikeStatusException.class)
-    public ResponseEntity<ErrorResponse> handleDuplicateLikeExceptionException(
+    public ResponseEntity<ErrorResponse> handleIllegalLikeStatusException(
             HandlerMethod handlerMethod, IllegalLikeStatusException exception) {
         LoggingUtils.exceptionLog(
                 AopUtils.extractMethodSignature(handlerMethod), HttpStatus.CONFLICT, exception);
         return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(ErrorResponse.from(exception.getErrorCode()));
+    }
+
+    @ExceptionHandler(IllegalCommentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalCommentException(
+            HandlerMethod handlerMethod, IllegalCommentException exception) {
+        LoggingUtils.exceptionLog(
+                AopUtils.extractMethodSignature(handlerMethod), HttpStatus.BAD_REQUEST, exception);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.from(exception.getErrorCode()));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/global/advice/post/PostControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/post/PostControllerAdvice.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.HandlerMethod;
 
 @RestControllerAdvice
-public class PostAdvisor {
+public class PostControllerAdvice {
     @ExceptionHandler(IllegalLikeStatusException.class)
     public ResponseEntity<ErrorResponse> handleIllegalLikeStatusException(
             HandlerMethod handlerMethod, IllegalLikeStatusException exception) {

--- a/src/main/java/com/konggogi/veganlife/global/config/SecurityConfig.java
+++ b/src/main/java/com/konggogi/veganlife/global/config/SecurityConfig.java
@@ -49,7 +49,6 @@ public class SecurityConfig {
                                                 new AntPathRequestMatcher(
                                                         "/api/v1/members/oauth/*/login"),
                                                 new AntPathRequestMatcher("/actuator/health"),
-                                                new AntPathRequestMatcher("/api/v1/members"),
                                                 new AntPathRequestMatcher("/api/v1/auth/reissue"))
                                         .permitAll()
                                         .anyRequest()

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -41,7 +41,11 @@ public enum ErrorCode {
 
     // sse
     SSE_CONNECTION_ERROR("SSE_001", "SSE 연결이 실패했습니다. 재연결이 필요합니다."),
-    NOT_FOUND_EMITTER("SSE_002", "SseEmitter를 찾을 수 없습니다.");
+    NOT_FOUND_EMITTER("SSE_002", "SseEmitter를 찾을 수 없습니다."),
+
+    // comment
+    NOT_FOUND_COMMENT("COMMENT_001", "댓글을 찾을 수 없습니다."),
+    IS_NOT_PARENT_COMMENT("COMMENT_002", "최상위 댓글에만 댓글을 등록할 수 있습니다.");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -1,6 +1,7 @@
 package com.konggogi.veganlife.post.domain;
 
 
+import com.konggogi.veganlife.comment.domain.Comment;
 import com.konggogi.veganlife.global.domain.TimeStamped;
 import com.konggogi.veganlife.member.domain.Member;
 import jakarta.persistence.*;
@@ -35,6 +36,9 @@ public class Post extends TimeStamped {
     @OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<PostLike> likes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<Comment> comments = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
@@ -60,6 +64,11 @@ public class Post extends TimeStamped {
     public void addPostLike(PostLike postLike) {
         likes.add(postLike);
         postLike.setPostAndMember(this, member);
+    }
+
+    public void addComment(Comment comment) {
+        comments.add(comment);
+        comment.setPost(this);
     }
 
     public void removePostLike(PostLike postLike) {

--- a/src/test/java/com/konggogi/veganlife/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/controller/CommentControllerTest.java
@@ -1,0 +1,184 @@
+package com.konggogi.veganlife.comment.controller;
+
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.konggogi.veganlife.comment.controller.dto.request.CommentAddRequest;
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.exception.IllegalCommentException;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.comment.service.CommentService;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import com.konggogi.veganlife.support.docs.RestDocsTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(CommentController.class)
+class CommentControllerTest extends RestDocsTest {
+    @MockBean CommentService commentService;
+    private final Member member = MemberFixture.DEFAULT_M.getMember();
+    private final Post post = PostFixture.CHALLENGE.getPostAllInfoWithId(1L);
+    private final Comment comment = CommentFixture.DEFAULT.getTopCommentWithId(1L, member, post);
+    private final Comment subComment =
+            CommentFixture.DEFAULT.getSubCommentWithId(2L, member, post, comment);
+
+    @Test
+    @DisplayName("댓글 등록 API")
+    void addTest() throws Exception {
+        // given
+        CommentAddRequest request = new CommentAddRequest(null, comment.getContent());
+        given(commentService.add(anyLong(), anyLong(), any(CommentAddRequest.class)))
+                .willReturn(comment);
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.commentId").value(comment.getId()))
+                .andExpect(jsonPath("$.createdAt").isNotEmpty());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "add-comment",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("postId").description("게시글 번호"))));
+    }
+
+    @Test
+    @DisplayName("댓글 등록 API - 없는 회원 예외 발생")
+    void addNotFoundMemberTest() throws Exception {
+        // given
+        CommentAddRequest request = new CommentAddRequest(null, comment.getContent());
+        given(commentService.add(anyLong(), anyLong(), any(CommentAddRequest.class)))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("add-comment-not-found-member", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 등록 API - 없는 게시글 예외 발생")
+    void addNotFoundPostTest() throws Exception {
+        // given
+        CommentAddRequest request = new CommentAddRequest(null, comment.getContent());
+        given(commentService.add(anyLong(), anyLong(), any(CommentAddRequest.class)))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST));
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print()).andDo(document("add-comment-not-found-post", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 등록 API - 대댓글")
+    void addSubTest() throws Exception {
+        // given
+        CommentAddRequest request = new CommentAddRequest(1L, comment.getContent());
+        given(commentService.add(anyLong(), anyLong(), any(CommentAddRequest.class)))
+                .willReturn(subComment);
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.commentId").value(subComment.getId()))
+                .andExpect(jsonPath("$.createdAt").isNotEmpty());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "add-sub-comment",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("postId").description("게시글 번호"))));
+    }
+
+    @Test
+    @DisplayName("댓글 등록 API - 없는 댓글 예외 발생")
+    void addNotFoundCommentTest() throws Exception {
+        // given
+        CommentAddRequest request = new CommentAddRequest(1L, comment.getContent());
+        given(commentService.add(anyLong(), anyLong(), any(CommentAddRequest.class)))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_COMMENT));
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("add-comment-not-found-comment", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 등록 API - 대댓글에 댓글을 등록하는 경우 예외 발생")
+    void addIllegalCommentTest() throws Exception {
+        // given
+        CommentAddRequest request = new CommentAddRequest(2L, comment.getContent());
+        given(commentService.add(anyLong(), anyLong(), any(CommentAddRequest.class)))
+                .willThrow(new IllegalCommentException(ErrorCode.IS_NOT_PARENT_COMMENT));
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isBadRequest());
+
+        perform.andDo(print()).andDo(document("add-comment-illegal", getDocumentResponse()));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/comment/fixture/CommentFixture.java
+++ b/src/test/java/com/konggogi/veganlife/comment/fixture/CommentFixture.java
@@ -4,6 +4,9 @@ package com.konggogi.veganlife.comment.fixture;
 import com.konggogi.veganlife.comment.domain.Comment;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.post.domain.Post;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import org.springframework.util.ReflectionUtils;
 
 public enum CommentFixture {
     DEFAULT("좋은 생각인 것 같습니다!");
@@ -18,7 +21,9 @@ public enum CommentFixture {
     }
 
     public Comment getTopCommentWithId(Long id, Member member, Post post) {
-        return Comment.builder().id(id).member(member).post(post).content(content).build();
+        Comment comment =
+                Comment.builder().id(id).member(member).post(post).content(content).build();
+        return setCreatedAt(comment);
     }
 
     public Comment getSubComment(Member member, Post post, Comment comment) {
@@ -30,13 +35,22 @@ public enum CommentFixture {
                 .build();
     }
 
-    public Comment getSubCommentWithId(Long id, Member member, Post post, Comment comment) {
-        return Comment.builder()
-                .id(id)
-                .member(member)
-                .post(post)
-                .parentComment(comment)
-                .content(content)
-                .build();
+    public Comment getSubCommentWithId(Long id, Member member, Post post, Comment parentComment) {
+        Comment comment =
+                Comment.builder()
+                        .id(id)
+                        .member(member)
+                        .post(post)
+                        .parentComment(parentComment)
+                        .content(content)
+                        .build();
+        return setCreatedAt(comment);
+    }
+
+    private Comment setCreatedAt(Comment comment) {
+        Field createdAtField = ReflectionUtils.findField(Comment.class, "createdAt");
+        ReflectionUtils.makeAccessible(createdAtField);
+        ReflectionUtils.setField(createdAtField, comment, LocalDateTime.now());
+        return comment;
     }
 }

--- a/src/test/java/com/konggogi/veganlife/comment/fixture/CommentFixture.java
+++ b/src/test/java/com/konggogi/veganlife/comment/fixture/CommentFixture.java
@@ -1,0 +1,42 @@
+package com.konggogi.veganlife.comment.fixture;
+
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.post.domain.Post;
+
+public enum CommentFixture {
+    DEFAULT("좋은 생각인 것 같습니다!");
+    private final String content;
+
+    CommentFixture(String content) {
+        this.content = content;
+    }
+
+    public Comment getTopComment(Member member, Post post) {
+        return Comment.builder().member(member).post(post).content(content).build();
+    }
+
+    public Comment getTopCommentWithId(Long id, Member member, Post post) {
+        return Comment.builder().id(id).member(member).post(post).content(content).build();
+    }
+
+    public Comment getSubComment(Member member, Post post, Comment comment) {
+        return Comment.builder()
+                .member(member)
+                .post(post)
+                .parentComment(comment)
+                .content(content)
+                .build();
+    }
+
+    public Comment getSubCommentWithId(Long id, Member member, Post post, Comment comment) {
+        return Comment.builder()
+                .id(id)
+                .member(member)
+                .post(post)
+                .parentComment(comment)
+                .content(content)
+                .build();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/repository/CommentRepositoryTest.java
@@ -1,0 +1,46 @@
+package com.konggogi.veganlife.comment.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.repository.MemberRepository;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import com.konggogi.veganlife.post.repository.PostRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class CommentRepositoryTest {
+    @Autowired MemberRepository memberRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired CommentRepository commentRepository;
+    private final Member member = MemberFixture.DEFAULT_M.getMember();
+    private final Post post = PostFixture.CHALLENGE.getPost();
+    private final Comment comment = CommentFixture.DEFAULT.getTopComment(member, post);
+
+    @BeforeEach
+    void setup() {
+        memberRepository.save(member);
+        postRepository.save(post);
+        commentRepository.save(comment);
+    }
+
+    @Test
+    @DisplayName("comment Id로 댓글 조회")
+    void findByIdTest() {
+        // given
+        Long commentId = comment.getId();
+        // when
+        Optional<Comment> foundComment = commentRepository.findById(commentId);
+        // then
+        assertThat(foundComment).isPresent();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentQueryServiceTest.java
@@ -48,8 +48,7 @@ class CommentQueryServiceTest {
     @DisplayName("없는 댓글 조회시 예외 발생")
     void searchNotFoundCommentTest() {
         // given
-        given(commentRepository.findById(anyLong()))
-                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_COMMENT));
+        given(commentRepository.findById(anyLong())).willReturn(Optional.empty());
         // when, then
         assertThatThrownBy(() -> commentQueryService.search(comment.getId()))
                 .isInstanceOf(NotFoundEntityException.class)

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentQueryServiceTest.java
@@ -1,0 +1,59 @@
+package com.konggogi.veganlife.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.comment.repository.CommentRepository;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentQueryServiceTest {
+    @Mock CommentRepository commentRepository;
+    @InjectMocks CommentQueryService commentQueryService;
+    private final Member member = MemberFixture.DEFAULT_M.getMember();
+    private final Post post = PostFixture.CHALLENGE.getPost();
+    private final Comment comment = CommentFixture.DEFAULT.getTopCommentWithId(1L, member, post);
+
+    @Test
+    @DisplayName("댓글 조회")
+    void searchTest() {
+        // given
+        given(commentRepository.findById(anyLong())).willReturn(Optional.of(comment));
+        // when
+        Comment foundComment = commentQueryService.search(comment.getId());
+        // then
+        assertThat(foundComment).isEqualTo(comment);
+        then(commentRepository).should().findById(anyLong());
+    }
+
+    @Test
+    @DisplayName("없는 댓글 조회시 예외 발생")
+    void searchNotFoundCommentTest() {
+        // given
+        given(commentRepository.findById(anyLong()))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_COMMENT));
+        // when, then
+        assertThatThrownBy(() -> commentQueryService.search(comment.getId()))
+                .isInstanceOf(NotFoundEntityException.class)
+                .hasMessageContaining(ErrorCode.NOT_FOUND_COMMENT.getDescription());
+        then(commentRepository).should().findById(anyLong());
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentServiceTest.java
@@ -1,0 +1,145 @@
+package com.konggogi.veganlife.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.konggogi.veganlife.comment.controller.dto.request.CommentAddRequest;
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
+import com.konggogi.veganlife.comment.exception.IllegalCommentException;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import com.konggogi.veganlife.post.service.PostQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+    @Mock MemberQueryService memberQueryService;
+    @Mock PostQueryService postQueryService;
+    @Mock CommentQueryService commentQueryService;
+    @Spy CommentMapper commentMapper;
+    @InjectMocks CommentService commentService;
+    private final Member member = MemberFixture.DEFAULT_M.getMember();
+    private final Post post = PostFixture.CHALLENGE.getPostAllInfoWithId(1L);
+    private final Comment comment = CommentFixture.DEFAULT.getTopCommentWithId(1L, member, post);
+    private final Comment subComment =
+            CommentFixture.DEFAULT.getSubCommentWithId(2L, member, post, comment);
+
+    @Test
+    @DisplayName("최상위 댓글 등록")
+    void addTest() {
+        // given
+        CommentAddRequest commentAddRequest = new CommentAddRequest(null, comment.getContent());
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(commentMapper.toEntity(member, commentAddRequest)).willReturn(comment);
+        given(postQueryService.search(anyLong())).willReturn(post);
+        // when
+        Comment savedComment = commentService.add(member.getId(), post.getId(), commentAddRequest);
+        // then
+        assertThat(savedComment).isEqualTo(comment);
+        assertThat(post.getComments()).contains(comment);
+        then(commentQueryService).should(never()).search(anyLong());
+    }
+
+    @Test
+    @DisplayName("대댓글 등록")
+    void addSubTest() {
+        // given
+        CommentAddRequest commentAddRequest = new CommentAddRequest(1L, comment.getContent());
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(commentMapper.toEntity(member, commentAddRequest)).willReturn(subComment);
+        given(commentQueryService.search(anyLong())).willReturn(comment);
+        given(postQueryService.search(anyLong())).willReturn(post);
+        // when
+        Comment savedComment = commentService.add(member.getId(), post.getId(), commentAddRequest);
+        // then
+        assertThat(savedComment).isEqualTo(subComment);
+        assertThat(post.getComments()).contains(subComment);
+        assertThat(comment.getSubComments()).contains(subComment);
+        then(commentQueryService).should().search(anyLong());
+    }
+
+    @Test
+    @DisplayName("댓글 등록 시 없는 회원이면 예외 발생")
+    void addNotFoundMemberTest() {
+        // given
+        CommentAddRequest commentAddRequest = new CommentAddRequest(1L, comment.getContent());
+        given(memberQueryService.search(anyLong()))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
+        // when, then
+        assertThatThrownBy(
+                        () -> commentService.add(member.getId(), post.getId(), commentAddRequest))
+                .isInstanceOf(NotFoundEntityException.class)
+                .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
+        then(commentQueryService).should(never()).search(anyLong());
+        then(postQueryService).should(never()).search(anyLong());
+    }
+
+    @Test
+    @DisplayName("댓글 등록 시 없는 게시글이면 예외 발생")
+    void addNotFoundPostTest() {
+        // given
+        CommentAddRequest commentAddRequest = new CommentAddRequest(null, comment.getContent());
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(commentMapper.toEntity(member, commentAddRequest)).willReturn(subComment);
+        given(postQueryService.search(anyLong()))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST));
+        // when, then
+        assertThatThrownBy(
+                        () -> commentService.add(member.getId(), post.getId(), commentAddRequest))
+                .isInstanceOf(NotFoundEntityException.class)
+                .hasMessageContaining(ErrorCode.NOT_FOUND_POST.getDescription());
+        then(commentQueryService).should(never()).search(anyLong());
+        then(postQueryService).should().search(anyLong());
+    }
+
+    @Test
+    @DisplayName("대댓글 등록 시 최상위 댓글이 없으면 예외 발생")
+    void addIllegalCommentTest() {
+        // given
+        CommentAddRequest commentAddRequest = new CommentAddRequest(1L, comment.getContent());
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(commentMapper.toEntity(member, commentAddRequest)).willReturn(subComment);
+        given(commentQueryService.search(anyLong()))
+                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_COMMENT));
+        // when, then
+        assertThatThrownBy(
+                        () -> commentService.add(member.getId(), post.getId(), commentAddRequest))
+                .isInstanceOf(NotFoundEntityException.class)
+                .hasMessageContaining(ErrorCode.NOT_FOUND_COMMENT.getDescription());
+        then(postQueryService).should(never()).search(anyLong());
+    }
+
+    @Test
+    @DisplayName("대댓글에 댓글을 등록하면 예외 발생")
+    void addNotFoundParentCommentTest() {
+        // given
+        CommentAddRequest commentAddRequest = new CommentAddRequest(2L, comment.getContent());
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(commentMapper.toEntity(member, commentAddRequest)).willReturn(subComment);
+        given(commentQueryService.search(anyLong())).willReturn(subComment);
+        // when, then
+        assertThatThrownBy(
+                        () -> commentService.add(member.getId(), post.getId(), commentAddRequest))
+                .isInstanceOf(IllegalCommentException.class)
+                .hasMessageContaining(ErrorCode.IS_NOT_PARENT_COMMENT.getDescription());
+        then(commentQueryService).should().search(anyLong());
+        then(postQueryService).should(never()).search(anyLong());
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/config/MapStructConfig.java
+++ b/src/test/java/com/konggogi/veganlife/config/MapStructConfig.java
@@ -1,6 +1,8 @@
 package com.konggogi.veganlife.config;
 
 
+import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
+import com.konggogi.veganlife.comment.domain.mapper.CommentMapperImpl;
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapperImpl;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
@@ -70,5 +72,10 @@ public class MapStructConfig {
     @Bean
     public NotificationMapper notificationMapper() {
         return new NotificationMapperImpl();
+    }
+
+    @Bean
+    public CommentMapper commentMapper() {
+        return new CommentMapperImpl();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/fixture/MemberFixture.java
+++ b/src/test/java/com/konggogi/veganlife/member/fixture/MemberFixture.java
@@ -8,7 +8,7 @@ import com.konggogi.veganlife.member.domain.VegetarianType;
 public enum MemberFixture {
     DEFAULT_F(
             "테스트유저",
-            "profileImageUrl",
+            "image1.jpg",
             2000,
             Gender.F,
             VegetarianType.VEGAN,
@@ -19,17 +19,7 @@ public enum MemberFixture {
             40,
             1821),
     DEFAULT_M(
-            "테스트유저",
-            "profileImageUrl",
-            1997,
-            Gender.M,
-            VegetarianType.OVO,
-            185,
-            85,
-            340,
-            204,
-            60,
-            2721);
+            "테스트유저", "image1.jpg", 1997, Gender.M, VegetarianType.OVO, 185, 85, 340, 204, 60, 2721);
     private Long id = 1L;
     private final String nickname;
     private final String profileImageUrl;


### PR DESCRIPTION
## 이슈 번호 (#186 )

## 요약
댓글 등록 API 구현
댓글 등록 시, 요청 dto의 parent가 null (최상위 댓글)이면 최상위 댓글로 저장
댓글 등록 시, 요청 dto의 parent가 null이 아니면 대댓글로 저장
댓글 등록 시, 요청 dto의 parent가 null이 아니고, 최상위 댓글도 아니면 대댓글이므로 등록 불가 `IllegalCommentException` 예외 처리 (대댓글에는 등록 불가능)
`IllegalCommentException` 예외 핸들링
댓글 등록 API 및 기능 테스트, CommentRepository 테스트

## 변경 내용
`SeurityFilterChain`에서 `/api/v1/members` 경로 허용 삭제
