### PR TITLE
댓글 좋아요/취소 API 구현

### DIFF
--- a/src/docs/asciidoc/comment.adoc
+++ b/src/docs/asciidoc/comment.adoc
@@ -18,6 +18,10 @@ endif::[]
 
 include::{snippets}/add-comment/request-headers.adoc[]
 
+==== Path Variable
+
+include::{snippets}/add-comment/path-parameters.adoc[]
+
 ==== Body
 
 최상위 댓글 등록

--- a/src/docs/asciidoc/like.adoc
+++ b/src/docs/asciidoc/like.adoc
@@ -73,3 +73,71 @@ include::{snippets}/remove-post-like-not-found-post/http-response.adoc[]
 ==== 409 CONFLICT
 
 include::{snippets}/remove-post-like-already/http-response.adoc[]
+
+== 댓글 좋아요 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/add-comment-like/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/add-comment-like/path-parameters.adoc[]
+
+==== Body
+
+include::{snippets}/add-comment-like/http-request.adoc[]
+
+=== Response
+
+==== 201 CREATED
+
+include::{snippets}/add-comment-like/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/add-comment-like-not-found-member/http-response.adoc[]
+
+include::{snippets}/add-comment-like-not-found-post/http-response.adoc[]
+
+include::{snippets}/add-comment-like-not-found-comment/http-response.adoc[]
+
+==== 409 CONFLICT
+
+include::{snippets}/add-comment-like-already/http-response.adoc[]
+
+== 댓글 좋아요 취소 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/remove-comment-like/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/remove-comment-like/path-parameters.adoc[]
+
+==== Body
+
+include::{snippets}/remove-comment-like/http-request.adoc[]
+
+=== Response
+
+==== 204 NO CONTENT
+
+include::{snippets}/remove-comment-like/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/remove-comment-like-not-found-member/http-response.adoc[]
+
+include::{snippets}/remove-comment-like-not-found-post/http-response.adoc[]
+
+include::{snippets}/remove-comment-like-not-found-comment/http-response.adoc[]
+
+==== 409 CONFLICT
+
+include::{snippets}/remove-comment-like-already/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.comment.domain;
 
 
 import com.konggogi.veganlife.global.domain.TimeStamped;
+import com.konggogi.veganlife.like.domain.CommentLike;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.post.domain.Post;
 import jakarta.persistence.*;
@@ -33,13 +34,16 @@ public class Comment extends TimeStamped {
     @JoinColumn(name = "post_id")
     private Post post;
 
-    // If comment is null, parent comment
+    // If parentComment is null, parent comment
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_id")
     private Comment parentComment;
 
     @OneToMany(mappedBy = "parentComment", orphanRemoval = true, cascade = CascadeType.ALL)
     private List<Comment> subComments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "comment", orphanRemoval = true, cascade = CascadeType.ALL)
+    private List<CommentLike> likes = new ArrayList<>();
 
     @Builder
     public Comment(Long id, String content, Member member, Post post, Comment parentComment) {

--- a/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
@@ -70,4 +70,9 @@ public class Comment extends TimeStamped {
     public Optional<Comment> getParent() {
         return Optional.ofNullable(parentComment);
     }
+
+    public void addCommentLike(CommentLike commentLike) {
+        likes.add(commentLike);
+        commentLike.setComment(this);
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
@@ -75,4 +75,8 @@ public class Comment extends TimeStamped {
         likes.add(commentLike);
         commentLike.setComment(this);
     }
+
+    public void removeCommentLike(CommentLike commentLike) {
+        likes.remove(commentLike);
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -49,7 +49,11 @@ public enum ErrorCode {
 
     // comment
     NOT_FOUND_COMMENT("COMMENT_001", "댓글을 찾을 수 없습니다."),
-    IS_NOT_PARENT_COMMENT("COMMENT_002", "최상위 댓글에만 댓글을 등록할 수 있습니다.");
+    IS_NOT_PARENT_COMMENT("COMMENT_002", "최상위 댓글에만 댓글을 등록할 수 있습니다."),
+
+    // comment-like
+    ALREADY_COMMENT_LIKED("COMMENT_LIKE_001", "좋아요가 되어 있는 댓글입니다."),
+    ALREADY_COMMENT_UNLIKED("COMMENT_LIKE_002", "좋아요가 되어 있지 않은 댓글입니다.");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -40,8 +40,8 @@ public enum ErrorCode {
     NOT_FOUND_POST("POST_001", "게시글을 찾을 수 없습니다."),
 
     // post-like
-    ALREADY_LIKED("POST_LIKE_001", "좋아요가 되어 있는 게시글입니다."),
-    ALREADY_UNLIKED("POST_LIKE_002", "좋아요가 되어 있지 않은 게시글입니다."),
+    ALREADY_POST_LIKED("POST_LIKE_001", "좋아요가 되어 있는 게시글입니다."),
+    ALREADY_POST_UNLIKED("POST_LIKE_002", "좋아요가 되어 있지 않은 게시글입니다."),
 
     // sse
     SSE_CONNECTION_ERROR("SSE_001", "SSE 연결이 실패했습니다. 재연결이 필요합니다."),

--- a/src/main/java/com/konggogi/veganlife/like/controller/LikeController.java
+++ b/src/main/java/com/konggogi/veganlife/like/controller/LikeController.java
@@ -37,4 +37,13 @@ public class LikeController {
         likeService.addCommentLike(userDetails.id(), postId, commentId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @DeleteMapping("/{postId}/comments/{commentId}/likes")
+    public ResponseEntity<Void> removeCommentLike(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeService.removeCommentLike(userDetails.id(), postId, commentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/like/controller/LikeController.java
+++ b/src/main/java/com/konggogi/veganlife/like/controller/LikeController.java
@@ -28,4 +28,13 @@ public class LikeController {
         likeService.removePostLike(userDetails.id(), postId);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/{postId}/comments/{commentId}/likes")
+    public ResponseEntity<Void> addCommentLike(
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        likeService.addCommentLike(userDetails.id(), postId, commentId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/like/domain/CommentLike.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/CommentLike.java
@@ -38,4 +38,8 @@ public class CommentLike {
         this.post = post;
         this.comment = comment;
     }
+
+    public void setComment(Comment comment) {
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/like/domain/CommentLike.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/CommentLike.java
@@ -1,0 +1,41 @@
+package com.konggogi.veganlife.like.domain;
+
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.post.domain.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Builder
+    public CommentLike(Long id, Member member, Post post, Comment comment) {
+        this.id = id;
+        this.member = member;
+        this.post = post;
+        this.comment = comment;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/like/domain/PostLike.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/PostLike.java
@@ -33,8 +33,7 @@ public class PostLike {
         this.member = member;
     }
 
-    public void setPostAndMember(Post post, Member member) {
+    public void setPost(Post post) {
         this.post = post;
-        this.member = member;
     }
 }

--- a/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
@@ -12,7 +12,7 @@ import org.mapstruct.Mapping;
 public interface LikeMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "member", source = "member")
-    PostLike toPostLike(Member member, Post post);
+    PostLike toPostLike(Member member);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "member", source = "member")

--- a/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
@@ -11,9 +11,11 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface LikeMapper {
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "post", ignore = true)
     PostLike toPostLike(Member member);
 
     @Mapping(target = "id", ignore = true)
+    @Mapping(target = "comment", ignore = true)
     @Mapping(target = "member", source = "member")
     CommentLike toCommentLike(Member member, Post post);
 }

--- a/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
@@ -11,7 +11,6 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface LikeMapper {
     @Mapping(target = "id", ignore = true)
-    @Mapping(target = "member", source = "member")
     PostLike toPostLike(Member member);
 
     @Mapping(target = "id", ignore = true)

--- a/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/like/domain/mapper/LikeMapper.java
@@ -1,6 +1,7 @@
 package com.konggogi.veganlife.like.domain.mapper;
 
 
+import com.konggogi.veganlife.like.domain.CommentLike;
 import com.konggogi.veganlife.like.domain.PostLike;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.post.domain.Post;
@@ -10,5 +11,10 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface LikeMapper {
     @Mapping(target = "id", ignore = true)
-    PostLike toEntity(Member member, Post post);
+    @Mapping(target = "member", source = "member")
+    PostLike toPostLike(Member member, Post post);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "member", source = "member")
+    CommentLike toCommentLike(Member member, Post post);
 }

--- a/src/main/java/com/konggogi/veganlife/like/repository/CommentLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/like/repository/CommentLikeRepository.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
-    Optional<CommentLike> findByMemberIdAndId(Long memberId, Long commentId);
+    Optional<CommentLike> findByMemberIdAndCommentId(Long memberId, Long commentId);
 }

--- a/src/main/java/com/konggogi/veganlife/like/repository/CommentLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/like/repository/CommentLikeRepository.java
@@ -1,0 +1,10 @@
+package com.konggogi.veganlife.like.repository;
+
+
+import com.konggogi.veganlife.like.domain.CommentLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+    Optional<CommentLike> findByMemberIdAndId(Long memberId, Long commentId);
+}

--- a/src/main/java/com/konggogi/veganlife/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/like/repository/PostLikeRepository.java
@@ -6,5 +6,5 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
-    Optional<PostLike> findByMemberIdAndId(Long memberId, Long postId);
+    Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
 }

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeQueryService.java
@@ -1,0 +1,20 @@
+package com.konggogi.veganlife.like.service;
+
+
+import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.repository.PostLikeRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikeQueryService {
+    private final PostLikeRepository postLikeRepository;
+
+    public Optional<PostLike> searchPostLike(Long memberId, Long postId) {
+        return postLikeRepository.findByMemberIdAndId(memberId, postId);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeQueryService.java
@@ -18,10 +18,10 @@ public class LikeQueryService {
     private final CommentLikeRepository commentLikeRepository;
 
     public Optional<PostLike> searchPostLike(Long memberId, Long postId) {
-        return postLikeRepository.findByMemberIdAndId(memberId, postId);
+        return postLikeRepository.findByMemberIdAndPostId(memberId, postId);
     }
 
     public Optional<CommentLike> searchCommentLike(Long memberId, Long commentId) {
-        return commentLikeRepository.findByMemberIdAndId(memberId, commentId);
+        return commentLikeRepository.findByMemberIdAndCommentId(memberId, commentId);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeQueryService.java
@@ -1,7 +1,9 @@
 package com.konggogi.veganlife.like.service;
 
 
+import com.konggogi.veganlife.like.domain.CommentLike;
 import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.repository.CommentLikeRepository;
 import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +15,13 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class LikeQueryService {
     private final PostLikeRepository postLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
 
     public Optional<PostLike> searchPostLike(Long memberId, Long postId) {
         return postLikeRepository.findByMemberIdAndId(memberId, postId);
+    }
+
+    public Optional<CommentLike> searchCommentLike(Long memberId, Long commentId) {
+        return commentLikeRepository.findByMemberIdAndId(memberId, commentId);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
@@ -50,12 +50,20 @@ public class LikeService {
         comment.addCommentLike(commentLike);
     }
 
+    public void removeCommentLike(Long memberId, Long postId, Long commentId) {
+        memberQueryService.search(memberId);
+        postQueryService.search(postId);
+        Comment comment = commentQueryService.search(commentId);
+        CommentLike commentLike = validateCommentLikeIsNotExist(memberId, commentId);
+        comment.removeCommentLike(commentLike);
+    }
+
     private void validatePostLikeIsExist(Long memberId, Long postId) {
         likeQueryService
                 .searchPostLike(memberId, postId)
                 .ifPresent(
                         postLike -> {
-                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED);
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_POST_LIKED);
                         });
     }
 
@@ -64,16 +72,25 @@ public class LikeService {
                 .searchPostLike(memberId, postId)
                 .orElseThrow(
                         () -> {
-                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_UNLIKED);
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_POST_UNLIKED);
                         });
     }
 
-    public void validateCommentLikeIsExist(Long memberId, Long commentId) {
+    private void validateCommentLikeIsExist(Long memberId, Long commentId) {
         likeQueryService
                 .searchCommentLike(memberId, commentId)
                 .ifPresent(
                         postLike -> {
-                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED);
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_COMMENT_LIKED);
+                        });
+    }
+
+    private CommentLike validateCommentLikeIsNotExist(Long memberId, Long commentId) {
+        return likeQueryService
+                .searchCommentLike(memberId, commentId)
+                .orElseThrow(
+                        () -> {
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_COMMENT_UNLIKED);
                         });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
@@ -1,8 +1,10 @@
 package com.konggogi.veganlife.like.service;
 
 
+import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.like.domain.PostLike;
 import com.konggogi.veganlife.like.domain.mapper.LikeMapper;
+import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.post.domain.Post;
@@ -17,12 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeService {
     private final MemberQueryService memberQueryService;
     private final PostQueryService postQueryService;
+    private final LikeQueryService likeQueryService;
     private final LikeMapper postLikeMapper;
 
     public void addPostLike(Long memberId, Long postId) {
         Member member = memberQueryService.search(memberId);
         Post post = postQueryService.search(postId);
-        postQueryService.validatePostLikeIsExist(memberId, postId);
+        validatePostLikeIsExist(memberId, postId);
         PostLike postLike = postLikeMapper.toEntity(member, post);
         post.addPostLike(postLike);
     }
@@ -30,7 +33,25 @@ public class LikeService {
     public void removePostLike(Long memberId, Long postId) {
         memberQueryService.search(memberId);
         Post post = postQueryService.search(postId);
-        PostLike postLike = postQueryService.validatePostLikeIsNotExist(memberId, postId);
+        PostLike postLike = validatePostLikeIsNotExist(memberId, postId);
         post.removePostLike(postLike);
+    }
+
+    private void validatePostLikeIsExist(Long memberId, Long postId) {
+        likeQueryService
+                .searchPostLike(memberId, postId)
+                .ifPresent(
+                        postLike -> {
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED);
+                        });
+    }
+
+    private PostLike validatePostLikeIsNotExist(Long memberId, Long postId) {
+        return likeQueryService
+                .searchPostLike(memberId, postId)
+                .orElseThrow(
+                        () -> {
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_UNLIKED);
+                        });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
@@ -30,7 +30,7 @@ public class LikeService {
         Member member = memberQueryService.search(memberId);
         Post post = postQueryService.search(postId);
         validatePostLikeIsExist(memberId, postId);
-        PostLike postLike = likeMapper.toPostLike(member, post);
+        PostLike postLike = likeMapper.toPostLike(member);
         post.addPostLike(postLike);
     }
 

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
@@ -1,7 +1,10 @@
 package com.konggogi.veganlife.like.service;
 
 
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.service.CommentQueryService;
 import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.like.domain.CommentLike;
 import com.konggogi.veganlife.like.domain.PostLike;
 import com.konggogi.veganlife.like.domain.mapper.LikeMapper;
 import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
@@ -19,14 +22,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class LikeService {
     private final MemberQueryService memberQueryService;
     private final PostQueryService postQueryService;
+    private final CommentQueryService commentQueryService;
     private final LikeQueryService likeQueryService;
-    private final LikeMapper postLikeMapper;
+    private final LikeMapper likeMapper;
 
     public void addPostLike(Long memberId, Long postId) {
         Member member = memberQueryService.search(memberId);
         Post post = postQueryService.search(postId);
         validatePostLikeIsExist(memberId, postId);
-        PostLike postLike = postLikeMapper.toEntity(member, post);
+        PostLike postLike = likeMapper.toPostLike(member, post);
         post.addPostLike(postLike);
     }
 
@@ -35,6 +39,15 @@ public class LikeService {
         Post post = postQueryService.search(postId);
         PostLike postLike = validatePostLikeIsNotExist(memberId, postId);
         post.removePostLike(postLike);
+    }
+
+    public void addCommentLike(Long memberId, Long postId, Long commentId) {
+        Member member = memberQueryService.search(memberId);
+        Post post = postQueryService.search(postId);
+        Comment comment = commentQueryService.search(commentId);
+        validateCommentLikeIsExist(memberId, commentId);
+        CommentLike commentLike = likeMapper.toCommentLike(member, post);
+        comment.addCommentLike(commentLike);
     }
 
     private void validatePostLikeIsExist(Long memberId, Long postId) {
@@ -52,6 +65,15 @@ public class LikeService {
                 .orElseThrow(
                         () -> {
                             throw new IllegalLikeStatusException(ErrorCode.ALREADY_UNLIKED);
+                        });
+    }
+
+    public void validateCommentLikeIsExist(Long memberId, Long commentId) {
+        likeQueryService
+                .searchCommentLike(memberId, commentId)
+                .ifPresent(
+                        postLike -> {
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED);
                         });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -64,7 +64,7 @@ public class Post extends TimeStamped {
 
     public void addPostLike(PostLike postLike) {
         likes.add(postLike);
-        postLike.setPostAndMember(this, member);
+        postLike.setPost(this);
     }
 
     public void addComment(Comment comment) {

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -3,12 +3,8 @@ package com.konggogi.veganlife.post.service;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
-import com.konggogi.veganlife.like.domain.PostLike;
-import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
-import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.repository.PostRepository;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,31 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PostQueryService {
     private final PostRepository postRepository;
-    private final PostLikeRepository postLikeRepository;
 
     public Post search(Long postId) {
         return postRepository
                 .findById(postId)
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_POST));
-    }
-
-    public Optional<PostLike> searchPostLike(Long memberId, Long postId) {
-        return postLikeRepository.findByMemberIdAndId(memberId, postId);
-    }
-
-    public void validatePostLikeIsExist(Long memberId, Long postId) {
-        searchPostLike(memberId, postId)
-                .ifPresent(
-                        postLike -> {
-                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED);
-                        });
-    }
-
-    public PostLike validatePostLikeIsNotExist(Long memberId, Long postId) {
-        return searchPostLike(memberId, postId)
-                .orElseThrow(
-                        () -> {
-                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_UNLIKED);
-                        });
     }
 }

--- a/src/test/java/com/konggogi/veganlife/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/controller/LikeControllerTest.java
@@ -178,4 +178,104 @@ class LikeControllerTest extends RestDocsTest {
 
         perform.andDo(print()).andDo(document("remove-post-like-already", getDocumentResponse()));
     }
+
+    @Test
+    @DisplayName("댓글 좋아요 API")
+    void addCommentLikeTest() throws Exception {
+        // given
+        doNothing().when(likeService).addCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isCreated());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "add-comment-like",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(
+                                        parameterWithName("postId").description("게시글 번호"),
+                                        parameterWithName("commentId").description("댓글 번호"))));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 API - 없는 회원 예외 발생")
+    void addCommentLikeNotFoundMemberTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
+                .when(likeService)
+                .addCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("add-comment-like-not-found-member", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 API - 없는 게시글 예외 발생")
+    void addCommentLikeNotFoundPostTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST))
+                .when(likeService)
+                .addCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("add-comment-like-not-found-post", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 API - 없는 댓글 예외 발생")
+    void addCommentLikeNotFoundCommentTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_COMMENT))
+                .when(likeService)
+                .addCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("add-comment-like-not-found-comment", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 API - 이미 좋아요한 경우 예외 발생")
+    void addCommentLikeAlreadyLikeTest() throws Exception {
+        // given
+        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_COMMENT_LIKED))
+                .when(likeService)
+                .addCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isConflict());
+
+        perform.andDo(print()).andDo(document("add-comment-like-already", getDocumentResponse()));
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/controller/LikeControllerTest.java
@@ -278,4 +278,105 @@ class LikeControllerTest extends RestDocsTest {
 
         perform.andDo(print()).andDo(document("add-comment-like-already", getDocumentResponse()));
     }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 API")
+    void removeCommentLikeTest() throws Exception {
+        // given
+        doNothing().when(likeService).removeCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNoContent());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "remove-comment-like",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(
+                                        parameterWithName("postId").description("게시글 번호"),
+                                        parameterWithName("commentId").description("댓글 번호"))));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 API - 없는 회원 예외 발생")
+    void removeCommentLikeNotFoundMemberTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
+                .when(likeService)
+                .removeCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("remove-comment-like-not-found-member", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 API - 없는 게시글 예외 발생")
+    void removeCommentLikeNotFoundPostTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST))
+                .when(likeService)
+                .removeCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("remove-comment-like-not-found-post", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 API - 없는 댓글 예외 발생")
+    void removeCommentLikeNotFoundCommentTest() throws Exception {
+        // given
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_COMMENT))
+                .when(likeService)
+                .removeCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("remove-comment-like-not-found-comment", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 취소 API - 이미 좋아요한 경우 예외 발생")
+    void removeCommentLikeAlreadyLikeTest() throws Exception {
+        // given
+        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_COMMENT_UNLIKED))
+                .when(likeService)
+                .removeCommentLike(anyLong(), anyLong(), anyLong());
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/posts/{postId}/comments/{commentId}/likes", 1L, 1L)
+                                .headers(authorizationHeader()));
+        // then
+        perform.andExpect(status().isConflict());
+
+        perform.andDo(print())
+                .andDo(document("remove-comment-like-already", getDocumentResponse()));
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/controller/LikeControllerTest.java
@@ -91,7 +91,7 @@ class LikeControllerTest extends RestDocsTest {
     @DisplayName("게시글 좋아요 API - 이미 좋아요한 경우 예외 발생")
     void addPostLikeAlreadyTest() throws Exception {
         // given
-        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_LIKED))
+        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_POST_LIKED))
                 .when(likeService)
                 .addPostLike(anyLong(), anyLong());
         // when
@@ -166,7 +166,7 @@ class LikeControllerTest extends RestDocsTest {
     @DisplayName("게시글 좋아요 취소 API - 좋아요 되어 있지 않은 경우 예외 발생")
     void removePostLikeAlreadyTest() throws Exception {
         // given
-        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_UNLIKED))
+        doThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_POST_UNLIKED))
                 .when(likeService)
                 .removePostLike(anyLong(), anyLong());
         // when

--- a/src/test/java/com/konggogi/veganlife/like/fixture/CommentLikeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/like/fixture/CommentLikeFixture.java
@@ -1,0 +1,21 @@
+package com.konggogi.veganlife.like.fixture;
+
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.like.domain.CommentLike;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.post.domain.Post;
+
+public enum CommentLikeFixture {
+    DEFAULT;
+
+    CommentLikeFixture() {}
+
+    public CommentLike get(Member member, Post post, Comment comment) {
+        return CommentLike.builder().member(member).post(post).comment(comment).build();
+    }
+
+    public CommentLike getWithId(Long id, Member member, Post post, Comment comment) {
+        return CommentLike.builder().id(id).member(member).post(post).comment(comment).build();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/like/fixture/PostLikeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/like/fixture/PostLikeFixture.java
@@ -1,0 +1,20 @@
+package com.konggogi.veganlife.like.fixture;
+
+
+import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.post.domain.Post;
+
+public enum PostLikeFixture {
+    DEFAULT;
+
+    PostLikeFixture() {}
+
+    public PostLike get(Member member, Post post) {
+        return PostLike.builder().member(member).post(post).build();
+    }
+
+    public PostLike getWithId(Long id, Member member, Post post) {
+        return PostLike.builder().id(id).member(member).post(post).build();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/like/repository/CommentLikeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/repository/CommentLikeRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.konggogi.veganlife.like.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.comment.repository.CommentRepository;
+import com.konggogi.veganlife.like.domain.CommentLike;
+import com.konggogi.veganlife.like.fixture.CommentLikeFixture;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.repository.MemberRepository;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import com.konggogi.veganlife.post.repository.PostRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class CommentLikeRepositoryTest {
+    @Autowired MemberRepository memberRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired CommentRepository commentRepository;
+    @Autowired CommentLikeRepository commentLikeRepository;
+
+    private final Post post = PostFixture.BAKERY.getPost();
+    private final Member member = MemberFixture.DEFAULT_F.getMember();
+    private final Comment comment = CommentFixture.DEFAULT.getTopComment(member, post);
+    private final CommentLike commentLike = CommentLikeFixture.DEFAULT.get(member, post, comment);
+
+    @BeforeEach
+    void setup() {
+        memberRepository.save(member);
+        postRepository.save(post);
+        commentRepository.save(comment);
+        commentLikeRepository.save(commentLike);
+    }
+
+    @Test
+    @DisplayName("회원 번호와 댓글 번호로 좋아요 찾기")
+    void findByMemberIdAndCommentIdTest() {
+        // when
+        Optional<CommentLike> foundCommentLike =
+                commentLikeRepository.findByMemberIdAndCommentId(member.getId(), comment.getId());
+        // then
+        assertThat(foundCommentLike).isPresent();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/like/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/repository/PostLikeRepositoryTest.java
@@ -3,6 +3,7 @@ package com.konggogi.veganlife.like.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.fixture.PostLikeFixture;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
@@ -24,7 +25,7 @@ class PostLikeRepositoryTest {
 
     private final Post post = PostFixture.BAKERY.getPost();
     private final Member member = MemberFixture.DEFAULT_F.getMember();
-    private final PostLike postLike = PostLike.builder().post(post).member(member).build();
+    private final PostLike postLike = PostLikeFixture.DEFAULT.get(member, post);
 
     @BeforeEach
     void setup() {
@@ -35,7 +36,7 @@ class PostLikeRepositoryTest {
 
     @Test
     @DisplayName("회원 번호와 게시글 번호로 좋아요 찾기")
-    void findByMemberIdAndIdTest() {
+    void findByMemberIdAndPostIdTest() {
         // when
         Optional<PostLike> foundPostLike =
                 postLikeRepository.findByMemberIdAndPostId(member.getId(), post.getId());

--- a/src/test/java/com/konggogi/veganlife/like/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/repository/PostLikeRepositoryTest.java
@@ -24,13 +24,12 @@ class PostLikeRepositoryTest {
 
     private final Post post = PostFixture.BAKERY.getPost();
     private final Member member = MemberFixture.DEFAULT_F.getMember();
-    private PostLike postLike;
+    private final PostLike postLike = PostLike.builder().post(post).member(member).build();
 
     @BeforeEach
     void setup() {
         memberRepository.save(member);
         postRepository.save(post);
-        postLike = PostLike.builder().post(post).member(member).build();
         postLikeRepository.save(postLike);
     }
 
@@ -39,7 +38,7 @@ class PostLikeRepositoryTest {
     void findByMemberIdAndIdTest() {
         // when
         Optional<PostLike> foundPostLike =
-                postLikeRepository.findByMemberIdAndId(member.getId(), postLike.getId());
+                postLikeRepository.findByMemberIdAndPostId(member.getId(), post.getId());
         // then
         assertThat(foundPostLike).isPresent();
     }

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeQueryServiceTest.java
@@ -5,7 +5,13 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.like.domain.CommentLike;
 import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.fixture.CommentLikeFixture;
+import com.konggogi.veganlife.like.fixture.PostLikeFixture;
+import com.konggogi.veganlife.like.repository.CommentLikeRepository;
 import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
@@ -22,10 +28,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class LikeQueryServiceTest {
     @Mock PostLikeRepository postLikeRepository;
+    @Mock CommentLikeRepository commentLikeRepository;
     @InjectMocks LikeQueryService likeQueryService;
     private final Member member = MemberFixture.DEFAULT_M.getMember();
     private final Post post = PostFixture.CHALLENGE.getPost();
-    private final PostLike postLike = PostLike.builder().post(post).member(member).build();
+    private final Comment comment = CommentFixture.DEFAULT.getTopComment(member, post);
+    private final PostLike postLike = PostLikeFixture.DEFAULT.get(member, post);
+    private final CommentLike commentLike = CommentLikeFixture.DEFAULT.get(member, post, comment);
 
     @Test
     @DisplayName("게시글 좋아요 여부 조회 - 존재하는 경우")
@@ -51,5 +60,33 @@ class LikeQueryServiceTest {
         // then
         assertThat(foundPostLike).isEmpty();
         then(postLikeRepository).should().findByMemberIdAndPostId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 여부 조회 - 존재하는 경우")
+    void searchCommentLikeExistTest() {
+        // given
+        given(commentLikeRepository.findByMemberIdAndCommentId(anyLong(), anyLong()))
+                .willReturn(Optional.of(commentLike));
+        // when
+        Optional<CommentLike> foundCommentLike =
+                likeQueryService.searchCommentLike(anyLong(), anyLong());
+        // then
+        assertThat(foundCommentLike).isPresent();
+        then(commentLikeRepository).should().findByMemberIdAndCommentId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 여부 조회 - 존재하지 않는 경우")
+    void searchCommentLikeNotFoundTest() {
+        // given
+        given(commentLikeRepository.findByMemberIdAndCommentId(anyLong(), anyLong()))
+                .willReturn(Optional.empty());
+        // when
+        Optional<CommentLike> foundCommentLike =
+                likeQueryService.searchCommentLike(anyLong(), anyLong());
+        // then
+        assertThat(foundCommentLike).isEmpty();
+        then(commentLikeRepository).should().findByMemberIdAndCommentId(anyLong(), anyLong());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeQueryServiceTest.java
@@ -31,25 +31,25 @@ class LikeQueryServiceTest {
     @DisplayName("게시글 좋아요 여부 조회 - 존재하는 경우")
     void searchPostLikeExistTest() {
         // given
-        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
+        given(postLikeRepository.findByMemberIdAndPostId(anyLong(), anyLong()))
                 .willReturn(Optional.of(postLike));
         // when
         Optional<PostLike> foundPostLike = likeQueryService.searchPostLike(anyLong(), anyLong());
         // then
         assertThat(foundPostLike).isPresent();
-        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
+        then(postLikeRepository).should().findByMemberIdAndPostId(anyLong(), anyLong());
     }
 
     @Test
     @DisplayName("게시글 좋아요 여부 조회 - 존재하지 않는 경우")
     void searchPostLikeNotFoundTest() {
         // given
-        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
+        given(postLikeRepository.findByMemberIdAndPostId(anyLong(), anyLong()))
                 .willReturn(Optional.empty());
         // when
         Optional<PostLike> foundPostLike = likeQueryService.searchPostLike(anyLong(), anyLong());
         // then
         assertThat(foundPostLike).isEmpty();
-        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
+        then(postLikeRepository).should().findByMemberIdAndPostId(anyLong(), anyLong());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeQueryServiceTest.java
@@ -1,0 +1,55 @@
+package com.konggogi.veganlife.like.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.konggogi.veganlife.like.domain.PostLike;
+import com.konggogi.veganlife.like.repository.PostLikeRepository;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LikeQueryServiceTest {
+    @Mock PostLikeRepository postLikeRepository;
+    @InjectMocks LikeQueryService likeQueryService;
+    private final Member member = MemberFixture.DEFAULT_M.getMember();
+    private final Post post = PostFixture.CHALLENGE.getPost();
+    private final PostLike postLike = PostLike.builder().post(post).member(member).build();
+
+    @Test
+    @DisplayName("게시글 좋아요 여부 조회 - 존재하는 경우")
+    void searchPostLikeExistTest() {
+        // given
+        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
+                .willReturn(Optional.of(postLike));
+        // when
+        Optional<PostLike> foundPostLike = likeQueryService.searchPostLike(anyLong(), anyLong());
+        // then
+        assertThat(foundPostLike).isPresent();
+        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("게시글 좋아요 여부 조회 - 존재하지 않는 경우")
+    void searchPostLikeNotFoundTest() {
+        // given
+        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
+                .willReturn(Optional.empty());
+        // when
+        Optional<PostLike> foundPostLike = likeQueryService.searchPostLike(anyLong(), anyLong());
+        // then
+        assertThat(foundPostLike).isEmpty();
+        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
@@ -95,7 +95,7 @@ class LikeServiceTest {
         // when, then
         assertThatThrownBy(() -> likeService.addPostLike(member.getId(), post.getId()))
                 .isInstanceOf(IllegalLikeStatusException.class)
-                .hasMessageContaining(ErrorCode.ALREADY_LIKED.getDescription());
+                .hasMessageContaining(ErrorCode.ALREADY_POST_LIKED.getDescription());
         then(memberQueryService).should().search(anyLong());
         then(postQueryService).should().search(anyLong());
         then(likeQueryService).should().searchPostLike(anyLong(), anyLong());
@@ -157,7 +157,7 @@ class LikeServiceTest {
         // when, then
         assertThatThrownBy(() -> likeService.removePostLike(member.getId(), post.getId()))
                 .isInstanceOf(IllegalLikeStatusException.class)
-                .hasMessageContaining(ErrorCode.ALREADY_UNLIKED.getDescription());
+                .hasMessageContaining(ErrorCode.ALREADY_POST_UNLIKED.getDescription());
         then(memberQueryService).should().search(anyLong());
         then(postQueryService).should().search(anyLong());
         then(likeQueryService).should().searchPostLike(anyLong(), anyLong());

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
@@ -31,7 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class LikeServiceTest {
     @Mock MemberQueryService memberQueryService;
     @Mock PostQueryService postQueryService;
-    @Spy LikeMapper postLikeMapper;
+    @Spy LikeMapper likeMapper;
     @Mock LikeQueryService likeQueryService;
     @InjectMocks LikeService likeService;
     private final Member member = MemberFixture.DEFAULT_M.getMember();
@@ -45,7 +45,7 @@ class LikeServiceTest {
         given(memberQueryService.search(anyLong())).willReturn(member);
         given(postQueryService.search(anyLong())).willReturn(post);
         given(likeQueryService.searchPostLike(anyLong(), anyLong())).willReturn(Optional.empty());
-        given(postLikeMapper.toEntity(any(Member.class), any(Post.class))).willReturn(postLike);
+        given(likeMapper.toPostLike(any(Member.class))).willReturn(postLike);
         // when
         likeService.addPostLike(member.getId(), post.getId());
         // then

--- a/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
@@ -8,11 +8,6 @@ import static org.mockito.BDDMockito.then;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
-import com.konggogi.veganlife.like.domain.PostLike;
-import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
-import com.konggogi.veganlife.like.repository.PostLikeRepository;
-import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.fixture.PostFixture;
 import com.konggogi.veganlife.post.repository.PostRepository;
@@ -27,11 +22,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class PostQueryServiceTest {
     @Mock PostRepository postRepository;
-    @Mock PostLikeRepository postLikeRepository;
     @InjectMocks PostQueryService postQueryService;
     private final Post post = PostFixture.CHALLENGE.getPost();
-    private final Member member = MemberFixture.DEFAULT_M.getMember();
-    private final PostLike postLike = PostLike.builder().post(post).member(member).build();
 
     @Test
     @DisplayName("게시글 번호로 게시글 조회")
@@ -55,79 +47,5 @@ class PostQueryServiceTest {
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_POST.getDescription());
         then(postRepository).should().findById(anyLong());
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 여부 조회 - 존재하는 경우")
-    void searchPostLikeExistTest() {
-        // given
-        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
-                .willReturn(Optional.of(postLike));
-        // when
-        Optional<PostLike> foundPostLike = postQueryService.searchPostLike(anyLong(), anyLong());
-        // then
-        assertThat(foundPostLike).isPresent();
-        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 여부 조회 - 존재하지 않는 경우")
-    void searchPostLikeNotFoundTest() {
-        // given
-        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
-                .willReturn(Optional.empty());
-        // when
-        Optional<PostLike> foundPostLike = postQueryService.searchPostLike(anyLong(), anyLong());
-        // then
-        assertThat(foundPostLike).isEmpty();
-        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 존재하는지 검증 - 존재하면 예외 발생")
-    void validatePostLikeIsExistTest() {
-        // given
-        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
-                .willReturn(Optional.of(postLike));
-        // when, then
-        assertThatThrownBy(() -> postQueryService.validatePostLikeIsExist(anyLong(), anyLong()))
-                .isInstanceOf(IllegalLikeStatusException.class)
-                .hasMessageContaining(ErrorCode.ALREADY_LIKED.getDescription());
-        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 존재하는지 검증 - 존재하지 않으면 예외 미발생")
-    void validatePostLikeIsExistNotFoundTest() {
-        // given
-        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
-                .willReturn(Optional.empty());
-        // when
-        postQueryService.validatePostLikeIsExist(anyLong(), anyLong());
-        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 존재하지 않는지 검증 - 존재하지 않으면 예외 발생")
-    void validatePostLikeIsNotExistTest() {
-        // given
-        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
-                .willReturn(Optional.empty());
-        // when, then
-        assertThatThrownBy(() -> postQueryService.validatePostLikeIsNotExist(anyLong(), anyLong()))
-                .isInstanceOf(IllegalLikeStatusException.class)
-                .hasMessageContaining(ErrorCode.ALREADY_UNLIKED.getDescription());
-        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("게시글 좋아요 존재하지 않는지 검증 - 존재하면 예외 미발생")
-    void validatePostLikeIsNotExistFoundTest() {
-        // given
-        given(postLikeRepository.findByMemberIdAndId(anyLong(), anyLong()))
-                .willReturn(Optional.of(postLike));
-        // when
-        postQueryService.validatePostLikeIsNotExist(anyLong(), anyLong());
-        then(postLikeRepository).should().findByMemberIdAndId(anyLong(), anyLong());
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#188 )

## 요약
댓글 좋아요/취소 API 구현
관련 ErrorCode 정의
LikeControllerTest, CommentLikeReposiroty, LikeService 테스트 케이스 추가

## 변경 내용
PostQueryService에 있던 validate 메서드를 LikeQueryService로 이동, 관련 테스트 코드 이동
PostLikeRepository의 findByMemberIdAndId() 메서드를 findByMemberIdAndPostId() 로 수정하여 버그 해결

