### PR TITLE
like 패키지 생성에 따른 로직 분리

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -21,3 +21,5 @@ include::{docdir}/src/docs/asciidoc/meal-log.adoc[]
 include::{docdir}/src/docs/asciidoc/post.adoc[]
 
 include::{docdir}/src/docs/asciidoc/comment.adoc[]
+
+include::{docdir}/src/docs/asciidoc/like.adoc[]

--- a/src/docs/asciidoc/like.adoc
+++ b/src/docs/asciidoc/like.adoc
@@ -1,0 +1,75 @@
+= Like API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== 피드 좋아요 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/add-post-like/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/add-post-like/path-parameters.adoc[]
+
+==== Body
+
+include::{snippets}/add-post-like/http-request.adoc[]
+
+=== Response
+
+==== 201 CREATED
+
+include::{snippets}/add-post-like/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/add-post-like-not-found-member/http-response.adoc[]
+
+include::{snippets}/add-post-like-not-found-post/http-response.adoc[]
+
+==== 409 CONFLICT
+
+include::{snippets}/add-post-like-already/http-response.adoc[]
+
+== 피드 좋아요 취소 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/remove-post-like/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/remove-post-like/path-parameters.adoc[]
+
+==== Body
+
+include::{snippets}/remove-post-like/http-request.adoc[]
+
+=== Response
+
+==== 204 NO CONTENT
+
+include::{snippets}/remove-post-like/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/remove-post-like-not-found-member/http-response.adoc[]
+
+include::{snippets}/remove-post-like-not-found-post/http-response.adoc[]
+
+==== 409 CONFLICT
+
+include::{snippets}/remove-post-like-already/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/comment/domain/mapper/CommentMapper.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/mapper/CommentMapper.java
@@ -11,6 +11,8 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface CommentMapper {
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "post", ignore = true)
+    @Mapping(target = "parentComment", ignore = true)
     Comment toEntity(Member member, CommentAddRequest commentAddRequest);
 
     @Mapping(target = "commentId", source = "comment.id")

--- a/src/main/java/com/konggogi/veganlife/global/advice/post/PostControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/post/PostControllerAdvice.java
@@ -5,7 +5,7 @@ import com.konggogi.veganlife.comment.exception.IllegalCommentException;
 import com.konggogi.veganlife.global.exception.dto.response.ErrorResponse;
 import com.konggogi.veganlife.global.util.AopUtils;
 import com.konggogi.veganlife.global.util.LoggingUtils;
-import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/src/main/java/com/konggogi/veganlife/like/controller/LikeController.java
+++ b/src/main/java/com/konggogi/veganlife/like/controller/LikeController.java
@@ -1,0 +1,31 @@
+package com.konggogi.veganlife.like.controller;
+
+
+import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import com.konggogi.veganlife.like.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/posts")
+public class LikeController {
+    private final LikeService likeService;
+
+    @PostMapping("/{postId}/likes")
+    public ResponseEntity<Void> addPostLike(
+            @PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeService.addPostLike(userDetails.id(), postId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{postId}/likes")
+    public ResponseEntity<Void> removePostLike(
+            @PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeService.removePostLike(userDetails.id(), postId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/like/domain/PostLike.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/PostLike.java
@@ -1,7 +1,8 @@
-package com.konggogi.veganlife.post.domain;
+package com.konggogi.veganlife.like.domain;
 
 
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
@@ -1,14 +1,14 @@
-package com.konggogi.veganlife.post.domain.mapper;
+package com.konggogi.veganlife.like.domain.mapper;
 
 
+import com.konggogi.veganlife.like.domain.PostLike;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.domain.PostLike;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
-public interface PostLikeMapper {
+public interface LikeMapper {
     @Mapping(target = "id", ignore = true)
     PostLike toEntity(Member member, Post post);
 }

--- a/src/main/java/com/konggogi/veganlife/like/exception/IllegalLikeStatusException.java
+++ b/src/main/java/com/konggogi/veganlife/like/exception/IllegalLikeStatusException.java
@@ -1,4 +1,4 @@
-package com.konggogi.veganlife.post.exception;
+package com.konggogi.veganlife.like.exception;
 
 
 import com.konggogi.veganlife.global.exception.ApiException;

--- a/src/main/java/com/konggogi/veganlife/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/like/repository/PostLikeRepository.java
@@ -1,7 +1,7 @@
-package com.konggogi.veganlife.post.repository;
+package com.konggogi.veganlife.like.repository;
 
 
-import com.konggogi.veganlife.post.domain.PostLike;
+import com.konggogi.veganlife.like.domain.PostLike;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
@@ -1,11 +1,12 @@
-package com.konggogi.veganlife.post.service;
+package com.konggogi.veganlife.like.service;
 
 
+import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.domain.mapper.LikeMapper;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.domain.PostLike;
-import com.konggogi.veganlife.post.domain.mapper.PostLikeMapper;
+import com.konggogi.veganlife.post.service.PostQueryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeService {
     private final MemberQueryService memberQueryService;
     private final PostQueryService postQueryService;
-    private final PostLikeMapper postLikeMapper;
+    private final LikeMapper postLikeMapper;
 
     public void addPostLike(Long memberId, Long postId) {
         Member member = memberQueryService.search(memberId);

--- a/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
@@ -2,7 +2,6 @@ package com.konggogi.veganlife.post.controller;
 
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
-import com.konggogi.veganlife.like.service.LikeService;
 import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
 import com.konggogi.veganlife.post.controller.dto.response.PostAddResponse;
 import com.konggogi.veganlife.post.domain.Post;
@@ -10,7 +9,6 @@ import com.konggogi.veganlife.post.domain.mapper.PostMapper;
 import com.konggogi.veganlife.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("api/v1/posts")
 public class PostController {
     private final PostService postService;
-    private final LikeService likeService;
     private final PostMapper postMapper;
 
     @PostMapping
@@ -29,19 +26,5 @@ public class PostController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         Post post = postService.add(userDetails.id(), postAddRequest);
         return ResponseEntity.ok(postMapper.toPostAddResponse(post));
-    }
-
-    @PostMapping("/{postId}/likes")
-    public ResponseEntity<Void> addPostLike(
-            @PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        likeService.addPostLike(userDetails.id(), postId);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
-    }
-
-    @DeleteMapping("/{postId}/likes")
-    public ResponseEntity<Void> removePostLike(
-            @PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        likeService.removePostLike(userDetails.id(), postId);
-        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
@@ -2,11 +2,11 @@ package com.konggogi.veganlife.post.controller;
 
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import com.konggogi.veganlife.like.service.LikeService;
 import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
 import com.konggogi.veganlife.post.controller.dto.response.PostAddResponse;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.domain.mapper.PostMapper;
-import com.konggogi.veganlife.post.service.LikeService;
 import com.konggogi.veganlife.post.service.PostService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -3,6 +3,7 @@ package com.konggogi.veganlife.post.domain;
 
 import com.konggogi.veganlife.comment.domain.Comment;
 import com.konggogi.veganlife.global.domain.TimeStamped;
+import com.konggogi.veganlife.like.domain.PostLike;
 import com.konggogi.veganlife.member.domain.Member;
 import jakarta.persistence.*;
 import java.util.ArrayList;

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -3,10 +3,10 @@ package com.konggogi.veganlife.post.service;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.domain.PostLike;
-import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
-import com.konggogi.veganlife.post.repository.PostLikeRepository;
 import com.konggogi.veganlife.post.repository.PostRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/konggogi/veganlife/config/MapStructConfig.java
+++ b/src/test/java/com/konggogi/veganlife/config/MapStructConfig.java
@@ -3,6 +3,8 @@ package com.konggogi.veganlife.config;
 
 import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
 import com.konggogi.veganlife.comment.domain.mapper.CommentMapperImpl;
+import com.konggogi.veganlife.like.domain.mapper.LikeMapper;
+import com.konggogi.veganlife.like.domain.mapper.LikeMapperImpl;
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapperImpl;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
@@ -60,8 +62,8 @@ public class MapStructConfig {
     }
 
     @Bean
-    public PostLikeMapper postLikeMapper() {
-        return new PostLikeMapperImpl();
+    public LikeMapper likeMapper() {
+        return new LikeMapperImpl();
     }
 
     @Bean

--- a/src/test/java/com/konggogi/veganlife/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/controller/LikeControllerTest.java
@@ -1,0 +1,181 @@
+package com.konggogi.veganlife.like.controller;
+
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.like.service.LikeService;
+import com.konggogi.veganlife.support.docs.RestDocsTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(LikeController.class)
+class LikeControllerTest extends RestDocsTest {
+    @MockBean LikeService likeService;
+
+    @Test
+    @DisplayName("게시글 좋아요 API")
+    void addPostLikeTest() throws Exception {
+        // given
+        doNothing().when(likeService).addPostLike(anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isCreated());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "add-post-like",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("postId").description("게시글 번호"))));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 API - 없는 회원 예외 발생")
+    void addPostLikeNotFoundMemberTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
+                .when(likeService)
+                .addPostLike(anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("add-post-like-not-found-member", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 API - 없는 게시글 예외 발생")
+    void addPostLikeNotFoundPostTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST))
+                .when(likeService)
+                .addPostLike(anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("add-post-like-not-found-post", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 API - 이미 좋아요한 경우 예외 발생")
+    void addPostLikeAlreadyTest() throws Exception {
+        // given
+        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED))
+                .when(likeService)
+                .addPostLike(anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isConflict());
+
+        perform.andDo(print()).andDo(document("add-post-like-already", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 취소 API")
+    void removePostLikeTest() throws Exception {
+        // given
+        doNothing().when(likeService).removePostLike(anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNoContent());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "remove-post-like",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("postId").description("게시글 번호"))));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 취소 API - 없는 회원 예외 발생")
+    void removePostLikeNotFoundMemberTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
+                .when(likeService)
+                .removePostLike(anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("remove-post-like-not-found-member", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 취소 API - 없는 게시글 예외 발생")
+    void removePostLikeNotFoundPostTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST))
+                .when(likeService)
+                .removePostLike(anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("remove-post-like-not-found-post", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 취소 API - 좋아요 되어 있지 않은 경우 예외 발생")
+    void removePostLikeAlreadyTest() throws Exception {
+        // given
+        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_UNLIKED))
+                .when(likeService)
+                .removePostLike(anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isConflict());
+
+        perform.andDo(print()).andDo(document("remove-post-like-already", getDocumentResponse()));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/like/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/repository/PostLikeRepositoryTest.java
@@ -1,14 +1,14 @@
-package com.konggogi.veganlife.post.repository;
+package com.konggogi.veganlife.like.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.konggogi.veganlife.like.domain.PostLike;
-import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.fixture.PostFixture;
+import com.konggogi.veganlife.post.repository.PostRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +35,7 @@ class PostLikeRepositoryTest {
     }
 
     @Test
-    @DisplayName("회원 번호와 게시글 번호로 게시글 찾기")
+    @DisplayName("회원 번호와 게시글 번호로 좋아요 찾기")
     void findByMemberIdAndIdTest() {
         // when
         Optional<PostLike> foundPostLike =

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
@@ -1,4 +1,4 @@
-package com.konggogi.veganlife.post.service;
+package com.konggogi.veganlife.like.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,12 +12,12 @@ import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.like.domain.PostLike;
 import com.konggogi.veganlife.like.domain.mapper.LikeMapper;
 import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
-import com.konggogi.veganlife.like.service.LikeService;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.fixture.PostFixture;
+import com.konggogi.veganlife.post.service.PostQueryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -261,7 +261,7 @@ class MemberControllerTest extends RestDocsTest {
     void getMemberDailyNutrientsTest() throws Exception {
         // given
         Member member = MemberFixture.DEFAULT_F.getMember();
-        given(memberQueryService.search(member.getId())).willReturn(member);
+        given(memberQueryService.search(anyLong())).willReturn(member);
         // when
         ResultActions perform =
                 mockMvc.perform(get("/api/v1/members/nutrients").headers(authorizationHeader()));

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -19,12 +19,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.like.service.LikeService;
 import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
 import com.konggogi.veganlife.post.fixture.PostFixture;
 import com.konggogi.veganlife.post.fixture.PostImageFixture;
-import com.konggogi.veganlife.post.service.LikeService;
 import com.konggogi.veganlife.post.service.PostService;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
 import java.util.List;

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -5,22 +5,15 @@ import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRe
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
-import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
-import com.konggogi.veganlife.like.service.LikeService;
 import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.fixture.PostFixture;
@@ -38,7 +31,6 @@ import org.springframework.test.web.servlet.ResultActions;
 @WebMvcTest(PostController.class)
 class PostControllerTest extends RestDocsTest {
     @MockBean PostService postService;
-    @MockBean LikeService likeService;
 
     @Test
     @DisplayName("게시글 등록 API")
@@ -93,155 +85,5 @@ class PostControllerTest extends RestDocsTest {
         perform.andExpect(status().isNotFound());
 
         perform.andDo(print()).andDo(document("add-post-not-found", getDocumentResponse()));
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 API")
-    void addPostLikeTest() throws Exception {
-        // given
-        doNothing().when(likeService).addPostLike(anyLong(), anyLong());
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        post("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
-        // then
-        perform.andExpect(status().isCreated());
-
-        perform.andDo(print())
-                .andDo(
-                        document(
-                                "add-post-like",
-                                getDocumentRequest(),
-                                getDocumentResponse(),
-                                requestHeaders(authorizationDesc()),
-                                pathParameters(parameterWithName("postId").description("게시글 번호"))));
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 API - 없는 회원 예외 발생")
-    void addPostLikeNotFoundMemberTest() throws Exception {
-        // given
-        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
-                .when(likeService)
-                .addPostLike(anyLong(), anyLong());
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        post("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
-        // then
-        perform.andExpect(status().isNotFound());
-
-        perform.andDo(print())
-                .andDo(document("add-post-like-not-found-member", getDocumentResponse()));
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 API - 없는 게시글 예외 발생")
-    void addPostLikeNotFoundPostTest() throws Exception {
-        // given
-        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST))
-                .when(likeService)
-                .addPostLike(anyLong(), anyLong());
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        post("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
-        // then
-        perform.andExpect(status().isNotFound());
-
-        perform.andDo(print())
-                .andDo(document("add-post-like-not-found-post", getDocumentResponse()));
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 API - 이미 좋아요한 경우 예외 발생")
-    void addPostLikeAlreadyTest() throws Exception {
-        // given
-        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED))
-                .when(likeService)
-                .addPostLike(anyLong(), anyLong());
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        post("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
-        // then
-        perform.andExpect(status().isConflict());
-
-        perform.andDo(print()).andDo(document("add-post-like-already", getDocumentResponse()));
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 취소 API")
-    void removePostLikeTest() throws Exception {
-        // given
-        doNothing().when(likeService).removePostLike(anyLong(), anyLong());
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        delete("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
-        // then
-        perform.andExpect(status().isNoContent());
-
-        perform.andDo(print())
-                .andDo(
-                        document(
-                                "remove-post-like",
-                                getDocumentRequest(),
-                                getDocumentResponse(),
-                                requestHeaders(authorizationDesc()),
-                                pathParameters(parameterWithName("postId").description("게시글 번호"))));
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 취소 API - 없는 회원 예외 발생")
-    void removePostLikeNotFoundMemberTest() throws Exception {
-        // given
-        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
-                .when(likeService)
-                .removePostLike(anyLong(), anyLong());
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        delete("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
-        // then
-        perform.andExpect(status().isNotFound());
-
-        perform.andDo(print())
-                .andDo(document("remove-post-like-not-found-member", getDocumentResponse()));
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 취소 API - 없는 게시글 예외 발생")
-    void removePostLikeNotFoundPostTest() throws Exception {
-        // given
-        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST))
-                .when(likeService)
-                .removePostLike(anyLong(), anyLong());
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        delete("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
-        // then
-        perform.andExpect(status().isNotFound());
-
-        perform.andDo(print())
-                .andDo(document("remove-post-like-not-found-post", getDocumentResponse()));
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 취소 API - 좋아요 되어 있지 않은 경우 예외 발생")
-    void removePostLikeAlreadyTest() throws Exception {
-        // given
-        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_UNLIKED))
-                .when(likeService)
-                .removePostLike(anyLong(), anyLong());
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        delete("/api/v1/posts/{postId}/likes", 1L).headers(authorizationHeader()));
-        // then
-        perform.andExpect(status().isConflict());
-
-        perform.andDo(print()).andDo(document("remove-post-like-already", getDocumentResponse()));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/post/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/repository/PostLikeRepositoryTest.java
@@ -2,11 +2,12 @@ package com.konggogi.veganlife.post.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.domain.PostLike;
 import com.konggogi.veganlife.post.fixture.PostFixture;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/com/konggogi/veganlife/post/service/LikeServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/LikeServiceTest.java
@@ -9,13 +9,14 @@ import static org.mockito.Mockito.*;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.domain.mapper.LikeMapper;
+import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.like.service.LikeService;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.domain.PostLike;
-import com.konggogi.veganlife.post.domain.mapper.PostLikeMapper;
-import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
 import com.konggogi.veganlife.post.fixture.PostFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class LikeServiceTest {
     @Mock MemberQueryService memberQueryService;
     @Mock PostQueryService postQueryService;
-    @Spy PostLikeMapper postLikeMapper;
+    @Spy LikeMapper postLikeMapper;
     @InjectMocks LikeService likeService;
 
     private final Member member = MemberFixture.DEFAULT_M.getMember();

--- a/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
@@ -8,13 +8,13 @@ import static org.mockito.BDDMockito.then;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.domain.PostLike;
-import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
 import com.konggogi.veganlife.post.fixture.PostFixture;
-import com.konggogi.veganlife.post.repository.PostLikeRepository;
 import com.konggogi.veganlife.post.repository.PostRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## 이슈 번호 (#189 )

## 요약
like 패키지 생성에 따른 로직 분리

## 변경 내용
게시글 좋아요 뿐만 아니라, 댓글 좋아요 기능도 존재하기 때문에 like 패키지를 생성하여 한 패키지에서 관리
PostController의 좋아요 관련 API를 LikeController로 이동
좋아요 관련 repository, service 이동

