### PR TITLE
회원 탈퇴시 연관된 엔티티로 인한 문제 해결

### DIFF
--- a/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
@@ -79,8 +79,4 @@ public class Comment extends TimeStamped {
     public void removeCommentLike(CommentLike commentLike) {
         likes.remove(commentLike);
     }
-
-    public void removeMember() {
-        member = null;
-    }
 }

--- a/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/Comment.java
@@ -23,7 +23,7 @@ public class Comment extends TimeStamped {
     @Column(name = "comment_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -78,5 +78,9 @@ public class Comment extends TimeStamped {
 
     public void removeCommentLike(CommentLike commentLike) {
         likes.remove(commentLike);
+    }
+
+    public void removeMember() {
+        member = null;
     }
 }

--- a/src/main/java/com/konggogi/veganlife/comment/repository/CommentRepository.java
+++ b/src/main/java/com/konggogi/veganlife/comment/repository/CommentRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findById(Long commentId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE Comment c SET c.member = NULL WHERE c.member.id = :memberId")
     void setMemberToNull(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/comment/repository/CommentRepository.java
+++ b/src/main/java/com/konggogi/veganlife/comment/repository/CommentRepository.java
@@ -4,7 +4,13 @@ package com.konggogi.veganlife.comment.repository;
 import com.konggogi.veganlife.comment.domain.Comment;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Optional<Comment> findById(Long commentId);
+
+    @Modifying
+    @Query("UPDATE Comment c SET c.member = NULL WHERE c.member.id = :memberId")
+    void setMemberToNull(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentService.java
@@ -5,6 +5,7 @@ import com.konggogi.veganlife.comment.controller.dto.request.CommentAddRequest;
 import com.konggogi.veganlife.comment.domain.Comment;
 import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
 import com.konggogi.veganlife.comment.exception.IllegalCommentException;
+import com.konggogi.veganlife.comment.repository.CommentRepository;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
@@ -23,6 +24,7 @@ public class CommentService {
     private final PostQueryService postQueryService;
     private final CommentQueryService commentQueryService;
     private final CommentNotifyService commentNotifyService;
+    private final CommentRepository commentRepository;
     private final CommentMapper commentMapper;
 
     public Comment add(Long memberId, Long postId, CommentAddRequest commentAddRequest) {
@@ -39,6 +41,10 @@ public class CommentService {
         post.addComment(comment);
         commentNotifyService.notifyAddCommentIfNotAuthor(memberId, postId);
         return comment;
+    }
+
+    public void removeMemberFromComment(Long memberId) {
+        commentRepository.setMemberToNull(memberId);
     }
 
     private Optional<Long> getParentCommentId(CommentAddRequest commentAddRequest) {

--- a/src/main/java/com/konggogi/veganlife/like/repository/CommentLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/like/repository/CommentLikeRepository.java
@@ -4,7 +4,13 @@ package com.konggogi.veganlife.like.repository;
 import com.konggogi.veganlife.like.domain.CommentLike;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
     Optional<CommentLike> findByMemberIdAndCommentId(Long memberId, Long commentId);
+
+    @Modifying
+    @Query("UPDATE CommentLike c SET c.member = NULL WHERE c.member.id = :memberId")
+    void setMemberToNull(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/like/repository/CommentLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/like/repository/CommentLikeRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
     Optional<CommentLike> findByMemberIdAndCommentId(Long memberId, Long commentId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE CommentLike c SET c.member = NULL WHERE c.member.id = :memberId")
     void setMemberToNull(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/like/repository/PostLikeRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE PostLike p SET p.member = NULL WHERE p.member.id = :memberId")
     void setMemberToNull(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/like/repository/PostLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/like/repository/PostLikeRepository.java
@@ -4,7 +4,13 @@ package com.konggogi.veganlife.like.repository;
 import com.konggogi.veganlife.like.domain.PostLike;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByMemberIdAndPostId(Long memberId, Long postId);
+
+    @Modifying
+    @Query("UPDATE PostLike p SET p.member = NULL WHERE p.member.id = :memberId")
+    void setMemberToNull(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
+++ b/src/main/java/com/konggogi/veganlife/like/service/LikeService.java
@@ -8,6 +8,8 @@ import com.konggogi.veganlife.like.domain.CommentLike;
 import com.konggogi.veganlife.like.domain.PostLike;
 import com.konggogi.veganlife.like.domain.mapper.LikeMapper;
 import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.like.repository.CommentLikeRepository;
+import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.post.domain.Post;
@@ -25,6 +27,8 @@ public class LikeService {
     private final CommentQueryService commentQueryService;
     private final LikeQueryService likeQueryService;
     private final LikeNotifyService likeNotifyService;
+    private final PostLikeRepository postLikeRepository;
+    private final CommentLikeRepository commentLikeRepository;
     private final LikeMapper likeMapper;
 
     public void addPostLike(Long memberId, Long postId) {
@@ -58,6 +62,11 @@ public class LikeService {
         Comment comment = commentQueryService.search(commentId);
         CommentLike commentLike = validateCommentLikeIsNotExist(memberId, commentId);
         comment.removeCommentLike(commentLike);
+    }
+
+    public void removeMemberFromLike(Long memberId) {
+        postLikeRepository.setMemberToNull(memberId);
+        commentLikeRepository.setMemberToNull(memberId);
     }
 
     private void validatePostLikeIsExist(Long memberId, Long postId) {

--- a/src/main/java/com/konggogi/veganlife/mealdata/repository/MealDataRepository.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/repository/MealDataRepository.java
@@ -13,4 +13,6 @@ public interface MealDataRepository extends JpaRepository<MealData, Long> {
 
     Page<MealData> findByNameContainingAndOwnerType(
             String keyword, OwnerType ownerType, Pageable pageable);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataService.java
+++ b/src/main/java/com/konggogi/veganlife/mealdata/service/MealDataService.java
@@ -24,4 +24,8 @@ public class MealDataService {
         mealDataRepository.save(
                 mealDataMapper.toEntity(request, memberQueryService.search(memberId)));
     }
+
+    public void removeAll(Long memberId) {
+        mealDataRepository.deleteAllByMemberId(memberId);
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -17,4 +17,6 @@ public interface MealLogRepository extends JpaRepository<MealLog, Long> {
     @Query(
             "select m from MealLog m where cast(m.createdAt as localdate) = :date and m.member.id = :memberId")
     List<MealLog> findAllByDate(LocalDate date, Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -56,6 +56,10 @@ public class MealLogService {
         mealLogRepository.deleteById(mealLogId);
     }
 
+    public void removeAll(Long memberId) {
+        mealLogRepository.deleteAllByMemberId(memberId);
+    }
+
     private void addMeals(List<MealAddRequest> requests, MealLog mealLog) {
         List<Meal> meals =
                 requests.stream()

--- a/src/main/java/com/konggogi/veganlife/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/konggogi/veganlife/member/repository/RefreshTokenRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findRefreshTokenByMemberId(Long memberId);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -97,6 +97,7 @@ public class MemberService {
     }
 
     private void removeRelatedData(Long memberId) {
+        refreshTokenRepository.deleteAllByMemberId(memberId);
         postService.removeMemberFromPost(memberId);
         commentService.removeMemberFromComment(memberId);
         likeService.removeMemberFromLike(memberId);

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -1,14 +1,20 @@
 package com.konggogi.veganlife.member.service;
 
 
+import com.konggogi.veganlife.comment.service.CommentService;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+import com.konggogi.veganlife.like.service.LikeService;
+import com.konggogi.veganlife.mealdata.service.MealDataService;
+import com.konggogi.veganlife.meallog.service.MealLogService;
 import com.konggogi.veganlife.member.controller.dto.request.MemberInfoRequest;
 import com.konggogi.veganlife.member.controller.dto.request.MemberProfileRequest;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.exception.DuplicatedNicknameException;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
+import com.konggogi.veganlife.notification.service.NotificationService;
+import com.konggogi.veganlife.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +25,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberQueryService memberQueryService;
+    private final NotificationService notificationService;
+    private final LikeService likeService;
+    private final PostService postService;
+    private final CommentService commentService;
+    private final MealDataService mealDataService;
+    private final MealLogService mealLogService;
     private final RefreshTokenRepository refreshTokenRepository;
 
     public Member addMember(String email) {
@@ -33,6 +45,7 @@ public class MemberService {
 
     public void removeMember(Long memberId) {
         Member member = memberQueryService.search(memberId);
+        removeRelatedData(memberId);
         memberRepository.delete(member);
     }
 
@@ -81,5 +94,14 @@ public class MemberService {
                         member -> {
                             throw new DuplicatedNicknameException(ErrorCode.DUPLICATED_NICKNAME);
                         });
+    }
+
+    private void removeRelatedData(Long memberId) {
+        postService.removeMemberFromPost(memberId);
+        commentService.removeMemberFromComment(memberId);
+        likeService.removeMemberFromLike(memberId);
+        notificationService.removeAll(memberId);
+        mealDataService.removeAll(memberId);
+        mealLogService.removeAll(memberId);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/konggogi/veganlife/notification/repository/NotificationRepository.java
@@ -13,4 +13,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Query(
             "select n from Notification n where n.member.id = :memberId and cast(n.createdAt as localdate) = :date and n.type = :type")
     Optional<Notification> findByDateAndType(Long memberId, LocalDate date, NotificationType type);
+
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/notification/service/NotificationService.java
+++ b/src/main/java/com/konggogi/veganlife/notification/service/NotificationService.java
@@ -38,6 +38,10 @@ public class NotificationService {
         return emitter;
     }
 
+    public void removeAll(Long memberId) {
+        notificationRepository.deleteAllByMemberId(memberId);
+    }
+
     public void sendNotification(Member member, NotificationType type, String message) {
         Notification notification =
                 notificationRepository.save(notificationMapper.toEntity(member, type, message));

--- a/src/main/java/com/konggogi/veganlife/post/domain/Tag.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Tag.java
@@ -17,7 +17,7 @@ public class Tag extends TimeStamped {
     @Column(name = "tag_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 10)
     private String name;
 
     @Builder

--- a/src/main/java/com/konggogi/veganlife/post/repository/PostRepository.java
+++ b/src/main/java/com/konggogi/veganlife/post/repository/PostRepository.java
@@ -3,5 +3,11 @@ package com.konggogi.veganlife.post.repository;
 
 import com.konggogi.veganlife.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
-public interface PostRepository extends JpaRepository<Post, Long> {}
+public interface PostRepository extends JpaRepository<Post, Long> {
+    @Modifying
+    @Query("UPDATE Post p SET p.member = NULL WHERE p.member.id = :memberId")
+    void setMemberToNull(Long memberId);
+}

--- a/src/main/java/com/konggogi/veganlife/post/repository/PostRepository.java
+++ b/src/main/java/com/konggogi/veganlife/post/repository/PostRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE Post p SET p.member = NULL WHERE p.member.id = :memberId")
     void setMemberToNull(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/post/service/PostService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostService.java
@@ -35,6 +35,10 @@ public class PostService {
         return postRepository.save(post);
     }
 
+    public void removeMemberFromPost(Long memberId) {
+        postRepository.setMemberToNull(memberId);
+    }
+
     private void addTags(Post post, List<String> tagNames) {
         tagNames.stream()
                 .distinct()

--- a/src/test/java/com/konggogi/veganlife/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/repository/CommentRepositoryTest.java
@@ -22,7 +22,7 @@ class CommentRepositoryTest {
     @Autowired MemberRepository memberRepository;
     @Autowired PostRepository postRepository;
     @Autowired CommentRepository commentRepository;
-    private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
+    private final Member member = MemberFixture.DEFAULT_M.get();
     private final Post post = PostFixture.CHALLENGE.get();
     private final Comment comment = CommentFixture.DEFAULT.getTopComment(member, post);
 
@@ -42,5 +42,22 @@ class CommentRepositoryTest {
         Optional<Comment> foundComment = commentRepository.findById(commentId);
         // then
         assertThat(foundComment).isPresent();
+    }
+
+    @Test
+    @DisplayName("회원이 작성한 댓글의 Member를 null로 변경")
+    void setMemberToNullTest() {
+        // given
+        Member otherMember = MemberFixture.DEFAULT_F.get();
+        memberRepository.save(otherMember);
+        Post otherPost = PostFixture.CHALLENGE.get();
+        postRepository.save(otherPost);
+        Comment otherComment = CommentFixture.DEFAULT.getTopComment(otherMember, otherPost);
+        commentRepository.save(otherComment);
+        // when
+        commentRepository.setMemberToNull(member.getId());
+        // then
+        assertThat(commentRepository.findById(comment.getId()).get().getMember()).isNull();
+        assertThat(commentRepository.findById(otherComment.getId()).get().getMember()).isNotNull();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentServiceTest.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.comment.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -13,6 +14,7 @@ import com.konggogi.veganlife.comment.domain.Comment;
 import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
 import com.konggogi.veganlife.comment.exception.IllegalCommentException;
 import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.comment.repository.CommentRepository;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.member.domain.Member;
@@ -35,6 +37,7 @@ class CommentServiceTest {
     @Mock PostQueryService postQueryService;
     @Mock CommentQueryService commentQueryService;
     @Mock CommentNotifyService commentNotifyService;
+    @Mock CommentRepository commentRepository;
     @Spy CommentMapper commentMapper;
     @InjectMocks CommentService commentService;
     private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
@@ -145,5 +148,13 @@ class CommentServiceTest {
                 .hasMessageContaining(ErrorCode.IS_NOT_PARENT_COMMENT.getDescription());
         then(commentQueryService).should().search(anyLong());
         then(postQueryService).should(never()).search(anyLong());
+    }
+
+    @Test
+    @DisplayName("회원 Id로 댓글의 Member null로 변환")
+    void removeMemberFromCommentTest() {
+        // when, then
+        assertDoesNotThrow(() -> commentService.removeMemberFromComment(member.getId()));
+        then(commentRepository).should().setMemberToNull(anyLong());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/like/repository/CommentLikeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/repository/CommentLikeRepositoryTest.java
@@ -49,4 +49,25 @@ class CommentLikeRepositoryTest {
         // then
         assertThat(foundCommentLike).isPresent();
     }
+
+    @Test
+    @DisplayName("회원의 댓글 좋아요 Member를 null로 변경")
+    void setMemberToNullTest() {
+        // given
+        Member otherMember = MemberFixture.DEFAULT_M.get();
+        memberRepository.save(otherMember);
+        Post otherPost = PostFixture.CHALLENGE.get();
+        postRepository.save(otherPost);
+        Comment otherComment = CommentFixture.DEFAULT.getTopComment(otherMember, otherPost);
+        commentRepository.save(otherComment);
+        CommentLike otherCommentLike =
+                CommentLikeFixture.DEFAULT.get(otherMember, otherPost, otherComment);
+        commentLikeRepository.save(otherCommentLike);
+        // when
+        commentLikeRepository.setMemberToNull(member.getId());
+        // then
+        assertThat(commentLikeRepository.findById(commentLike.getId()).get().getMember()).isNull();
+        assertThat(commentLikeRepository.findById(otherCommentLike.getId()).get().getMember())
+                .isNotNull();
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/like/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/repository/PostLikeRepositoryTest.java
@@ -43,4 +43,22 @@ class PostLikeRepositoryTest {
         // then
         assertThat(foundPostLike).isPresent();
     }
+
+    @Test
+    @DisplayName("회원의 게시글 좋아요 Member를 null로 변경")
+    void setMemberToNullTest() {
+        // given
+        Member otherMember = MemberFixture.DEFAULT_M.get();
+        memberRepository.save(otherMember);
+        Post otherPost = PostFixture.CHALLENGE.get();
+        postRepository.save(otherPost);
+        PostLike otherPostLike = PostLikeFixture.DEFAULT.get(otherMember, otherPost);
+        postLikeRepository.save(otherPostLike);
+        // when
+        postLikeRepository.setMemberToNull(member.getId());
+        // then
+        assertThat(postLikeRepository.findById(postLike.getId()).get().getMember()).isNull();
+        assertThat(postLikeRepository.findById(otherPostLike.getId()).get().getMember())
+                .isNotNull();
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/like/service/LikeServiceTest.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.like.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -18,6 +19,8 @@ import com.konggogi.veganlife.like.domain.mapper.LikeMapper;
 import com.konggogi.veganlife.like.exception.IllegalLikeStatusException;
 import com.konggogi.veganlife.like.fixture.CommentLikeFixture;
 import com.konggogi.veganlife.like.fixture.PostLikeFixture;
+import com.konggogi.veganlife.like.repository.CommentLikeRepository;
+import com.konggogi.veganlife.like.repository.PostLikeRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.service.MemberQueryService;
@@ -40,6 +43,8 @@ class LikeServiceTest {
     @Mock CommentQueryService commentQueryService;
     @Mock LikeQueryService likeQueryService;
     @Mock LikeNotifyService likeNotifyService;
+    @Mock PostLikeRepository postLikeRepository;
+    @Mock CommentLikeRepository commentLikeRepository;
     @Spy LikeMapper likeMapper;
     @InjectMocks LikeService likeService;
     private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
@@ -266,5 +271,14 @@ class LikeServiceTest {
         then(postQueryService).should().search(anyLong());
         then(commentQueryService).should().search(anyLong());
         then(likeQueryService).should().searchCommentLike(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("회원 Id로 좋아요의 Member null로 변환")
+    void removeMemberFromCommentTest() {
+        // when, then
+        assertDoesNotThrow(() -> likeService.removeMemberFromLike(member.getId()));
+        then(postLikeRepository).should().setMemberToNull(anyLong());
+        then(commentLikeRepository).should().setMemberToNull(anyLong());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/mealdata/repository/MealDataRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/repository/MealDataRepositoryTest.java
@@ -6,6 +6,7 @@ import com.konggogi.veganlife.mealdata.domain.MealData;
 import com.konggogi.veganlife.mealdata.domain.OwnerType;
 import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import java.util.List;
 import java.util.Objects;
@@ -24,7 +25,7 @@ public class MealDataRepositoryTest {
     @Autowired private MealDataRepository mealDataRepository;
     @Autowired private MemberRepository memberRepository;
 
-    Member member = Member.builder().email("test123@test.com").build();
+    private final Member member = MemberFixture.DEFAULT_M.get();
 
     @BeforeEach
     void setup() {
@@ -78,9 +79,28 @@ public class MealDataRepositoryTest {
     @Test
     @DisplayName("MealData 저장")
     void saveTest() {
+        // given
         MealData mealData = MealDataFixture.TOTAL_AMOUNT.get(member);
+        // when
         mealDataRepository.save(mealData);
-
+        // then
         assertThat(mealData.getId()).matches(Objects::nonNull);
+    }
+
+    @Test
+    @DisplayName("회원의 MealData 모두 삭제")
+    void deleteAllByMemberIdTest() {
+        // given
+        Member otherMember = MemberFixture.DEFAULT_F.get();
+        memberRepository.save(otherMember);
+        MealData mealData = MealDataFixture.TOTAL_AMOUNT.get(member);
+        MealData otherMealData = MealDataFixture.TOTAL_AMOUNT.get(otherMember);
+        mealDataRepository.save(mealData);
+        mealDataRepository.save(otherMealData);
+        // when
+        mealDataRepository.deleteAllByMemberId(member.getId());
+        // then
+        assertThat(mealDataRepository.findById(otherMealData.getId())).isPresent();
+        assertThat(mealDataRepository.findById(mealData.getId())).isEmpty();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/service/MealDataServiceTest.java
@@ -1,6 +1,7 @@
 package com.konggogi.veganlife.mealdata.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -14,6 +15,7 @@ import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapper;
 import com.konggogi.veganlife.mealdata.domain.mapper.MealDataMapperImpl;
 import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,7 +33,7 @@ public class MealDataServiceTest {
     @Spy MealDataMapper mealDataMapper = new MealDataMapperImpl();
     @InjectMocks MealDataService mealDataService;
 
-    Member member = Member.builder().email("test123@test.com").build();
+    private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
 
     @Test
     @DisplayName("식품 데이터를 등록")
@@ -51,5 +53,13 @@ public class MealDataServiceTest {
         assertThat(mealData.getCarbsPerUnit()).isEqualTo((double) 30 / 100);
         assertThat(mealData.getProteinPerUnit()).isEqualTo((double) 5 / 100);
         assertThat(mealData.getFatPerUnit()).isEqualTo((double) 3 / 100);
+    }
+
+    @Test
+    @DisplayName("회원 Id로 MealData 모두 삭제")
+    void removeAllTest() {
+        // when, then
+        assertDoesNotThrow(() -> mealDataService.removeAll(member.getId()));
+        then(mealDataRepository).should().deleteAllByMemberId(anyLong());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -1,6 +1,8 @@
 package com.konggogi.veganlife.meallog.service;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doNothing;
@@ -17,12 +19,7 @@ import com.konggogi.veganlife.meallog.domain.Meal;
 import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
-import com.konggogi.veganlife.meallog.domain.mapper.MealImageMapper;
-import com.konggogi.veganlife.meallog.domain.mapper.MealImageMapperImpl;
-import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
-import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapperImpl;
-import com.konggogi.veganlife.meallog.domain.mapper.MealMapper;
-import com.konggogi.veganlife.meallog.domain.mapper.MealMapperImpl;
+import com.konggogi.veganlife.meallog.domain.mapper.*;
 import com.konggogi.veganlife.meallog.fixture.MealFixture;
 import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
 import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
@@ -115,5 +112,13 @@ public class MealLogServiceTest {
         mealLogService.remove(1L);
         // then
         then(mealLogRepository).should(times(1)).deleteById(1L);
+    }
+
+    @Test
+    @DisplayName("회원 Id로 MealLog 모두 삭제")
+    void removeAllTest() {
+        // when, then
+        assertDoesNotThrow(() -> mealLogService.removeAll(member.getId()));
+        then(mealLogRepository).should().deleteAllByMemberId(anyLong());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/fixture/MemberFixture.java
+++ b/src/test/java/com/konggogi/veganlife/member/fixture/MemberFixture.java
@@ -8,7 +8,7 @@ import com.konggogi.veganlife.member.domain.VegetarianType;
 public enum MemberFixture {
     DEFAULT_F(
             "testF@test.com",
-            "비건라이프",
+            "비건라이프F",
             "https:/s3/images/image.png",
             2000,
             Gender.F,
@@ -21,7 +21,7 @@ public enum MemberFixture {
             1821),
     DEFAULT_M(
             "testM@test.com",
-            "비건라이프",
+            "비건라이프M",
             "https:/s3/images/image.png",
             1997,
             Gender.M,

--- a/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
@@ -6,12 +6,15 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.*;
 
+import com.konggogi.veganlife.comment.service.CommentService;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+import com.konggogi.veganlife.like.service.LikeService;
+import com.konggogi.veganlife.mealdata.service.MealDataService;
+import com.konggogi.veganlife.meallog.service.MealLogService;
 import com.konggogi.veganlife.member.controller.dto.request.MemberInfoRequest;
 import com.konggogi.veganlife.member.controller.dto.request.MemberProfileRequest;
 import com.konggogi.veganlife.member.domain.Gender;
@@ -21,6 +24,8 @@ import com.konggogi.veganlife.member.exception.DuplicatedNicknameException;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
+import com.konggogi.veganlife.notification.service.NotificationService;
+import com.konggogi.veganlife.post.service.PostService;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,6 +39,12 @@ class MemberServiceTest {
     @Mock MemberRepository memberRepository;
     @Mock RefreshTokenRepository refreshTokenRepository;
     @Mock MemberQueryService memberQueryService;
+    @Mock NotificationService notificationService;
+    @Mock LikeService likeService;
+    @Mock PostService postService;
+    @Mock CommentService commentService;
+    @Mock MealDataService mealDataService;
+    @Mock MealLogService mealLogService;
     @InjectMocks MemberService memberService;
     private final Member member = MemberFixture.DEFAULT_F.getOnlyEmailWithId(1L);
 
@@ -70,6 +81,13 @@ class MemberServiceTest {
         // given
         Long memberId = member.getId();
         given(memberQueryService.search(memberId)).willReturn(member);
+        doNothing().when(refreshTokenRepository).deleteAllByMemberId(anyLong());
+        doNothing().when(postService).removeMemberFromPost(anyLong());
+        doNothing().when(commentService).removeMemberFromComment(anyLong());
+        doNothing().when(likeService).removeMemberFromLike(anyLong());
+        doNothing().when(notificationService).removeAll(anyLong());
+        doNothing().when(mealDataService).removeAll(anyLong());
+        doNothing().when(mealLogService).removeAll(anyLong());
         // when
         memberService.removeMember(memberId);
         // then

--- a/src/test/java/com/konggogi/veganlife/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/notification/repository/NotificationRepositoryTest.java
@@ -44,4 +44,19 @@ class NotificationRepositoryTest {
         // then
         assertThat(foundNotification).isPresent();
     }
+
+    @Test
+    @DisplayName("회원의 Notification 모두 삭제")
+    void deleteAllByMemberIdTest() {
+        // given
+        Member otherMember = MemberFixture.DEFAULT_F.get();
+        memberRepository.save(otherMember);
+        Notification otherNotification = NotificationFixture.SSE.get(otherMember);
+        notificationRepository.save(otherNotification);
+        // when
+        notificationRepository.deleteAllByMemberId(member.getId());
+        // then
+        assertThat(notificationRepository.findById(otherNotification.getId())).isPresent();
+        assertThat(notificationRepository.findById(notification.getId())).isEmpty();
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/notification/service/NotificationServiceTest.java
@@ -113,4 +113,12 @@ class NotificationServiceTest {
                 .hasMessageContaining(ErrorCode.NOT_FOUND_EMITTER.getDescription());
         then(emitterRepository).should().findById(anyLong());
     }
+
+    @Test
+    @DisplayName("회원 Id로 Notification 모두 삭제")
+    void removeAllTest() {
+        // when, then
+        assertDoesNotThrow(() -> notificationService.removeAll(member.getId()));
+        then(notificationRepository).should().deleteAllByMemberId(anyLong());
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/repository/PostRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.konggogi.veganlife.post.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.repository.MemberRepository;
+import com.konggogi.veganlife.post.domain.Post;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class PostRepositoryTest {
+    @Autowired MemberRepository memberRepository;
+    @Autowired PostRepository postRepository;
+    private final Member member = MemberFixture.DEFAULT_M.get();
+    private final Post post =
+            Post.builder().member(member).title("title").content("content").build();
+
+    @BeforeEach
+    void setup() {
+        memberRepository.save(member);
+        postRepository.save(post);
+    }
+
+    @Test
+    @DisplayName("회원이 작성한 게시글의 Member를 null로 변경")
+    void setMemberToNullTest() {
+        // given
+        Member otherMember = MemberFixture.DEFAULT_F.get();
+        memberRepository.save(otherMember);
+        Post otherPost =
+                Post.builder().member(otherMember).title("title").content("content").build();
+        postRepository.save(otherPost);
+        // when
+        postRepository.setMemberToNull(member.getId());
+        // then
+        assertThat(postRepository.findById(post.getId()).get().getMember()).isNull();
+        assertThat(postRepository.findById(otherPost.getId()).get().getMember()).isNotNull();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/post/service/PostServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/PostServiceTest.java
@@ -2,6 +2,8 @@ package com.konggogi.veganlife.post.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -79,6 +81,14 @@ class PostServiceTest {
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
         then(memberQueryService).should().search(memberId);
+    }
+
+    @Test
+    @DisplayName("회원 Id로 Post의 Member null로 변환")
+    void removeMemberFromPostTest() {
+        // when, then
+        assertDoesNotThrow(() -> postService.removeMemberFromPost(member.getId()));
+        then(postRepository).should().setMemberToNull(anyLong());
     }
 
     private PostAddRequest createPostAddRequest() {


### PR DESCRIPTION
## 이슈 번호 (#129 )

## 요약
회원 탈퇴시 연관된 엔티티로 인한 문제 해결
Member를 참조하는 Post, Comment, PostLike, CommentLike의 member 필드를 null로 변경
Member를 참조하는 MealData, MealLog, Notification 데이터 삭제

## 트러블슈팅

### 문제 상황
```
    @Modifying
    @Query("UPDATE Comment c SET c.member = NULL WHERE c.member.id = :memberId")
    void setMemberToNull(Long memberId);
```

`@Modifying` 애노테이션은 `@Query` 애노테이션으로 작성된 INSERT, UPDATE, DELETE와 같은 쿼리에 사용됩니다. (SELECT제외)

테스트 코드
```
    @Test
    @DisplayName("회원이 작성한 댓글의 Member를 null로 변경")
    void setMemberToNullTest() {
        // given
        Member otherMember = MemberFixture.DEFAULT_F.get();
        memberRepository.save(otherMember);
        Post otherPost = PostFixture.CHALLENGE.get();
        postRepository.save(otherPost);
        Comment otherComment = CommentFixture.DEFAULT.getTopComment(otherMember, otherPost);
        commentRepository.save(otherComment);
        // when
        commentRepository.setMemberToNull(member.getId());
        // then
        assertThat(commentRepository.findById(comment.getId()).get().getMember()).isNull();
        assertThat(commentRepository.findById(otherComment.getId()).get().getMember()).isNotNull();
    }
```

다음과 같이 테스트 코드를 작성했을 때, assertThat이 실패하는 문제가 있었습니다. 

### 원인
기존 JPA를 통해 조회를 할 때 순서는 다음과 같습니다.

1차 캐시 조회 > 존재하면 반환 > 없으면 DB 접근하여 반환

하지만 `@Query`로 정의된 JPQL은 JPA처럼 영속성 컨텍스트를 거쳐 쓰기 지연SQL로 동작하는 것이 아닌, **데이터베이스에 바로 질의**하게 됩니다.

그렇게 되면, 영속성 컨텍스트의 1차 캐시와 DB의 **데이터 싱크가 맞지 않게 됩니다.**

테스트 코드에서 findById로 데이터를 가져왔지만 기존 데이터가 사용되는 이유는, **이미 같은 Id로 영속성 컨텍스트에 데이터가 존재하기 때문**에 DB에 접근하지 않고, 1차 캐시를 통해 가져오기 때문에 기존 데이터가 사용되는 것입니다. 

### 해결
`@Modifying`의 속성 중 `clearAutomatically` 라는 속성이 있습니다. 이 속성을 true로 변경하면 문제를 해결할 수 있습니다.

```
public interface CommentRepository extends JpaRepository<Comment, Long> {
    Optional<Comment> findById(Long commentId);

    @Modifying(clearAutomatically = true)
    @Query("UPDATE Comment c SET c.member = NULL WHERE c.member.id = :memberId")
    void setMemberToNull(Long memberId);
}
```

`clearAutomatically`는 `@Query`로 정의된 JPQL을 실행한 후에 자동으로 영속성 컨텍스트를 비워줍니다.

그래서 findById를 수행하게 되면 1차 캐시에 데이터가 존재하지 않기 때문에 DB 조회 쿼리를 수행하게 됩니다. 그리고 이는 다시 영속성 컨텍스트로 관리되어 최신 상태를 유지할 수 있습니다.





