### PR TITLE
댓글 등록, 댓글 좋아요시 알림 보내는 기능 구현

### DIFF
--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentNotifyService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentNotifyService.java
@@ -19,7 +19,7 @@ public class CommentNotifyService {
     private final PostQueryService postQueryService;
     private final NotificationService notificationService;
 
-    public void notifyAddCommentIfNotPostOwner(Long authorId, Long postId) {
+    public void notifyAddCommentIfNotAuthor(Long authorId, Long postId) {
         Member commentAuthor = memberQueryService.search(authorId);
         Member postAuthor = postQueryService.search(postId).getMember();
         if (commentAuthor.equals(postAuthor)) {

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentNotifyService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentNotifyService.java
@@ -8,14 +8,12 @@ import com.konggogi.veganlife.notification.domain.NotificationType;
 import com.konggogi.veganlife.notification.service.NotificationService;
 import com.konggogi.veganlife.post.service.PostQueryService;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-@Slf4j
 public class CommentNotifyService {
     private final MemberQueryService memberQueryService;
     private final PostQueryService postQueryService;

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentNotifyService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentNotifyService.java
@@ -1,0 +1,36 @@
+package com.konggogi.veganlife.comment.service;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.notification.domain.NotificationMessage;
+import com.konggogi.veganlife.notification.domain.NotificationType;
+import com.konggogi.veganlife.notification.service.NotificationService;
+import com.konggogi.veganlife.post.service.PostQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class CommentNotifyService {
+    private final MemberQueryService memberQueryService;
+    private final PostQueryService postQueryService;
+    private final NotificationService notificationService;
+
+    public void notifyAddCommentIfNotPostOwner(Long authorId, Long postId) {
+        Member commentAuthor = memberQueryService.search(authorId);
+        Member postAuthor = postQueryService.search(postId).getMember();
+        if (commentAuthor.equals(postAuthor)) {
+            return;
+        }
+        notificationService.sendNotification(
+                postAuthor,
+                NotificationType.COMMENT,
+                NotificationMessage.ADD_COMMENT.getMessage(
+                        commentAuthor.getNickname(), postAuthor.getNickname()));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
@@ -37,7 +37,7 @@ public class CommentService {
                         });
         Post post = postQueryService.search(postId);
         post.addComment(comment);
-        commentNotifyService.notifyAddCommentIfNotPostOwner(memberId, postId);
+        commentNotifyService.notifyAddCommentIfNotAuthor(memberId, postId);
         return comment;
     }
 

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
@@ -22,6 +22,7 @@ public class CommentService {
     private final MemberQueryService memberQueryService;
     private final PostQueryService postQueryService;
     private final CommentQueryService commentQueryService;
+    private final CommentNotifyService commentNotifyService;
     private final CommentMapper commentMapper;
 
     public Comment add(Long memberId, Long postId, CommentAddRequest commentAddRequest) {
@@ -36,6 +37,7 @@ public class CommentService {
                         });
         Post post = postQueryService.search(postId);
         post.addComment(comment);
+        commentNotifyService.notifyAddCommentIfNotPostOwner(memberId, postId);
         return comment;
     }
 

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeNotifyService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeNotifyService.java
@@ -1,0 +1,34 @@
+package com.konggogi.veganlife.like.service;
+
+
+import com.konggogi.veganlife.comment.service.CommentQueryService;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.notification.domain.NotificationMessage;
+import com.konggogi.veganlife.notification.domain.NotificationType;
+import com.konggogi.veganlife.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LikeNotifyService {
+    private final MemberQueryService memberQueryService;
+    private final CommentQueryService commentQueryService;
+    private final NotificationService notificationService;
+
+    public void notifyAddCommentLikeIfNotAuthor(Long memberId, Long commentId) {
+        Member commentLikeMember = memberQueryService.search(memberId);
+        Member commentAuthor = commentQueryService.search(commentId).getMember();
+        if (commentLikeMember.equals(commentAuthor)) {
+            return;
+        }
+        notificationService.sendNotification(
+                commentAuthor,
+                NotificationType.COMMENT_LIKE,
+                NotificationMessage.COMMENT_LIKE.getMessage(
+                        commentLikeMember.getNickname(), commentAuthor.getNickname()));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
@@ -24,6 +24,7 @@ public class LikeService {
     private final PostQueryService postQueryService;
     private final CommentQueryService commentQueryService;
     private final LikeQueryService likeQueryService;
+    private final LikeNotifyService likeNotifyService;
     private final LikeMapper likeMapper;
 
     public void addPostLike(Long memberId, Long postId) {
@@ -48,6 +49,7 @@ public class LikeService {
         validateCommentLikeIsExist(memberId, commentId);
         CommentLike commentLike = likeMapper.toCommentLike(member, post);
         comment.addCommentLike(commentLike);
+        likeNotifyService.notifyAddCommentLikeIfNotAuthor(memberId, commentId);
     }
 
     public void removeCommentLike(Long memberId, Long postId, Long commentId) {

--- a/src/main/java/com/konggogi/veganlife/notification/domain/MessageFormatter.java
+++ b/src/main/java/com/konggogi/veganlife/notification/domain/MessageFormatter.java
@@ -8,4 +8,8 @@ public interface MessageFormatter {
     default String getMessage(int data) {
         return getMessage();
     }
+
+    default String getMessage(String data, String subData) {
+        return getMessage();
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/notification/domain/NotificationMessage.java
+++ b/src/main/java/com/konggogi/veganlife/notification/domain/NotificationMessage.java
@@ -3,11 +3,20 @@ package com.konggogi.veganlife.notification.domain;
 public enum NotificationMessage implements MessageFormatter {
     // sse
     SSE_CONNECTION("SSE 연결이 완료되었습니다."),
+
     // intake
     OVER_INTAKE("오늘의 칼로리 섭취량이 %dKcal 초과되었습니다.") {
         @Override
         public String getMessage(int calorie) {
             return String.format(this.getMessage(), calorie);
+        }
+    },
+
+    // comment
+    ADD_COMMENT("%s님이 %s님의 게시글에 댓글을 달았습니다!") {
+        @Override
+        public String getMessage(String commentAuthor, String postAuthor) {
+            return String.format(this.getMessage(), commentAuthor, postAuthor);
         }
     };
 

--- a/src/main/java/com/konggogi/veganlife/notification/domain/NotificationMessage.java
+++ b/src/main/java/com/konggogi/veganlife/notification/domain/NotificationMessage.java
@@ -18,6 +18,14 @@ public enum NotificationMessage implements MessageFormatter {
         public String getMessage(String commentAuthor, String postAuthor) {
             return String.format(this.getMessage(), commentAuthor, postAuthor);
         }
+    },
+
+    // comment-like
+    COMMENT_LIKE("%s님이 %s님의 댓글에 좋아요를 눌렀습니다!") {
+        @Override
+        public String getMessage(String commentLikeMember, String commentAuthor) {
+            return String.format(this.getMessage(), commentLikeMember, commentAuthor);
+        }
     };
 
     private final String message;

--- a/src/main/java/com/konggogi/veganlife/notification/domain/NotificationType.java
+++ b/src/main/java/com/konggogi/veganlife/notification/domain/NotificationType.java
@@ -3,5 +3,6 @@ package com.konggogi.veganlife.notification.domain;
 public enum NotificationType {
     SSE,
     INTAKE_OVER_30,
-    INTAKE_OVER_60
+    INTAKE_OVER_60,
+    COMMENT
 }

--- a/src/main/java/com/konggogi/veganlife/notification/domain/NotificationType.java
+++ b/src/main/java/com/konggogi/veganlife/notification/domain/NotificationType.java
@@ -4,5 +4,6 @@ public enum NotificationType {
     SSE,
     INTAKE_OVER_30,
     INTAKE_OVER_60,
-    COMMENT
+    COMMENT,
+    COMMENT_LIKE
 }

--- a/src/main/java/com/konggogi/veganlife/notification/service/NotificationService.java
+++ b/src/main/java/com/konggogi/veganlife/notification/service/NotificationService.java
@@ -15,18 +15,16 @@ import com.konggogi.veganlife.notification.repository.NotificationRepository;
 import com.konggogi.veganlife.notification.service.dto.NotificationData;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 @Transactional
 public class NotificationService {
     private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60 * 2;
-    private static final Long RECONNECTION_TIME = 1000L;
+    private static final Long RECONNECTION_TIME = 2000L;
     private final NotificationRepository notificationRepository;
     private final EmitterRepository emitterRepository;
     private final MemberQueryService memberQueryService;

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentNotifyServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentNotifyServiceTest.java
@@ -1,0 +1,63 @@
+package com.konggogi.veganlife.comment.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.notification.domain.NotificationType;
+import com.konggogi.veganlife.notification.service.NotificationService;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.service.PostQueryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentNotifyServiceTest {
+    @Mock MemberQueryService memberQueryService;
+    @Mock PostQueryService postQueryService;
+    @Mock NotificationService notificationService;
+    @InjectMocks CommentNotifyService commentNotifyService;
+
+    private final Member postAuthor = MemberFixture.DEFAULT_M.getWithId(1L);
+    private final Member commentAuthor = MemberFixture.DEFAULT_F.getWithId(2L);
+    private final Post post = Post.builder().id(1L).member(postAuthor).build();
+
+    @Test
+    @DisplayName("댓글 등록 알림")
+    void notifyAddCommentIfNotAuthorTest() {
+        // given
+        given(memberQueryService.search(anyLong())).willReturn(commentAuthor);
+        given(postQueryService.search(anyLong())).willReturn(post);
+        // when, then
+        assertDoesNotThrow(
+                () ->
+                        commentNotifyService.notifyAddCommentIfNotAuthor(
+                                commentAuthor.getId(), post.getId()));
+        then(notificationService)
+                .should()
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+    }
+
+    @Test
+    @DisplayName("댓글 등록 알림 - 댓글 작성자가 게시글 작성자와 같다면 미알림")
+    void notifyAddCommentIfAuthorTest() {
+        // given
+        given(memberQueryService.search(anyLong())).willReturn(postAuthor);
+        given(postQueryService.search(anyLong())).willReturn(post);
+        // when
+        commentNotifyService.notifyAddCommentIfNotAuthor(postAuthor.getId(), post.getId());
+        // then
+        then(notificationService)
+                .should(never())
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 
 import com.konggogi.veganlife.comment.controller.dto.request.CommentAddRequest;
@@ -33,6 +34,7 @@ class CommentServiceTest {
     @Mock MemberQueryService memberQueryService;
     @Mock PostQueryService postQueryService;
     @Mock CommentQueryService commentQueryService;
+    @Mock CommentNotifyService commentNotifyService;
     @Spy CommentMapper commentMapper;
     @InjectMocks CommentService commentService;
     private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
@@ -49,6 +51,7 @@ class CommentServiceTest {
         given(memberQueryService.search(anyLong())).willReturn(member);
         given(commentMapper.toEntity(member, commentAddRequest)).willReturn(comment);
         given(postQueryService.search(anyLong())).willReturn(post);
+        doNothing().when(commentNotifyService).notifyAddCommentIfNotAuthor(anyLong(), anyLong());
         // when
         Comment savedComment = commentService.add(member.getId(), post.getId(), commentAddRequest);
         // then
@@ -66,6 +69,7 @@ class CommentServiceTest {
         given(commentMapper.toEntity(member, commentAddRequest)).willReturn(subComment);
         given(commentQueryService.search(anyLong())).willReturn(comment);
         given(postQueryService.search(anyLong())).willReturn(post);
+        doNothing().when(commentNotifyService).notifyAddCommentIfNotAuthor(anyLong(), anyLong());
         // when
         Comment savedComment = commentService.add(member.getId(), post.getId(), commentAddRequest);
         // then

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeNotifyServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeNotifyServiceTest.java
@@ -1,0 +1,67 @@
+package com.konggogi.veganlife.like.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.comment.service.CommentQueryService;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.notification.domain.NotificationType;
+import com.konggogi.veganlife.notification.service.NotificationService;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LikeNotifyServiceTest {
+    @Mock MemberQueryService memberQueryService;
+    @Mock CommentQueryService commentQueryService;
+    @Mock NotificationService notificationService;
+    @InjectMocks LikeNotifyService likeNotifyService;
+    private final Member commentAuthor = MemberFixture.DEFAULT_M.getWithId(1L);
+    private final Member commentLikeMember = MemberFixture.DEFAULT_F.getWithId(2L);
+    private final Post post = PostFixture.CHALLENGE.getWithId(1L);
+    private final Comment comment =
+            CommentFixture.DEFAULT.getTopCommentWithId(1L, commentAuthor, post);
+
+    @Test
+    @DisplayName("댓글 좋아요 알림")
+    void notifyAddCommentLikeIfNotAuthorTest() {
+        // given
+        given(memberQueryService.search(anyLong())).willReturn(commentLikeMember);
+        given(commentQueryService.search(anyLong())).willReturn(comment);
+        // when, then
+        assertDoesNotThrow(
+                () ->
+                        likeNotifyService.notifyAddCommentLikeIfNotAuthor(
+                                commentLikeMember.getId(), comment.getId()));
+        then(notificationService)
+                .should()
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+    }
+
+    @Test
+    @DisplayName("댓글 좋아요 알림 - 좋아요한 회원이 댓글 작성자와 같다면 미알림")
+    void notNotifyAddCommentLikeIfAuthorTest() {
+        // given
+        given(memberQueryService.search(anyLong())).willReturn(commentAuthor);
+        given(commentQueryService.search(anyLong())).willReturn(comment);
+        // when
+        likeNotifyService.notifyAddCommentLikeIfNotAuthor(commentAuthor.getId(), comment.getId());
+        // then
+        then(notificationService)
+                .should(never())
+                .sendNotification(any(Member.class), any(NotificationType.class), anyString());
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
@@ -39,6 +39,7 @@ class LikeServiceTest {
     @Mock PostQueryService postQueryService;
     @Mock CommentQueryService commentQueryService;
     @Mock LikeQueryService likeQueryService;
+    @Mock LikeNotifyService likeNotifyService;
     @Spy LikeMapper likeMapper;
     @InjectMocks LikeService likeService;
     private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
@@ -180,6 +181,7 @@ class LikeServiceTest {
         given(likeQueryService.searchCommentLike(anyLong(), anyLong()))
                 .willReturn(Optional.empty());
         given(likeMapper.toCommentLike(any(Member.class), any(Post.class))).willReturn(commentLike);
+        doNothing().when(likeNotifyService).notifyAddCommentLikeIfNotAuthor(anyLong(), anyLong());
         // when
         likeService.addCommentLike(member.getId(), post.getId(), comment.getId());
         // then


### PR DESCRIPTION
## 이슈 번호 (#194 )

## 요약
댓글 등록시 알림 보내는 기능 구현 - `CommentNofityService`
댓글 좋아요시 알림 보내는 기능 구현 - `LikeNotifyService`
댓글 등록한 사람이 게시글의 작성자와 같다면 알림을 보내지 않음
댓글을 좋아요한 사람이 댓글의 작성자와 같다면 알림을 보내지 않음

## 변경 내용
`CommentService`의 `add()`에서 `commentNotifyService.notifyAddCommentIfNotAuthor` 호출
`LikeService`의 `addCommentLike()`에서 `likeNotifyService.notifyAddCommentLikeIfNotAuthor` 호출
