### PR TITLE
meallog 도메인 end to end 테스트

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/advice/common/GlobalControllerAdvice.java
+++ b/src/main/java/com/konggogi/veganlife/global/advice/common/GlobalControllerAdvice.java
@@ -8,6 +8,7 @@ import com.konggogi.veganlife.global.util.AopUtils;
 import com.konggogi.veganlife.global.util.LoggingUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -85,5 +86,17 @@ public class GlobalControllerAdvice {
                 exception);
 
         return ResponseEntity.status(HttpStatus.REQUEST_TIMEOUT).build();
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Void> handleAsyncRequestTimeoutException(
+            HandlerMethod handlerMethod, HttpMessageNotReadableException exception) {
+
+        LoggingUtils.exceptionLog(
+                AopUtils.extractMethodSignature(handlerMethod),
+                HttpStatus.METHOD_NOT_ALLOWED,
+                exception);
+
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/mealdata/controller/dto/response/MealDataDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/controller/dto/response/MealDataDetailsResponse.java
@@ -11,7 +11,7 @@ public record MealDataDetailsResponse(
         Integer amount,
         Integer amountPerServe,
         Double caloriePerUnit,
+        Double carbsPerUnit,
         Double proteinPerUnit,
         Double fatPerUnit,
-        Double carbsPerUnit,
         IntakeUnit intakeUnit) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/MealLogController.java
@@ -7,7 +7,7 @@ import com.konggogi.veganlife.meallog.controller.dto.request.MealLogModifyReques
 import com.konggogi.veganlife.meallog.controller.dto.response.MealLogDetailsResponse;
 import com.konggogi.veganlife.meallog.controller.dto.response.MealLogListResponse;
 import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
-import com.konggogi.veganlife.meallog.service.MealLogQueryService;
+import com.konggogi.veganlife.meallog.service.MealLogSearchService;
 import com.konggogi.veganlife.meallog.service.MealLogService;
 import jakarta.validation.Valid;
 import java.time.LocalDate;
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MealLogController {
 
     private final MealLogService mealLogService;
-    private final MealLogQueryService mealLogQueryService;
+    private final MealLogSearchService mealLogSearchService;
     private final MealLogMapper mealLogMapper;
 
     @PostMapping
@@ -49,7 +49,7 @@ public class MealLogController {
             @RequestParam LocalDate date, @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
         return ResponseEntity.ok(
-                mealLogQueryService.searchByDate(date, userDetails.id()).stream()
+                mealLogSearchService.searchByDate(date, userDetails.id()).stream()
                         .map(mealLogMapper::toMealLogListResponse)
                         .toList());
     }
@@ -58,7 +58,7 @@ public class MealLogController {
     public ResponseEntity<MealLogDetailsResponse> getMealLogDetails(@PathVariable Long id) {
 
         return ResponseEntity.ok(
-                mealLogMapper.toMealLogDetailsResponse(mealLogQueryService.searchById(id)));
+                mealLogMapper.toMealLogDetailsResponse(mealLogSearchService.searchById(id)));
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -3,7 +3,6 @@ package com.konggogi.veganlife.meallog.domain;
 
 import com.konggogi.veganlife.global.domain.TimeStamped;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,7 +16,6 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.ToIntFunction;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -70,31 +68,5 @@ public class MealLog extends TimeStamped {
     public void updateMealImages(List<MealImage> mealImages) {
         this.mealImages.clear();
         this.mealImages.addAll(mealImages);
-    }
-
-    public String getThumbnailUrl() {
-        if (!mealImages.isEmpty()) {
-            return mealImages.get(0).getImageUrl();
-        }
-        return null;
-    }
-
-    public Integer getTotalCalorie() {
-
-        return calculateTotal(Meal::getCalorie, meals);
-    }
-
-    public IntakeNutrients getTotalIntakeNutrients() {
-        // TODO: reduce를 사용했을 때와 성능 비교해보기
-        return new IntakeNutrients(
-                calculateTotal(Meal::getCalorie, meals),
-                calculateTotal(Meal::getCarbs, meals),
-                calculateTotal(Meal::getProtein, meals),
-                calculateTotal(Meal::getFat, meals));
-    }
-
-    private Integer calculateTotal(ToIntFunction<Meal> func, List<Meal> meals) {
-
-        return meals.stream().mapToInt(func).sum();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -41,7 +42,7 @@ public class MealLog extends TimeStamped {
     @OneToMany(mappedBy = "mealLog", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MealImage> mealImages = new ArrayList<>();
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -6,6 +6,8 @@ import com.konggogi.veganlife.meallog.controller.dto.response.MealLogListRespons
 import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.meallog.service.dto.MealLogDetailsDto;
+import com.konggogi.veganlife.meallog.service.dto.MealLogListDto;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import org.mapstruct.Mapper;
@@ -18,19 +20,23 @@ public interface MealLogMapper {
     @Mapping(target = "id", ignore = true)
     MealLog toEntity(MealType mealType, Member member);
 
-    @Mapping(source = "mealLog", target = "thumbnailUrl", qualifiedByName = "getThumbnailUrl")
-    @Mapping(source = "mealLog", target = "totalCalorie", qualifiedByName = "getTotalCalorie")
-    MealLogListResponse toMealLogListResponse(MealLog mealLog);
+    @Mapping(source = "mealLogDto", target = "thumbnailUrl", qualifiedByName = "getThumbnailUrl")
+    @Mapping(source = "mealLogDto", target = "totalCalorie", qualifiedByName = "getTotalCalorie")
+    MealLogListResponse toMealLogListResponse(MealLogListDto mealLogDto);
 
     @Mapping(
-            source = "mealLog.mealImages",
+            source = "mealLogDetailsDto.mealImages",
             target = "imageUrls",
             qualifiedByName = "mealImageToImageUrl")
     @Mapping(
-            source = "mealLog",
+            source = "mealLogDetailsDto",
             target = "totalIntakeNutrients",
             qualifiedByName = "getTotalIntakeNutrients")
-    MealLogDetailsResponse toMealLogDetailsResponse(MealLog mealLog);
+    MealLogDetailsResponse toMealLogDetailsResponse(MealLogDetailsDto mealLogDetailsDto);
+
+    MealLogListDto toMealLogListDto(MealLog mealLog);
+
+    MealLogDetailsDto toMealDetailsDto(MealLog mealLog);
 
     @Named("mealImageToImageUrl")
     static String mealImageToImageUrl(MealImage mealImage) {
@@ -39,20 +45,20 @@ public interface MealLogMapper {
     }
 
     @Named("getThumbnailUrl")
-    static String getThumbnailUrl(MealLog mealLog) {
+    static String getThumbnailUrl(MealLogListDto mealLogDto) {
 
-        return mealLog.getThumbnailUrl();
+        return mealLogDto.getThumbnailUrl();
     }
 
     @Named("getTotalCalorie")
-    static Integer getTotalCalorie(MealLog mealLog) {
+    static Integer getTotalCalorie(MealLogListDto mealLogDto) {
 
-        return mealLog.getTotalCalorie();
+        return mealLogDto.getTotalCalorie();
     }
 
     @Named("getTotalIntakeNutrients")
-    static IntakeNutrients getTotalIntakeNutrients(MealLog mealLog) {
+    static IntakeNutrients getTotalIntakeNutrients(MealLogDetailsDto mealLogDetailsDto) {
 
-        return mealLog.getTotalIntakeNutrients();
+        return mealLogDetailsDto.getTotalIntakeNutrients();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealMapper.java
@@ -4,7 +4,6 @@ package com.konggogi.veganlife.meallog.domain.mapper;
 import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
 import com.konggogi.veganlife.meallog.controller.dto.request.MealModifyRequest;
-import com.konggogi.veganlife.meallog.controller.dto.response.MealDetailsResponse;
 import com.konggogi.veganlife.meallog.domain.Meal;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import org.mapstruct.Mapper;
@@ -18,6 +17,4 @@ public interface MealMapper {
 
     @Mapping(target = "id", ignore = true)
     Meal toEntity(MealModifyRequest request, MealLog mealLog, MealData mealData);
-
-    MealDetailsResponse toMealDetailsResponse(Meal meal);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -5,6 +5,7 @@ import com.konggogi.veganlife.meallog.domain.MealLog;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,7 +15,11 @@ public interface MealLogRepository extends JpaRepository<MealLog, Long> {
     List<MealLog> findAllByMemberIdAndCreatedAtBetween(
             Long memberId, LocalDateTime startDate, LocalDateTime endDate);
 
+    @Query(" select distinct m from MealLog m join fetch m.meals" + " where m.id = :id")
+    Optional<MealLog> findById(Long id);
+
     @Query(
-            "select m from MealLog m where cast(m.createdAt as localdate) = :date and m.member.id = :memberId")
+            " select distinct m from MealLog m join fetch m.meals"
+                    + " where cast(m.createdAt as localdate) = :date and m.member.id = :memberId")
     List<MealLog> findAllByDate(LocalDate date, Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogSearchService.java
@@ -1,0 +1,32 @@
+package com.konggogi.veganlife.meallog.service;
+
+
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
+import com.konggogi.veganlife.meallog.service.dto.MealLogDetailsDto;
+import com.konggogi.veganlife.meallog.service.dto.MealLogListDto;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MealLogSearchService {
+
+    private final MealLogQueryService mealLogQueryService;
+    private final MealLogMapper mealLogMapper;
+
+    public List<MealLogListDto> searchByDate(LocalDate date, Long memberId) {
+
+        return mealLogQueryService.searchByDate(date, memberId).stream()
+                .map(mealLogMapper::toMealLogListDto)
+                .toList();
+    }
+
+    public MealLogDetailsDto searchById(Long id) {
+
+        return mealLogMapper.toMealDetailsDto(mealLogQueryService.searchById(id));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -48,6 +48,7 @@ public class MealLogService {
         MealLog mealLog = mealLogQueryService.searchById(mealLogId);
         modifyMeals(request.meals(), mealLog);
         modifyMealImages(request.imageUrls(), mealLog);
+        mealLogRepository.flush();
         intakeNotifyService.notifyIfOverIntake(mealLog.getMember().getId());
     }
 

--- a/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealDataDetailsDto.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealDataDetailsDto.java
@@ -1,0 +1,17 @@
+package com.konggogi.veganlife.meallog.service.dto;
+
+
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.MealDataType;
+
+public record MealDataDetailsDto(
+        Long id,
+        String name,
+        MealDataType type,
+        Integer amount,
+        Integer amountPerServe,
+        Double caloriePerUnit,
+        Double carbsPerUnit,
+        Double proteinPerUnit,
+        Double fatPerUnit,
+        IntakeUnit intakeUnit) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealDetailsDto.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealDetailsDto.java
@@ -1,0 +1,10 @@
+package com.konggogi.veganlife.meallog.service.dto;
+
+public record MealDetailsDto(
+        Long id,
+        Integer intake,
+        Integer calorie,
+        Integer carbs,
+        Integer protein,
+        Integer fat,
+        MealDataDetailsDto mealData) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealListDto.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealListDto.java
@@ -1,0 +1,4 @@
+package com.konggogi.veganlife.meallog.service.dto;
+
+public record MealListDto(
+        Long id, Integer intake, Integer calorie, Integer carbs, Integer protein, Integer fat) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealLogDetailsDto.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealLogDetailsDto.java
@@ -1,0 +1,40 @@
+package com.konggogi.veganlife.meallog.service.dto;
+
+
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
+import java.util.List;
+import java.util.function.ToIntFunction;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public record MealLogDetailsDto(
+        Long id,
+        MealType mealType,
+        List<MealDetailsDto> meals,
+        List<MealImage> mealImages,
+        Member member) {
+
+    public String getThumbnailUrl() {
+        if (!mealImages.isEmpty()) {
+            return mealImages.get(0).getImageUrl();
+        }
+        return null;
+    }
+
+    public IntakeNutrients getTotalIntakeNutrients() {
+        // TODO: reduce를 사용했을 때와 성능 비교해보기
+        return new IntakeNutrients(
+                calculateTotal(MealDetailsDto::calorie, meals),
+                calculateTotal(MealDetailsDto::carbs, meals),
+                calculateTotal(MealDetailsDto::protein, meals),
+                calculateTotal(MealDetailsDto::fat, meals));
+    }
+
+    private Integer calculateTotal(ToIntFunction<MealDetailsDto> func, List<MealDetailsDto> meals) {
+
+        return meals.stream().mapToInt(func).sum();
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealLogListDto.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/dto/MealLogListDto.java
@@ -1,0 +1,35 @@
+package com.konggogi.veganlife.meallog.service.dto;
+
+
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.member.domain.Member;
+import java.util.List;
+import java.util.function.ToIntFunction;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public record MealLogListDto(
+        Long id,
+        MealType mealType,
+        List<MealListDto> meals,
+        List<MealImage> mealImages,
+        Member member) {
+
+    public String getThumbnailUrl() {
+        if (!mealImages.isEmpty()) {
+            return mealImages.get(0).getImageUrl();
+        }
+        return null;
+    }
+
+    public Integer getTotalCalorie() {
+
+        return calculateTotal(MealListDto::calorie, meals);
+    }
+
+    private Integer calculateTotal(ToIntFunction<MealListDto> func, List<MealListDto> meals) {
+
+        return meals.stream().mapToInt(func).sum();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,7 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+        default_batch_fetch_size: 1000
   security:
     oauth2:
       client:

--- a/src/test/java/com/konggogi/veganlife/config/JpaAuditingConfig.java
+++ b/src/test/java/com/konggogi/veganlife/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.konggogi.veganlife.config;
+
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing(dateTimeProviderRef = "dateTimeImpl")
+@TestConfiguration
+public class JpaAuditingConfig {}

--- a/src/test/java/com/konggogi/veganlife/mealdata/MealDataIntegrationTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/MealDataIntegrationTest.java
@@ -7,23 +7,15 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.konggogi.veganlife.mealdata.controller.dto.request.MealDataAddRequest;
 import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
 import com.konggogi.veganlife.mealdata.domain.MealDataType;
-import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
-import com.konggogi.veganlife.mealdata.service.MealDataQueryService;
-import com.konggogi.veganlife.mealdata.service.MealDataService;
 import com.konggogi.veganlife.support.restassured.IntegrationTest;
 import io.restassured.path.json.JsonPath;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 public class MealDataIntegrationTest extends IntegrationTest {
-
-    @Autowired MealDataQueryService mealDataQueryService;
-    @Autowired MealDataService mealDataService;
-    @Autowired MealDataMapper mealDataMapper;
 
     @Test
     @DisplayName("식품 데이터 등록")
@@ -56,8 +48,6 @@ public class MealDataIntegrationTest extends IntegrationTest {
                 given().log()
                         .all()
                         .header(AUTHORIZATION, getAccessToken())
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .body(toJson(request))
                         .when()
                         .get("/api/v1/meal-data/{id}", 1L)
                         .then()

--- a/src/test/java/com/konggogi/veganlife/meallog/MealLogIntegrationTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/MealLogIntegrationTest.java
@@ -1,0 +1,220 @@
+package com.konggogi.veganlife.meallog;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.konggogi.veganlife.mealdata.controller.dto.request.MealDataAddRequest;
+import com.konggogi.veganlife.mealdata.domain.IntakeUnit;
+import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
+import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogAddRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealLogModifyRequest;
+import com.konggogi.veganlife.meallog.controller.dto.request.MealModifyRequest;
+import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.support.restassured.IntegrationTest;
+import com.konggogi.veganlife.support.utils.DateTimeImpl;
+import io.restassured.path.json.JsonPath;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class MealLogIntegrationTest extends IntegrationTest {
+
+    @Autowired MealDataRepository mealDataRepository;
+    @Autowired MealDataMapper mealDataMapper;
+
+    @BeforeEach
+    void setup() {
+        List<MealDataAddRequest> requests =
+                List.of(
+                        new MealDataAddRequest("통밀빵", 300, 100, 200, 40, 7, 3, IntakeUnit.G),
+                        new MealDataAddRequest("통밀크래커", 300, 100, 200, 40, 7, 3, IntakeUnit.G),
+                        new MealDataAddRequest("가지볶음", 300, 100, 200, 40, 7, 3, IntakeUnit.G));
+        requests.stream()
+                .map(request -> mealDataMapper.toEntity(request, member))
+                .forEach(mealDataRepository::save);
+    }
+
+    @Test
+    @DisplayName("식단 기록 등록 테스트")
+    void addMealLogTest() throws Exception {
+
+        List<MealAddRequest> meals =
+                List.of(
+                        new MealAddRequest(200, 180, 30, 10, 5, 1L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 2L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 3L));
+        List<String> imageUrls = List.of("/image1.png", "/image2.png", "/image3.png");
+        MealLogAddRequest request = new MealLogAddRequest(MealType.BREAKFAST, meals, imageUrls);
+
+        given().log()
+                .all()
+                .header(AUTHORIZATION, getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(toJson(request))
+                .when()
+                .post("/api/v1/meal-log")
+                .then()
+                .log()
+                .all()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("식단 기록 목록 조회 테스트")
+    void getMealLogListTest() throws Exception {
+
+        List<MealAddRequest> meals =
+                List.of(
+                        new MealAddRequest(200, 180, 30, 10, 5, 1L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 2L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 3L));
+        List<String> imageUrls =
+                List.of("/image1.png", "/image2.png", "/image3.png", "/image4.png");
+        List<MealLogAddRequest> requests =
+                List.of(
+                        new MealLogAddRequest(MealType.BREAKFAST, meals, imageUrls),
+                        new MealLogAddRequest(MealType.LUNCH, meals, imageUrls),
+                        new MealLogAddRequest(MealType.LUNCH_SNACK, meals, imageUrls));
+        for (MealLogAddRequest request : requests) {
+            addMealLog(request);
+        }
+
+        JsonPath response =
+                given().log()
+                        .all()
+                        .header(AUTHORIZATION, getAccessToken())
+                        .param("date", DateTimeImpl.now.toString())
+                        .when()
+                        .get("/api/v1/meal-log")
+                        .then()
+                        .log()
+                        .all()
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath();
+
+        assertAll(
+                () -> {
+                    assertThat(response.getList("")).hasSize(3);
+                    assertThat(response.getLong("[0].id")).isEqualTo(1L);
+                    assertThat(response.getString("[0].mealType")).isEqualTo("BREAKFAST");
+                    assertThat(response.getString("[0].thumbnailUrl")).isEqualTo("/image1.png");
+                    assertThat(response.getInt("[0].totalCalorie")).isEqualTo(180 * 3);
+                });
+    }
+
+    @Test
+    @DisplayName("식단 기록 상세 조회 테스트")
+    void getMealLogDetailsTest() throws Exception {
+
+        List<MealAddRequest> meals =
+                List.of(
+                        new MealAddRequest(200, 180, 30, 10, 5, 1L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 2L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 3L));
+        List<String> imageUrls =
+                List.of("/image1.png", "/image2.png", "/image3.png", "/image4.png");
+        MealLogAddRequest request = new MealLogAddRequest(MealType.BREAKFAST, meals, imageUrls);
+        addMealLog(request);
+
+        JsonPath response =
+                given().log()
+                        .all()
+                        .header(AUTHORIZATION, getAccessToken())
+                        .when()
+                        .get("/api/v1/meal-log/{id}", 1L)
+                        .then()
+                        .log()
+                        .all()
+                        .statusCode(HttpStatus.OK.value())
+                        .extract()
+                        .jsonPath();
+
+        assertAll(
+                () -> {
+                    assertThat(response.getLong("id")).isEqualTo(1L);
+                    assertThat(response.getString("mealType")).isEqualTo("BREAKFAST");
+                    assertThat(response.getInt("totalIntakeNutrients.calorie")).isEqualTo(180 * 3);
+                    assertThat(response.getInt("totalIntakeNutrients.carbs")).isEqualTo(30 * 3);
+                    assertThat(response.getInt("totalIntakeNutrients.protein")).isEqualTo(10 * 3);
+                    assertThat(response.getInt("totalIntakeNutrients.fat")).isEqualTo(5 * 3);
+                    assertThat(response.getList("imageUrls")).hasSize(4);
+                    assertThat(response.getList("meals")).hasSize(3);
+                });
+    }
+
+    @Test
+    @DisplayName("식단 기록 수정 테스트")
+    void modifyMealLogTest() throws Exception {
+
+        List<MealAddRequest> meals =
+                List.of(
+                        new MealAddRequest(200, 180, 30, 10, 5, 1L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 2L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 3L));
+        List<String> imageUrls = List.of("/image1.png", "/image2.png", "/image3.png");
+        MealLogAddRequest request = new MealLogAddRequest(MealType.BREAKFAST, meals, imageUrls);
+        addMealLog(request);
+
+        List<MealModifyRequest> modifiedMeals =
+                List.of(
+                        new MealModifyRequest(200, 200, 30, 10, 5, 1L),
+                        new MealModifyRequest(300, 220, 30, 10, 5, 2L),
+                        new MealModifyRequest(400, 240, 30, 10, 5, 3L));
+        List<String> modifiedImageUrls = List.of("/image1.png", "/image2.png", "/image4.png");
+        MealLogModifyRequest mealLogModifyRequest =
+                new MealLogModifyRequest(modifiedMeals, modifiedImageUrls);
+
+        given().log()
+                .all()
+                .header(AUTHORIZATION, getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(toJson(mealLogModifyRequest))
+                .when()
+                .put("/api/v1/meal-log/{id}", 1L)
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("식단 기록 삭제 테스트")
+    void removeMealLogTest() throws Exception {
+
+        List<MealAddRequest> meals =
+                List.of(
+                        new MealAddRequest(200, 180, 30, 10, 5, 1L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 2L),
+                        new MealAddRequest(200, 180, 30, 10, 5, 3L));
+        List<String> imageUrls = List.of("/image1.png", "/image2.png", "/image3.png");
+        MealLogAddRequest request = new MealLogAddRequest(MealType.BREAKFAST, meals, imageUrls);
+        addMealLog(request);
+
+        given().log()
+                .all()
+                .header(AUTHORIZATION, getAccessToken())
+                .when()
+                .delete("/api/v1/meal-log/{id}", 1L)
+                .then()
+                .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    private void addMealLog(MealLogAddRequest request) throws Exception {
+
+        given().log()
+                .all()
+                .header(AUTHORIZATION, getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(toJson(request))
+                .when()
+                .post("/api/v1/meal-log")
+                .then()
+                .statusCode(HttpStatus.CREATED.value());
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/support/restassured/IntegrationTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/restassured/IntegrationTest.java
@@ -3,22 +3,26 @@ package com.konggogi.veganlife.support.restassured;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.konggogi.veganlife.config.JpaAuditingConfig;
 import com.konggogi.veganlife.global.security.jwt.JwtProvider;
 import com.konggogi.veganlife.member.domain.Gender;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.VegetarianType;
-import com.konggogi.veganlife.member.service.MemberService;
+import com.konggogi.veganlife.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.ContextConfiguration;
 
 @ExtendWith(DatabaseClearExtension.class)
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+@ContextConfiguration(classes = JpaAuditingConfig.class)
 public class IntegrationTest {
 
     @Autowired private ObjectMapper objectMapper;
-    @Autowired private MemberService memberService;
+    @Autowired private MemberRepository memberRepository;
     @Autowired private JwtProvider jwtProvider;
 
     protected static final String AUTHORIZATION = "Authorization";
@@ -29,10 +33,14 @@ public class IntegrationTest {
         return objectMapper.writeValueAsString(object);
     }
 
-    protected String getAccessToken() {
+    @BeforeEach
+    void beforeEach() {
         member = Member.builder().email("test123@test.com").build();
         member.updateMemberInfo("비건라이프", Gender.F, VegetarianType.VEGAN, 2000, 160, 50);
-        memberService.addMember(member.getEmail());
+        memberRepository.save(member);
+    }
+
+    protected String getAccessToken() {
 
         return jwtProvider.createToken(member.getEmail());
     }

--- a/src/test/java/com/konggogi/veganlife/support/utils/DateTimeImpl.java
+++ b/src/test/java/com/konggogi/veganlife/support/utils/DateTimeImpl.java
@@ -1,0 +1,19 @@
+package com.konggogi.veganlife.support.utils;
+
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAccessor;
+import java.util.Optional;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DateTimeImpl implements DateTimeProvider {
+
+    public static LocalDate now = LocalDate.of(2023, 12, 23);
+
+    @Override
+    public Optional<TemporalAccessor> getNow() {
+        return Optional.of(LocalDate.of(2023, 12, 23));
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#177)

## 요약
- MealLog 도메인 E2E 테스트를 진행함
- E2E 테스트용 `Member` 저장 로직 변경
- E2E 테스트의 멱등성을 위해 JpaAuditing 생성시간 fix
- MealLog 조회 로직에서 발생하는 `LazyInitializationException` 해결
- MealLog 조회 시 fetch join, batch_fetch_size 속성을 이용하여 N+1 문제 해결
- 요청 Method가 일치하지 않을 때의 예외 핸들

## `LazyInitializationException` 해결

### 문제 상황

`MealLog`는 `Meal`, `MealImage` 엔티티와 일대다 관계를 가진다.
Service 레이어에서 `MealLog` 엔티티를 반환하고 Controller에서 이를 Response DTO로 매핑해주었다.
그러나 매핑하는 과정에서 자식 엔티티의 프록시 객체에 접근할 때 LazyInitializationException이 발생했다.

### 발생 이유

OSIV 설정을 false로 해두었기 때문에 영속성 컨텍스트의 생존 범위가 트랜잭션 범위로 한정된다.
그러므로 모든 지연 로딩을 트랜잭션 안에서 처리해야 한다.

### 해결 방법

**에러가 발생하는 조회 메서드에 한정하여 fetch join을 이용해 자식 엔티티들을 하나의 쿼리로 모두 조회한다.**

그러나 문제가 되는 엔티티는 `@OneToMany` 연관관계를 두 개 가지고 있어 fetch join을 두 번 사용할 수 없었다.
- `MultipleBagFetchException`이 발생한다.
- 예상치못한 카테시안 곱이 발생할 수 있기 때문에 JPA에서는 이를 금지한다.

**Transactional 안에서 자식 엔티티들을 DTO로 변환한다.**

Service DTO를 정의하여 트랜잭션 안에서 자식 엔티티를 조회한 후, 이를 DTO로 변환한다.
제대로 동작하긴 하지만, 자식 엔티티를 조회하는 순간 N+1 문제가 발생한다.

**N+1 문제를 어떻게 해결할 수 있을까?**

### batch_fetch_size 를 이용한 N+1 문제 해결

```yaml
spring:  
  jpa:  
    open-in-view: false  
    properties:  
      hibernate:  
        default_batch_fetch_size: 30   // 한 번에 가져올 수 있는 자식 엔티티의 수
```

다음과 같이 `application.yml` 파일에 설정해준다.

`default_batch_fetch_size`를 설정해두면 조회 결과가 N개일 때 각각 쿼리를 날리는 것이 아니라, **batch size**만큼 한꺼번에 날리게 된다.
- N+1 문제를 해결할 수 있다.

원래 같으면 `MealLog`가 가지고 있는 `MealImage`의 수만큼 조회 쿼리가 발생해야 하지만
`default_batch_fetch_size`를 설정해두면 아래와 같이 `in`절을 활용하여 자식 엔티티들을 한 번에 가져온다.

```
Hibernate: 
    select
        m1_0.meal_log_id,
        m1_0.meal_image_id,
        m1_0.image_url 
    from
        meal_image m1_0 
    where
        m1_0.meal_log_id in (?,?,?,?,?,?,?,? ...)
```

**`default_batch_fetch_size`의 값을 30으로 설정한 이유**는 현재 서비스에서 30개를 초과하는 자식 엔티티를 가지는 경우가 없기 때문이다.
Hibernate는 `default_batch_fetch_size` 값에 따른 정적쿼리를 생성하기 때문에 Tomcat 서버를 작동하는 데에 더 오랜 시간이 소요될 수 있다.
- https://stackoverflow.com/questions/21162172/default-batch-fetch-size-recommended-values

해당 설정은 전역적으로 적용되기 때문에, N+1 문제가 발생하는 다른 쿼리들에도 적용이 되었을 것이다.
그래도 fetch join이 적용 가능한 곳에는 최대한 fetch join을 사용하자!

또 다른 자식 엔티티인 `Meal`은 fetch join을 사용하여 `MealLog` 조회 시 함께 조회되도록 하였다.
- 이 때 JPQL에 `distinct` 키워드를 붙여주어야 DB에서 조회한 레코드들을 하나의 엔티티에 중복없이 매핑할 수 있다.

**결과적으로 1+N+M 개의 조회 쿼리를 단 2개로 줄일 수 있었다.**

### 추가) 성능 테스트 결과

테스트 툴: K6
조건: 100건의 식단 기록 데이터 조회, 10VU, 1분 동안 성능 테스트 진행
결과: 평균 응답 속도 약 341% 개선 (486ms ➡️ 110ms), TPS 약 339% 개선 (20.50/s ➡️ 90.19/s)

**전**

<img width="1256" alt="image" src="https://github.com/Vegan-Life/VeganLife-Backend/assets/74900921/7fae1eb4-57e5-48cc-b933-20a73db0728b">


**후**

<img width="1254" alt="image" src="https://github.com/Vegan-Life/VeganLife-Backend/assets/74900921/5f4d625d-103a-471e-9f1b-42b0858a4627">

