### PR TITLE
게시글 상세 조회 API구현

### DIFF
--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -32,6 +32,34 @@ include::{snippets}/add-post/http-response.adoc[]
 
 include::{snippets}/add-post-not-found/http-response.adoc[]
 
+== 피드 상세 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/get-post/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/get-post/path-parameters.adoc[]
+
+==== Body
+
+include::{snippets}/get-post/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/get-post/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/get-post-not-found-member/http-response.adoc[]
+
+include::{snippets}/get-post-not-found-post/http-response.adoc[]
+
 == 피드 좋아요 API
 
 === Request

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentLikeQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentLikeQueryService.java
@@ -17,8 +17,4 @@ public class CommentLikeQueryService {
     public Optional<CommentLike> searchCommentLike(Long memberId, Long commentId) {
         return commentLikeRepository.findByMemberIdAndCommentId(memberId, commentId);
     }
-
-    public boolean isCommentLike(Long memberId, Long commentId) {
-        return searchCommentLike(memberId, commentId).isPresent();
-    }
 }

--- a/src/main/java/com/konggogi/veganlife/comment/service/CommentSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/CommentSearchService.java
@@ -27,13 +27,13 @@ public class CommentSearchService {
         postQueryService.search(postId);
         Comment foundComment = commentQueryService.searchWithMember(commentId);
 
-        boolean isLike = commentLikeQueryService.isCommentLike(memberId, commentId);
+        boolean isLike = isCommentLike(memberId, commentId);
         List<SubCommentDetailsDto> subComments = getAllSubCommentDetails(memberId, foundComment);
         return commentMapper.toCommentDetailsDto(foundComment, subComments, isLike);
     }
 
     private SubCommentDetailsDto toSubCommentDetails(Long memberId, Comment subComment) {
-        boolean isLike = commentLikeQueryService.isCommentLike(memberId, subComment.getId());
+        boolean isLike = isCommentLike(memberId, subComment.getId());
         return commentMapper.toSubCommentDetailsDto(subComment, isLike);
     }
 
@@ -41,5 +41,9 @@ public class CommentSearchService {
         return comment.getSubComments().stream()
                 .map(subComment -> toSubCommentDetails(memberId, subComment))
                 .toList();
+    }
+
+    private boolean isCommentLike(Long memberId, Long commentId) {
+        return commentLikeQueryService.searchCommentLike(memberId, commentId).isPresent();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
@@ -4,10 +4,13 @@ package com.konggogi.veganlife.post.controller;
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
 import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
 import com.konggogi.veganlife.post.controller.dto.response.PostAddResponse;
+import com.konggogi.veganlife.post.controller.dto.response.PostDetailsResponse;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.domain.mapper.PostMapper;
 import com.konggogi.veganlife.post.service.PostLikeService;
+import com.konggogi.veganlife.post.service.PostSearchService;
 import com.konggogi.veganlife.post.service.PostService;
+import com.konggogi.veganlife.post.service.dto.PostDetailsDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("api/v1/posts")
 public class PostController {
     private final PostService postService;
+    private final PostSearchService postSearchService;
     private final PostLikeService postLikeService;
     private final PostMapper postMapper;
 
@@ -29,6 +33,14 @@ public class PostController {
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         Post post = postService.add(userDetails.id(), postAddRequest);
         return ResponseEntity.ok(postMapper.toPostAddResponse(post));
+    }
+
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostDetailsResponse> getPost(
+            @PathVariable Long postId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        PostDetailsDto postDetailsDto =
+                postSearchService.searchDetailsById(userDetails.id(), postId);
+        return ResponseEntity.ok(postMapper.toPostDetailsResponse(postDetailsDto));
     }
 
     @PostMapping("/{postId}/likes")

--- a/src/main/java/com/konggogi/veganlife/post/controller/dto/response/PostDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/dto/response/PostDetailsResponse.java
@@ -1,0 +1,20 @@
+package com.konggogi.veganlife.post.controller.dto.response;
+
+
+import com.konggogi.veganlife.comment.controller.dto.response.CommentDetailsResponse;
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostDetailsResponse(
+        Long id,
+        String author,
+        VegetarianType vegetarianType,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        boolean isLike,
+        Integer likeCount,
+        List<String> imageUrls,
+        List<String> tags,
+        List<CommentDetailsResponse> comments) {}

--- a/src/main/java/com/konggogi/veganlife/post/controller/dto/response/PostDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/dto/response/PostDetailsResponse.java
@@ -15,6 +15,7 @@ public record PostDetailsResponse(
         LocalDateTime createdAt,
         boolean isLike,
         Integer likeCount,
+        Integer commentCount,
         List<String> imageUrls,
         List<String> tags,
         List<CommentDetailsResponse> comments) {}

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -74,4 +74,8 @@ public class Post extends TimeStamped {
     public void removePostLike(PostLike postLike) {
         likes.remove(postLike);
     }
+
+    public int countLikes() {
+        return likes.size();
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -78,4 +78,8 @@ public class Post extends TimeStamped {
     public int countLikes() {
         return likes.size();
     }
+
+    public int countComments() {
+        return comments.size();
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
@@ -1,6 +1,7 @@
 package com.konggogi.veganlife.post.domain.mapper;
 
 
+import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
 import com.konggogi.veganlife.comment.service.dto.CommentDetailsDto;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
@@ -15,7 +16,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = CommentMapper.class)
 public interface PostMapper {
     @Mapping(target = "id", ignore = true)
     Post toEntity(Member member, PostAddRequest postAddRequest);

--- a/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
@@ -34,6 +34,7 @@ public interface PostMapper {
     @Mapping(target = "author", source = "postDetailsDto.post.member.nickname")
     @Mapping(target = "vegetarianType", source = "postDetailsDto.post.member.vegetarianType")
     @Mapping(target = "imageUrls", source = "postDetailsDto.imageUrls")
+    @Mapping(target = "commentCount", expression = "java(postDetailsDto.post().countComments())")
     @Mapping(target = "tags", source = "postDetailsDto.tags")
     @Mapping(target = "comments", source = "postDetailsDto.comments")
     @Mapping(target = "title", source = "postDetailsDto.post.title")

--- a/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
@@ -35,7 +35,9 @@ public interface PostMapper {
     @Mapping(target = "imageUrls", source = "postDetailsDto.imageUrls")
     @Mapping(target = "tags", source = "postDetailsDto.tags")
     @Mapping(target = "comments", source = "postDetailsDto.comments")
-    @Mapping(target = ".", source = "postDetailsDto.post")
+    @Mapping(target = "title", source = "postDetailsDto.post.title")
+    @Mapping(target = "content", source = "postDetailsDto.post.content")
+    @Mapping(target = "createdAt", source = "postDetailsDto.post.createdAt")
     PostDetailsResponse toPostDetailsResponse(PostDetailsDto postDetailsDto);
 
     @Named("postImageToString")

--- a/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
@@ -1,7 +1,6 @@
 package com.konggogi.veganlife.post.domain.mapper;
 
 
-import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
 import com.konggogi.veganlife.comment.service.dto.CommentDetailsDto;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
@@ -11,12 +10,12 @@ import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.domain.PostImage;
 import com.konggogi.veganlife.post.domain.PostTag;
 import com.konggogi.veganlife.post.service.dto.PostDetailsDto;
-import java.util.Collections;
 import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
-@Mapper(componentModel = "spring", uses = CommentMapper.class)
+@Mapper(componentModel = "spring")
 public interface PostMapper {
     @Mapping(target = "id", ignore = true)
     Post toEntity(Member member, PostAddRequest postAddRequest);
@@ -27,24 +26,25 @@ public interface PostMapper {
     @Mapping(target = "post", source = "post")
     @Mapping(target = "comments", source = "comments")
     @Mapping(target = "likeCount", expression = "java(post.countLikes())")
+    @Mapping(target = "imageUrls", source = "post.imageUrls", qualifiedByName = "postImageToString")
+    @Mapping(target = "tags", source = "post.tags", qualifiedByName = "postTagsToString")
     PostDetailsDto toPostDetailsDto(Post post, List<CommentDetailsDto> comments, boolean isLike);
 
     @Mapping(target = "author", source = "postDetailsDto.post.member.nickname")
     @Mapping(target = "vegetarianType", source = "postDetailsDto.post.member.vegetarianType")
+    @Mapping(target = "imageUrls", source = "postDetailsDto.imageUrls")
+    @Mapping(target = "tags", source = "postDetailsDto.tags")
+    @Mapping(target = "comments", source = "postDetailsDto.comments")
     @Mapping(target = ".", source = "postDetailsDto.post")
     PostDetailsResponse toPostDetailsResponse(PostDetailsDto postDetailsDto);
 
-    default List<String> mapImageUrls(List<PostImage> postImages) {
-        if (postImages == null) {
-            return Collections.emptyList();
-        }
-        return postImages.stream().map(PostImage::getImageUrl).toList();
+    @Named("postImageToString")
+    static String postImageToString(PostImage postImage) {
+        return postImage.getImageUrl();
     }
 
-    default List<String> mapTags(List<PostTag> postTags) {
-        if (postTags == null) {
-            return Collections.emptyList();
-        }
-        return postTags.stream().map(postTag -> postTag.getTag().getName()).toList();
+    @Named("postTagsToString")
+    static String postTagsToString(PostTag postTag) {
+        return postTag.getTag().getName();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
@@ -1,18 +1,50 @@
 package com.konggogi.veganlife.post.domain.mapper;
 
 
+import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
+import com.konggogi.veganlife.comment.service.dto.CommentDetailsDto;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
 import com.konggogi.veganlife.post.controller.dto.response.PostAddResponse;
+import com.konggogi.veganlife.post.controller.dto.response.PostDetailsResponse;
 import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.PostImage;
+import com.konggogi.veganlife.post.domain.PostTag;
+import com.konggogi.veganlife.post.service.dto.PostDetailsDto;
+import java.util.Collections;
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = CommentMapper.class)
 public interface PostMapper {
     @Mapping(target = "id", ignore = true)
     Post toEntity(Member member, PostAddRequest postAddRequest);
 
-    @Mapping(source = "post.id", target = "postId")
+    @Mapping(target = "postId", source = "post.id")
     PostAddResponse toPostAddResponse(Post post);
+
+    @Mapping(target = "post", source = "post")
+    @Mapping(target = "comments", source = "comments")
+    @Mapping(target = "likeCount", expression = "java(post.countLikes())")
+    PostDetailsDto toPostDetailsDto(Post post, List<CommentDetailsDto> comments, boolean isLike);
+
+    @Mapping(target = "author", source = "postDetailsDto.post.member.nickname")
+    @Mapping(target = "vegetarianType", source = "postDetailsDto.post.member.vegetarianType")
+    @Mapping(target = ".", source = "postDetailsDto.post")
+    PostDetailsResponse toPostDetailsResponse(PostDetailsDto postDetailsDto);
+
+    default List<String> mapImageUrls(List<PostImage> postImages) {
+        if (postImages == null) {
+            return Collections.emptyList();
+        }
+        return postImages.stream().map(PostImage::getImageUrl).toList();
+    }
+
+    default List<String> mapTags(List<PostTag> postTags) {
+        if (postTags == null) {
+            return Collections.emptyList();
+        }
+        return postTags.stream().map(postTag -> postTag.getTag().getName()).toList();
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/post/repository/PostRepository.java
+++ b/src/main/java/com/konggogi/veganlife/post/repository/PostRepository.java
@@ -2,11 +2,15 @@ package com.konggogi.veganlife.post.repository;
 
 
 import com.konggogi.veganlife.post.domain.Post;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    @Query("select distinct p from Post p join fetch p.member " + "where p.id = :postId")
+    Optional<Post> findByIdFetchJoinMember(Long postId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Post p SET p.member = NULL WHERE p.member.id = :memberId")
     void setMemberToNull(Long memberId);

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -20,4 +20,10 @@ public class PostQueryService {
                 .findById(postId)
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_POST));
     }
+
+    public Post searchWithMember(Long postId) {
+        return postRepository
+                .findByIdFetchJoinMember(postId)
+                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_POST));
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/post/service/PostSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostSearchService.java
@@ -1,0 +1,43 @@
+package com.konggogi.veganlife.post.service;
+
+
+import com.konggogi.veganlife.comment.service.CommentSearchService;
+import com.konggogi.veganlife.comment.service.dto.CommentDetailsDto;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.mapper.PostMapper;
+import com.konggogi.veganlife.post.service.dto.PostDetailsDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostSearchService {
+    private final MemberQueryService memberQueryService;
+    private final PostQueryService postQueryService;
+    private final PostLikeQueryService postLikeQueryService;
+    private final CommentSearchService commentSearchService;
+    private final PostMapper postMapper;
+
+    public PostDetailsDto searchDetailsById(Long memberId, Long postId) {
+        memberQueryService.search(memberId);
+        Post post = postQueryService.searchWithMember(postId);
+
+        boolean isLike = postLikeQueryService.searchPostLike(memberId, postId).isPresent();
+        List<CommentDetailsDto> commentDetails = getAllCommentDetails(memberId, post);
+        return postMapper.toPostDetailsDto(post, commentDetails, isLike);
+    }
+
+    private List<CommentDetailsDto> getAllCommentDetails(Long memberId, Post post) {
+        return post.getComments().stream()
+                .filter(comment -> comment.getParent().isEmpty())
+                .map(
+                        comment ->
+                                commentSearchService.searchDetailsById(
+                                        memberId, post.getId(), comment.getId()))
+                .toList();
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/post/service/dto/PostDetailsDto.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/dto/PostDetailsDto.java
@@ -1,0 +1,15 @@
+package com.konggogi.veganlife.post.service.dto;
+
+
+import com.konggogi.veganlife.comment.service.dto.CommentDetailsDto;
+import com.konggogi.veganlife.post.domain.Post;
+import java.util.List;
+
+public record PostDetailsDto(
+        Long id,
+        Post post,
+        boolean isLike,
+        Integer likeCount,
+        List<String> imageUrls,
+        List<String> tags,
+        List<CommentDetailsDto> comments) {}

--- a/src/test/java/com/konggogi/veganlife/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/controller/CommentControllerTest.java
@@ -219,6 +219,7 @@ class CommentControllerTest extends RestDocsTest {
                 .andExpect(jsonPath("$.content").value(detailsDto.comment().getContent()))
                 .andExpect(jsonPath("$.isLike").value(detailsDto.isLike()))
                 .andExpect(jsonPath("$.likeCount").value(detailsDto.likeCount()))
+                .andExpect(jsonPath("$.createdAt").isNotEmpty())
                 .andExpect(jsonPath("$.subComments").isNotEmpty());
 
         perform.andDo(print())

--- a/src/test/java/com/konggogi/veganlife/comment/fixture/CommentFixture.java
+++ b/src/test/java/com/konggogi/veganlife/comment/fixture/CommentFixture.java
@@ -37,6 +37,7 @@ public enum CommentFixture {
                         .parentComment(parentComment)
                         .content(content)
                         .build();
+        post.addComment(comment);
         parentComment.addSubComment(comment);
         return comment;
     }
@@ -50,6 +51,7 @@ public enum CommentFixture {
                         .parentComment(parentComment)
                         .content(content)
                         .build();
+        post.addComment(comment);
         parentComment.addSubComment(comment);
         return setCreatedAt(comment);
     }

--- a/src/test/java/com/konggogi/veganlife/comment/fixture/CommentFixture.java
+++ b/src/test/java/com/konggogi/veganlife/comment/fixture/CommentFixture.java
@@ -17,12 +17,15 @@ public enum CommentFixture {
     }
 
     public Comment getTopComment(Member member, Post post) {
-        return Comment.builder().member(member).post(post).content(content).build();
+        Comment comment = Comment.builder().member(member).post(post).content(content).build();
+        post.addComment(comment);
+        return comment;
     }
 
     public Comment getTopCommentWithId(Long id, Member member, Post post) {
         Comment comment =
                 Comment.builder().id(id).member(member).post(post).content(content).build();
+        post.addComment(comment);
         return setCreatedAt(comment);
     }
 

--- a/src/test/java/com/konggogi/veganlife/comment/repository/CommentRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/repository/CommentRepositoryTest.java
@@ -65,7 +65,7 @@ class CommentRepositoryTest {
     @DisplayName("Comment Id로 댓글 및 회원 조회")
     void findByIdFetchJoinMemberTest() {
         // when
-        Optional<Comment> foundComment = commentRepository.findById(comment.getId());
+        Optional<Comment> foundComment = commentRepository.findByIdFetchJoinMember(comment.getId());
         // then
         assertThat(foundComment).isPresent();
         assertThat(foundComment.get().getMember()).isNotNull();

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentLikeQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentLikeQueryServiceTest.java
@@ -59,30 +59,4 @@ class CommentLikeQueryServiceTest {
         assertThat(foundCommentLike).isEmpty();
         then(commentLikeRepository).should().findByMemberIdAndCommentId(anyLong(), anyLong());
     }
-
-    @Test
-    @DisplayName("댓글 좋아요 여부 - 존재하는 경우")
-    void isCommentLikeTrueTest() {
-        // given
-        given(commentLikeRepository.findByMemberIdAndCommentId(anyLong(), anyLong()))
-                .willReturn(Optional.of(commentLike));
-        // when
-        boolean result = commentLikeQueryService.isCommentLike(member.getId(), comment.getId());
-        // then
-        assertThat(result).isTrue();
-        then(commentLikeRepository).should().findByMemberIdAndCommentId(anyLong(), anyLong());
-    }
-
-    @Test
-    @DisplayName("댓글 좋아요 여부 - 존재하지 않는 경우")
-    void isCommentLikeFalseTest() {
-        // given
-        given(commentLikeRepository.findByMemberIdAndCommentId(anyLong(), anyLong()))
-                .willReturn(Optional.empty());
-        // when
-        boolean result = commentLikeQueryService.isCommentLike(member.getId(), comment.getId());
-        // then
-        assertThat(result).isFalse();
-        then(commentLikeRepository).should().findByMemberIdAndCommentId(anyLong(), anyLong());
-    }
 }

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentSearchServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentSearchServiceTest.java
@@ -17,6 +17,7 @@ import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.fixture.PostFixture;
 import com.konggogi.veganlife.post.service.PostQueryService;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +49,8 @@ class CommentSearchServiceTest {
         given(memberQueryService.search(anyLong())).willReturn(member);
         given(postQueryService.search(anyLong())).willReturn(post);
         given(commentQueryService.searchWithMember(anyLong())).willReturn(comment);
-        given(commentLikeQueryService.isCommentLike(anyLong(), anyLong())).willReturn(true);
+        given(commentLikeQueryService.searchCommentLike(anyLong(), anyLong()))
+                .willReturn(Optional.of(commentLike));
         // when
         CommentDetailsDto result =
                 commentSearchService.searchDetailsById(

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -27,6 +27,7 @@ import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
 import com.konggogi.veganlife.post.fixture.PostFixture;
 import com.konggogi.veganlife.post.fixture.PostImageFixture;
 import com.konggogi.veganlife.post.service.PostLikeService;
+import com.konggogi.veganlife.post.service.PostSearchService;
 import com.konggogi.veganlife.post.service.PostService;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.springframework.test.web.servlet.ResultActions;
 class PostControllerTest extends RestDocsTest {
     @MockBean PostService postService;
     @MockBean PostLikeService postLikeService;
+    @MockBean PostSearchService postSearchService;
     private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
 
     @Test

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -154,6 +154,7 @@ class PostControllerTest extends RestDocsTest {
                                 "get-post",
                                 getDocumentRequest(),
                                 getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
                                 pathParameters(parameterWithName("postId").description("게시글 번호"))));
     }
 

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -111,6 +111,7 @@ class PostControllerTest extends RestDocsTest {
         // given
         Post post = PostFixture.CHALLENGE.getWithId(1L, member);
         Comment comment1 = CommentFixture.DEFAULT.getTopCommentWithId(1L, member, post);
+        Comment subComment = CommentFixture.DEFAULT.getSubCommentWithId(3L, member, post, comment1);
         Comment comment2 = CommentFixture.DEFAULT.getTopCommentWithId(2L, member, post);
         List<String> imageUrls =
                 List.of(
@@ -144,6 +145,7 @@ class PostControllerTest extends RestDocsTest {
                 .andExpect(jsonPath("$.createdAt").isNotEmpty())
                 .andExpect(jsonPath("$.isLike").value(postDetailsDto.isLike()))
                 .andExpect(jsonPath("$.likeCount").value(postDetailsDto.likeCount()))
+                .andExpect(jsonPath("$.commentCount").value(postDetailsDto.post().countComments()))
                 .andExpect(jsonPath("$.imageUrls").isNotEmpty())
                 .andExpect(jsonPath("$.tags").isNotEmpty())
                 .andExpect(jsonPath("$.comments").isNotEmpty());

--- a/src/test/java/com/konggogi/veganlife/post/fixture/PostFixture.java
+++ b/src/test/java/com/konggogi/veganlife/post/fixture/PostFixture.java
@@ -1,15 +1,12 @@
 package com.konggogi.veganlife.post.fixture;
 
 
-import com.konggogi.veganlife.comment.domain.Comment;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.post.domain.Post;
-import com.konggogi.veganlife.post.domain.PostLike;
 import com.konggogi.veganlife.post.domain.PostTag;
 import com.konggogi.veganlife.post.domain.Tag;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.util.ReflectionUtils;
 
 public enum PostFixture {
@@ -36,14 +33,6 @@ public enum PostFixture {
         post.addPostTag(postTag);
         post.addPostImage(PostImageFixture.DEFAULT.getPostImage());
         return setCreatedAt(post);
-    }
-
-    public Post getPostAllInfoWithId(
-            Long id, Member member, List<PostLike> postLikes, List<Comment> comments) {
-        Post post = getWithId(id, member);
-        postLikes.forEach(post::addPostLike);
-        comments.forEach(post::addComment);
-        return post;
     }
 
     private Post setCreatedAt(Post post) {

--- a/src/test/java/com/konggogi/veganlife/post/fixture/PostLikeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/post/fixture/PostLikeFixture.java
@@ -11,10 +11,14 @@ public enum PostLikeFixture {
     PostLikeFixture() {}
 
     public PostLike get(Member member, Post post) {
-        return PostLike.builder().member(member).post(post).build();
+        PostLike postLike = PostLike.builder().member(member).post(post).build();
+        post.addPostLike(postLike);
+        return postLike;
     }
 
     public PostLike getWithId(Long id, Member member, Post post) {
-        return PostLike.builder().id(id).member(member).post(post).build();
+        PostLike postLike = PostLike.builder().id(id).member(member).post(post).build();
+        post.addPostLike(postLike);
+        return postLike;
     }
 }

--- a/src/test/java/com/konggogi/veganlife/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/repository/PostRepositoryTest.java
@@ -6,6 +6,7 @@ import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.post.domain.Post;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,5 +41,15 @@ class PostRepositoryTest {
         // then
         assertThat(postRepository.findById(post.getId()).get().getMember()).isNull();
         assertThat(postRepository.findById(otherPost.getId()).get().getMember()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Post Id로 게시글 및 회원 조회")
+    void findByIdFetchJoinMemberTest() {
+        // when
+        Optional<Post> foundPost = postRepository.findByIdFetchJoinMember(post.getId());
+        // then
+        assertThat(foundPost).isPresent();
+        assertThat(foundPost.get().getMember()).isNotNull();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
@@ -51,4 +51,29 @@ class PostQueryServiceTest {
                 .hasMessageContaining(ErrorCode.NOT_FOUND_POST.getDescription());
         then(postRepository).should().findById(anyLong());
     }
+
+    @Test
+    @DisplayName("게시글 번호로 게시글, 회원 조회")
+    void searchWithMemberTest() {
+        // given
+        given(postRepository.findByIdFetchJoinMember(anyLong())).willReturn(Optional.of(post));
+        // when
+        Post foundPost = postQueryService.searchWithMember(anyLong());
+        // then
+        assertThat(foundPost).isEqualTo(post);
+        then(postRepository).should().findById(anyLong());
+        assertThat(foundPost.getMember()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("없는 게시글 번호로 게시글 조회시 예외 발생")
+    void searchWithMemberNotFoundPostTest() {
+        // given
+        given(postRepository.findByIdFetchJoinMember(anyLong())).willReturn(Optional.empty());
+        // when, then
+        assertThatThrownBy(() -> postQueryService.searchWithMember(anyLong()))
+                .isInstanceOf(NotFoundEntityException.class)
+                .hasMessageContaining(ErrorCode.NOT_FOUND_POST.getDescription());
+        then(postRepository).should().findById(anyLong());
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
@@ -61,7 +61,7 @@ class PostQueryServiceTest {
         Post foundPost = postQueryService.searchWithMember(anyLong());
         // then
         assertThat(foundPost).isEqualTo(post);
-        then(postRepository).should().findById(anyLong());
+        then(postRepository).should().findByIdFetchJoinMember(anyLong());
         assertThat(foundPost.getMember()).isNotNull();
     }
 
@@ -74,6 +74,6 @@ class PostQueryServiceTest {
         assertThatThrownBy(() -> postQueryService.searchWithMember(anyLong()))
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_POST.getDescription());
-        then(postRepository).should().findById(anyLong());
+        then(postRepository).should().findByIdFetchJoinMember(anyLong());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/post/service/PostSearchServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/PostSearchServiceTest.java
@@ -1,0 +1,62 @@
+package com.konggogi.veganlife.post.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.comment.service.CommentSearchService;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.PostLike;
+import com.konggogi.veganlife.post.domain.mapper.PostMapper;
+import com.konggogi.veganlife.post.domain.mapper.PostMapperImpl;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import com.konggogi.veganlife.post.fixture.PostLikeFixture;
+import com.konggogi.veganlife.post.service.dto.PostDetailsDto;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PostSearchServiceTest {
+    @Mock MemberQueryService memberQueryService;
+    @Mock PostQueryService postQueryService;
+    @Mock PostLikeQueryService postLikeQueryService;
+    @Mock CommentSearchService commentSearchService;
+    @Spy PostMapper postMapper = new PostMapperImpl();
+    @InjectMocks PostSearchService postSearchService;
+
+    private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
+    private final Post post = PostFixture.CHALLENGE.getWithId(1L, member);
+    private final Comment comment = CommentFixture.DEFAULT.getTopCommentWithId(1L, member, post);
+    private final PostLike postLike = PostLikeFixture.DEFAULT.get(member, post);
+
+    @Test
+    @DisplayName("게시글 상세 조회")
+    void searchDetailsByIdTest() {
+        // given
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(postQueryService.searchWithMember(anyLong())).willReturn(post);
+        given(postLikeQueryService.searchPostLike(anyLong(), anyLong()))
+                .willReturn(Optional.of(postLike));
+        // when
+        PostDetailsDto result = postSearchService.searchDetailsById(member.getId(), post.getId());
+        // then
+        assertThat(result.id()).isEqualTo(post.getId());
+        assertThat(result.post()).isEqualTo(post);
+        assertThat(result.isLike()).isTrue();
+        assertThat(result.likeCount()).isEqualTo(1);
+        assertThat(result.imageUrls()).hasSize(1);
+        assertThat(result.tags()).hasSize(1);
+        assertThat(result.comments()).hasSize(1);
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#208 )

## 요약
게시글 상세 조회 기능 구현 - `PostSearchService` - `postDetailsById`
게시글 상세 조회 API 구현
관련 기능 테스트
`PostMapper`에 `List<PostImage>`, `List<PostTag>` 를 `List<String>`으로 변환하는 디폴트 메서드 구현
(`default` 키워드와 `mapXx` 메서드 명으로 `PostMapperImpl` 생성 시, 해당 로직을 자동으로 사용하게 됩니다.)
-> 이 부분은 `qualifuedByName`을 사용하면 더 간단해질 것 같네요. (변경 완료)

`PostMapper`에서 `target`과 이름이 같음에도 불구하고 제대로 매핑 되지 않는 경우 `@Mapping`을 통해 수동 설정해주었습니다.

## 변경 내용
게시글 상세 조회에 기존 `CommentLikeQuerySerivce`의 `isCommentLike`가 사용되지 않아 삭제
`CommentSearchService`에서 `isCommetLike`를 구현
변경 사항으로 인한 테스트 수정
