### PR TITLE
레시피 목록 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/recipe.adoc
+++ b/src/docs/asciidoc/recipe.adoc
@@ -1,0 +1,31 @@
+= Recipe API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+== 레시피 목록 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/recipe-get-recipe-list/request-headers.adoc[]
+
+==== Parameter
+
+include::{snippets}/recipe-get-recipe-list/query-parameters.adoc[]
+
+include::{snippets}/recipe-get-recipe-list/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/recipe-get-recipe-list/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/member/domain/VegetarianType.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/VegetarianType.java
@@ -8,7 +8,8 @@ public enum VegetarianType {
     VEGAN,
     LACTO,
     OVO,
-    LACTO_OVO;
+    LACTO_OVO,
+    PESCO;
 
     @JsonCreator
     public static VegetarianType parsing(String input) {

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
@@ -1,0 +1,29 @@
+package com.konggogi.veganlife.recipe.controller;
+
+
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
+import com.konggogi.veganlife.recipe.service.RecipeSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/recipes")
+public class RecipeController {
+
+    private final RecipeSearchService recipeSearchService;
+
+    @GetMapping
+    public ResponseEntity<Page<RecipeListResponse>> getRecipeList(
+            VegetarianType vegetarianType, Pageable pageable) {
+
+        Page<RecipeListResponse> page = recipeSearchService.searchAll(vegetarianType, pageable);
+        return ResponseEntity.ok(page);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
@@ -23,7 +23,6 @@ public class RecipeController {
     public ResponseEntity<Page<RecipeListResponse>> getRecipeList(
             VegetarianType vegetarianType, Pageable pageable) {
 
-        Page<RecipeListResponse> page = recipeSearchService.searchAll(vegetarianType, pageable);
-        return ResponseEntity.ok(page);
+        return ResponseEntity.ok(recipeSearchService.searchAll(vegetarianType, pageable));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeListResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeListResponse.java
@@ -1,0 +1,8 @@
+package com.konggogi.veganlife.recipe.controller.dto.response;
+
+
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import java.util.List;
+
+public record RecipeListResponse(
+        Long id, String name, String thumbnailUrl, List<VegetarianType> recipeTypes) {}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
@@ -1,0 +1,104 @@
+package com.konggogi.veganlife.recipe.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Recipe extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RecipeType> recipeTypes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RecipeImage> recipeImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RecipeIngredient> ingredients = new ArrayList<>();
+
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RecipeDescription> descriptions = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public Recipe(Long id, String name, Member member) {
+        this.id = id;
+        this.name = name;
+        this.member = member;
+    }
+
+    public String getThumbnailUrl() {
+
+        if (recipeImages.isEmpty()) {
+            return null;
+        }
+        return recipeImages.get(0).getImageUrl();
+    }
+
+    public List<VegetarianType> getRecipeTypes() {
+
+        return recipeTypes.stream().map(RecipeType::getVegetarianType).toList();
+    }
+
+    public void update(
+            List<RecipeType> recipeTypes,
+            List<RecipeImage> recipeImages,
+            List<RecipeIngredient> ingredients,
+            List<RecipeDescription> descriptions) {
+
+        updateRecipeTypes(recipeTypes);
+        updateRecipeImages(recipeImages);
+        updateIngredients(ingredients);
+        updateDescriptions(descriptions);
+    }
+
+    private void updateRecipeTypes(List<RecipeType> recipeTypes) {
+        this.recipeTypes.clear();
+        this.recipeTypes.addAll(recipeTypes);
+    }
+
+    private void updateRecipeImages(List<RecipeImage> recipeImages) {
+        this.recipeImages.clear();
+        this.recipeImages.addAll(recipeImages);
+    }
+
+    private void updateIngredients(List<RecipeIngredient> ingredients) {
+        this.ingredients.clear();
+        this.ingredients.addAll(ingredients);
+    }
+
+    private void updateDescriptions(List<RecipeDescription> descriptions) {
+        this.descriptions.clear();
+        this.descriptions.addAll(descriptions);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeDescription.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeDescription.java
@@ -1,0 +1,45 @@
+package com.konggogi.veganlife.recipe.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecipeDescription extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_description_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private Integer sequence;
+
+    @Column(nullable = false)
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    @Builder
+    public RecipeDescription(Long id, Integer sequence, String description, Recipe recipe) {
+        this.id = id;
+        this.sequence = sequence;
+        this.description = description;
+        this.recipe = recipe;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeImage.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeImage.java
@@ -1,0 +1,39 @@
+package com.konggogi.veganlife.recipe.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecipeImage extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_image_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    public RecipeImage(Long id, String imageUrl, Recipe recipe) {
+        this.id = id;
+        this.imageUrl = imageUrl;
+        this.recipe = recipe;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeIngredient.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeIngredient.java
@@ -1,0 +1,49 @@
+package com.konggogi.veganlife.recipe.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecipeIngredient extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_ingredient_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Column(nullable = false)
+    private String unit;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    @Builder
+    public RecipeIngredient(Long id, String name, Integer amount, String unit, Recipe recipe) {
+        this.id = id;
+        this.name = name;
+        this.amount = amount;
+        this.unit = unit;
+        this.recipe = recipe;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeType.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeType.java
@@ -1,0 +1,43 @@
+package com.konggogi.veganlife.recipe.domain;
+
+
+import com.konggogi.veganlife.global.domain.TimeStamped;
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecipeType extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_type_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VegetarianType vegetarianType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    public RecipeType(Long id, VegetarianType vegetarianType, Recipe recipe) {
+        this.id = id;
+        this.vegetarianType = vegetarianType;
+        this.recipe = recipe;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
@@ -1,0 +1,15 @@
+package com.konggogi.veganlife.recipe.domain.mapper;
+
+
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface RecipeMapper {
+
+    @Mapping(target = "thumbnailUrl", expression = "java(recipe.getThumbnailUrl())")
+    @Mapping(target = "recipeTypes", expression = "java(recipe.getRecipeTypes())")
+    RecipeListResponse toRecipeListResponse(Recipe recipe);
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/repository/RecipeRepository.java
@@ -1,0 +1,21 @@
+package com.konggogi.veganlife.recipe.repository;
+
+
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeRepository extends JpaRepository<Recipe, Long> {
+
+    /** parameter로 들어온 vegeterianType이 null이라면 전체 레코드를 조회한다. */
+    @Query(
+            "select r from Recipe r where exists"
+                    + " (select t from r.recipeTypes t"
+                    + " where (t.vegetarianType = :vegetarianType or :vegetarianType is null))")
+    Page<Recipe> findAllByRecipeTypes(VegetarianType vegetarianType, Pageable pageable);
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeQueryService.java
@@ -1,0 +1,24 @@
+package com.konggogi.veganlife.recipe.service;
+
+
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.repository.RecipeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecipeQueryService {
+
+    private final RecipeRepository recipeRepository;
+
+    public Page<Recipe> searchAllByRecipeType(VegetarianType vegetarianType, Pageable pageable) {
+
+        return recipeRepository.findAllByRecipeTypes(vegetarianType, pageable);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
@@ -1,0 +1,27 @@
+package com.konggogi.veganlife.recipe.service;
+
+
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
+import com.konggogi.veganlife.recipe.domain.mapper.RecipeMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecipeSearchService {
+
+    private final RecipeQueryService recipeQueryService;
+    private final RecipeMapper recipeMapper;
+
+    public Page<RecipeListResponse> searchAll(VegetarianType vegetarianType, Pageable pageable) {
+
+        return recipeQueryService
+                .searchAllByRecipeType(vegetarianType, pageable)
+                .map(recipeMapper::toRecipeListResponse);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeControllerTest.java
@@ -1,0 +1,129 @@
+package com.konggogi.veganlife.recipe.controller;
+
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeDescription;
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
+import com.konggogi.veganlife.recipe.domain.mapper.RecipeMapper;
+import com.konggogi.veganlife.recipe.domain.mapper.RecipeMapperImpl;
+import com.konggogi.veganlife.recipe.fixture.RecipeDescriptionFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeImageFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeIngredientsFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeTypeFixture;
+import com.konggogi.veganlife.recipe.service.RecipeSearchService;
+import com.konggogi.veganlife.support.docs.RestDocsTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Spy;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(RecipeController.class)
+public class RecipeControllerTest extends RestDocsTest {
+
+    @MockBean RecipeSearchService recipeSearchService;
+    @Spy RecipeMapper recipeMapper = new RecipeMapperImpl();
+
+    private final Member member = MemberFixture.DEFAULT_M.get();
+
+    @Test
+    @DisplayName("레시피 목록 조회 API")
+    void getRecipeList() throws Exception {
+
+        List<RecipeListResponse> recipe =
+                List.of(
+                        recipeMapper.toRecipeListResponse(
+                                createRecipe(1L, "표고버섯 탕수", RecipeTypeFixture.LACTO.get())),
+                        recipeMapper.toRecipeListResponse(
+                                createRecipe(2L, "가지 탕수", RecipeTypeFixture.LACTO.get())),
+                        recipeMapper.toRecipeListResponse(
+                                createRecipe(3L, "통밀 츄러스", RecipeTypeFixture.LACTO.get())));
+        Page<RecipeListResponse> response =
+                PageableExecutionUtils.getPage(recipe, Pageable.ofSize(20), recipe::size);
+
+        given(recipeSearchService.searchAll(any(VegetarianType.class), any(Pageable.class)))
+                .willReturn(response);
+
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/api/v1/recipes")
+                                .headers(authorizationHeader())
+                                .queryParam("vegetarianType", VegetarianType.LACTO.name())
+                                .queryParam("page", "0")
+                                .queryParam("size", "20"));
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(3))
+                .andExpect(jsonPath("$.content.[0].id").value(1L))
+                .andExpect(jsonPath("$.content.[0].name").value("표고버섯 탕수"))
+                .andExpect(
+                        jsonPath("$.content.[0].thumbnailUrl").value(recipe.get(0).thumbnailUrl()))
+                .andExpect(jsonPath("$.content.[0].recipeTypes.size()").value(1))
+                .andExpect(
+                        jsonPath("$.content.[0].recipeTypes[0]")
+                                .value(VegetarianType.LACTO.name()));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "recipe-get-recipe-list",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                queryParameters(
+                                        parameterWithName("vegetarianType")
+                                                .description("레시피 채식 타입"),
+                                        pageDesc(),
+                                        sizeDesc())));
+    }
+
+    private Recipe createRecipe(Long id, String name, RecipeType recipeType) {
+
+        List<RecipeType> recipeTypes = List.of(recipeType);
+
+        List<RecipeImage> recipeImages =
+                List.of(
+                        RecipeImageFixture.DEFAULT.get(),
+                        RecipeImageFixture.DEFAULT.get(),
+                        RecipeImageFixture.DEFAULT.get());
+
+        List<RecipeIngredient> ingredients =
+                List.of(
+                        RecipeIngredientsFixture.DEFAULT.get(),
+                        RecipeIngredientsFixture.DEFAULT.get(),
+                        RecipeIngredientsFixture.DEFAULT.get());
+
+        List<RecipeDescription> descriptions =
+                List.of(
+                        RecipeDescriptionFixture.DEFAULT.get(),
+                        RecipeDescriptionFixture.DEFAULT.get(),
+                        RecipeDescriptionFixture.DEFAULT.get());
+
+        return RecipeFixture.DEFAULT.getWithName(
+                id, name, recipeTypes, recipeImages, ingredients, descriptions, member);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeDescriptionFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeDescriptionFixture.java
@@ -1,0 +1,30 @@
+package com.konggogi.veganlife.recipe.fixture;
+
+
+import com.konggogi.veganlife.recipe.domain.RecipeDescription;
+
+public enum RecipeDescriptionFixture {
+    DEFAULT(1, "표고버섯을 먹기 좋은 크기로 자릅니다.");
+
+    private Integer sequence;
+    private String description;
+
+    RecipeDescriptionFixture(Integer sequence, String description) {
+        this.sequence = sequence;
+        this.description = description;
+    }
+
+    public RecipeDescription get() {
+
+        return RecipeDescription.builder().sequence(sequence).description(description).build();
+    }
+
+    public RecipeDescription get(Long id) {
+
+        return RecipeDescription.builder()
+                .id(id)
+                .sequence(sequence)
+                .description(description)
+                .build();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeFixture.java
@@ -1,0 +1,122 @@
+package com.konggogi.veganlife.recipe.fixture;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeDescription;
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.springframework.util.ReflectionUtils;
+
+public enum RecipeFixture {
+    DEFAULT("표고버섯 탕수육");
+
+    private String name;
+
+    RecipeFixture(String name) {
+        this.name = name;
+    }
+
+    public Recipe get(
+            List<RecipeType> recipeTypes,
+            List<RecipeImage> recipeImages,
+            List<RecipeIngredient> ingredients,
+            List<RecipeDescription> descriptions,
+            Member member) {
+
+        Recipe recipe = Recipe.builder().name(name).member(member).build();
+
+        recipeTypes.forEach(recipeType -> setRecipe(recipeType, recipe));
+        recipeImages.forEach(recipeImage -> setRecipe(recipeImage, recipe));
+        ingredients.forEach(ingredient -> setRecipe(ingredient, recipe));
+        descriptions.forEach(description -> setRecipe(description, recipe));
+        recipe.update(recipeTypes, recipeImages, ingredients, descriptions);
+
+        return recipe;
+    }
+
+    public Recipe get(
+            Long id,
+            List<RecipeType> recipeTypes,
+            List<RecipeImage> recipeImages,
+            List<RecipeIngredient> ingredients,
+            List<RecipeDescription> descriptions,
+            Member member) {
+
+        Recipe recipe = Recipe.builder().id(id).name(name).member(member).build();
+
+        recipeTypes.forEach(recipeType -> setRecipe(recipeType, recipe));
+        recipeImages.forEach(recipeImage -> setRecipe(recipeImage, recipe));
+        ingredients.forEach(ingredient -> setRecipe(ingredient, recipe));
+        descriptions.forEach(description -> setRecipe(description, recipe));
+        recipe.update(recipeTypes, recipeImages, ingredients, descriptions);
+
+        return recipe;
+    }
+
+    public Recipe getWithName(
+            String name,
+            List<RecipeType> recipeTypes,
+            List<RecipeImage> recipeImages,
+            List<RecipeIngredient> ingredients,
+            List<RecipeDescription> descriptions,
+            Member member) {
+
+        Recipe recipe = Recipe.builder().name(name).member(member).build();
+
+        recipeTypes.forEach(recipeType -> setRecipe(recipeType, recipe));
+        recipeImages.forEach(recipeImage -> setRecipe(recipeImage, recipe));
+        ingredients.forEach(ingredient -> setRecipe(ingredient, recipe));
+        descriptions.forEach(description -> setRecipe(description, recipe));
+        recipe.update(recipeTypes, recipeImages, ingredients, descriptions);
+
+        return recipe;
+    }
+
+    public Recipe getWithName(
+            Long id,
+            String name,
+            List<RecipeType> recipeTypes,
+            List<RecipeImage> recipeImages,
+            List<RecipeIngredient> ingredients,
+            List<RecipeDescription> descriptions,
+            Member member) {
+
+        Recipe recipe = Recipe.builder().id(id).name(name).member(member).build();
+
+        recipeTypes.forEach(recipeType -> setRecipe(recipeType, recipe));
+        recipeImages.forEach(recipeImage -> setRecipe(recipeImage, recipe));
+        ingredients.forEach(ingredient -> setRecipe(ingredient, recipe));
+        descriptions.forEach(description -> setRecipe(description, recipe));
+        recipe.update(recipeTypes, recipeImages, ingredients, descriptions);
+
+        return recipe;
+    }
+
+    private void setRecipe(RecipeType recipeType, Recipe recipe) {
+        Field recipeField = ReflectionUtils.findField(RecipeType.class, "recipe");
+        ReflectionUtils.makeAccessible(recipeField);
+        ReflectionUtils.setField(recipeField, recipeType, recipe);
+    }
+
+    private void setRecipe(RecipeImage recipeImage, Recipe recipe) {
+        Field recipeField = ReflectionUtils.findField(RecipeImage.class, "recipe");
+        ReflectionUtils.makeAccessible(recipeField);
+        ReflectionUtils.setField(recipeField, recipeImage, recipe);
+    }
+
+    private void setRecipe(RecipeIngredient ingredient, Recipe recipe) {
+        Field recipeField = ReflectionUtils.findField(RecipeIngredient.class, "recipe");
+        ReflectionUtils.makeAccessible(recipeField);
+        ReflectionUtils.setField(recipeField, ingredient, recipe);
+    }
+
+    private void setRecipe(RecipeDescription description, Recipe recipe) {
+        Field recipeField = ReflectionUtils.findField(RecipeDescription.class, "recipe");
+        ReflectionUtils.makeAccessible(recipeField);
+        ReflectionUtils.setField(recipeField, description, recipe);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeImageFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeImageFixture.java
@@ -1,0 +1,24 @@
+package com.konggogi.veganlife.recipe.fixture;
+
+
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+
+public enum RecipeImageFixture {
+    DEFAULT("/image1.png");
+
+    private String imageUrl;
+
+    RecipeImageFixture(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public RecipeImage get() {
+
+        return new RecipeImage(null, imageUrl, null);
+    }
+
+    public RecipeImage get(Long id) {
+
+        return new RecipeImage(id, imageUrl, null);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeIngredientsFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeIngredientsFixture.java
@@ -1,0 +1,28 @@
+package com.konggogi.veganlife.recipe.fixture;
+
+
+import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
+
+public enum RecipeIngredientsFixture {
+    DEFAULT("올리브유", 1, "tbsp");
+
+    private String name;
+    private Integer amount;
+    private String unit;
+
+    RecipeIngredientsFixture(String name, Integer amount, String unit) {
+        this.name = name;
+        this.amount = amount;
+        this.unit = unit;
+    }
+
+    public RecipeIngredient get() {
+
+        return RecipeIngredient.builder().name(name).amount(amount).unit(unit).build();
+    }
+
+    public RecipeIngredient get(Long id) {
+
+        return RecipeIngredient.builder().id(id).name(name).amount(amount).unit(unit).build();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeTypeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeTypeFixture.java
@@ -1,0 +1,29 @@
+package com.konggogi.veganlife.recipe.fixture;
+
+
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
+
+public enum RecipeTypeFixture {
+    OVO(VegetarianType.OVO),
+    LACTO(VegetarianType.LACTO),
+    LACTO_OVO(VegetarianType.LACTO_OVO),
+    VEGAN(VegetarianType.VEGAN),
+    PESCO(VegetarianType.PESCO);
+
+    private VegetarianType vegetarianType;
+
+    RecipeTypeFixture(VegetarianType vegetarianType) {
+        this.vegetarianType = vegetarianType;
+    }
+
+    public RecipeType get() {
+
+        return new RecipeType(null, vegetarianType, null);
+    }
+
+    public RecipeType get(Long id) {
+
+        return new RecipeType(id, vegetarianType, null);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/repository/RecipeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/repository/RecipeRepositoryTest.java
@@ -1,0 +1,112 @@
+package com.konggogi.veganlife.recipe.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.repository.MemberRepository;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeDescription;
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
+import com.konggogi.veganlife.recipe.fixture.RecipeDescriptionFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeImageFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeIngredientsFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeTypeFixture;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@DataJpaTest
+@EnableJpaAuditing(setDates = false)
+public class RecipeRepositoryTest {
+
+    @Autowired RecipeRepository recipeRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired EntityManager em;
+
+    private final Member member = MemberFixture.DEFAULT_M.get();
+
+    @BeforeEach
+    void setup() {
+        memberRepository.save(member);
+    }
+
+    @Test
+    @DisplayName("VegetarianType에 해당하는 Recipe 레코드 목록을 조회한다.")
+    void findAllByRecipeTypesTest() {
+
+        List<RecipeType> recipeTypes1 =
+                List.of(RecipeTypeFixture.OVO.get(), RecipeTypeFixture.LACTO.get());
+        Recipe recipe1 = createRecipe(recipeTypes1);
+        recipeRepository.save(recipe1);
+
+        List<RecipeType> recipeTypes2 = List.of(RecipeTypeFixture.OVO.get());
+        Recipe recipe2 = createRecipe(recipeTypes2);
+        recipeRepository.save(recipe2);
+
+        Pageable pageable = Pageable.ofSize(20);
+        Page<Recipe> recipes1 = recipeRepository.findAllByRecipeTypes(VegetarianType.OVO, pageable);
+        Page<Recipe> recipes2 =
+                recipeRepository.findAllByRecipeTypes(VegetarianType.LACTO, pageable);
+
+        assertThat(recipes1.getNumberOfElements()).isEqualTo(2);
+        assertThat(recipes2.getNumberOfElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("VegetarianType이 null이라면 전체 Recipe 레코드 목록을 조회한다.")
+    void findAllIfVegetarianTypeTest() {
+
+        List<RecipeType> recipeTypes1 =
+                List.of(RecipeTypeFixture.OVO.get(), RecipeTypeFixture.LACTO.get());
+        Recipe recipe1 = createRecipe(recipeTypes1);
+        recipeRepository.save(recipe1);
+
+        List<RecipeType> recipeTypes2 = List.of(RecipeTypeFixture.OVO.get());
+        Recipe recipe2 = createRecipe(recipeTypes2);
+        recipeRepository.save(recipe2);
+
+        Pageable pageable = Pageable.ofSize(20);
+        Page<Recipe> recipes = recipeRepository.findAllByRecipeTypes(null, pageable);
+
+        assertThat(recipes.getNumberOfElements()).isEqualTo(2);
+    }
+
+    private Recipe createRecipe(List<RecipeType> recipeType) {
+
+        List<RecipeType> recipeTypes = new ArrayList<>(recipeType);
+
+        List<RecipeImage> recipeImages =
+                List.of(
+                        RecipeImageFixture.DEFAULT.get(),
+                        RecipeImageFixture.DEFAULT.get(),
+                        RecipeImageFixture.DEFAULT.get());
+
+        List<RecipeIngredient> ingredients =
+                List.of(
+                        RecipeIngredientsFixture.DEFAULT.get(),
+                        RecipeIngredientsFixture.DEFAULT.get(),
+                        RecipeIngredientsFixture.DEFAULT.get());
+
+        List<RecipeDescription> descriptions =
+                List.of(
+                        RecipeDescriptionFixture.DEFAULT.get(),
+                        RecipeDescriptionFixture.DEFAULT.get(),
+                        RecipeDescriptionFixture.DEFAULT.get());
+
+        return RecipeFixture.DEFAULT.get(
+                recipeTypes, recipeImages, ingredients, descriptions, member);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/service/RecipeSearchServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/service/RecipeSearchServiceTest.java
@@ -1,0 +1,99 @@
+package com.konggogi.veganlife.recipe.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeDescription;
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
+import com.konggogi.veganlife.recipe.domain.mapper.RecipeMapper;
+import com.konggogi.veganlife.recipe.domain.mapper.RecipeMapperImpl;
+import com.konggogi.veganlife.recipe.fixture.RecipeDescriptionFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeImageFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeIngredientsFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeTypeFixture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@ExtendWith(MockitoExtension.class)
+public class RecipeSearchServiceTest {
+
+    @Mock RecipeQueryService recipeQueryService;
+    @Spy RecipeMapper recipeMapper = new RecipeMapperImpl();
+    @InjectMocks RecipeSearchService recipeSearchService;
+
+    private final Member member = MemberFixture.DEFAULT_M.get();
+
+    @Test
+    @DisplayName("레시피 목록 조회 테스트 - response dto로 변환하여 반환한다.")
+    void searchAllTest() {
+
+        List<Recipe> recipes =
+                List.of(
+                        createRecipe(1L, "표고버섯 탕수", RecipeTypeFixture.OVO.get()),
+                        createRecipe(2L, "가지 탕수", RecipeTypeFixture.OVO.get()));
+        Page<Recipe> result =
+                PageableExecutionUtils.getPage(recipes, Pageable.ofSize(20), recipes::size);
+
+        given(
+                        recipeQueryService.searchAllByRecipeType(
+                                any(VegetarianType.class), any(Pageable.class)))
+                .willReturn(result);
+
+        Page<RecipeListResponse> response =
+                recipeSearchService.searchAll(VegetarianType.OVO, Pageable.ofSize(20));
+
+        assertThat(response.getNumberOfElements()).isEqualTo(2);
+        assertThat(response.getContent().get(0).thumbnailUrl())
+                .isEqualTo(recipes.get(0).getThumbnailUrl());
+        assertThat(response.getContent().get(1).thumbnailUrl())
+                .isEqualTo(recipes.get(1).getThumbnailUrl());
+        assertThat(response.getContent().get(0).recipeTypes())
+                .containsAll(recipes.get(0).getRecipeTypes());
+        assertThat(response.getContent().get(1).recipeTypes())
+                .containsAll(recipes.get(1).getRecipeTypes());
+    }
+
+    private Recipe createRecipe(Long id, String name, RecipeType recipeType) {
+
+        List<RecipeType> recipeTypes = List.of(recipeType);
+
+        List<RecipeImage> recipeImages =
+                List.of(
+                        RecipeImageFixture.DEFAULT.get(),
+                        RecipeImageFixture.DEFAULT.get(),
+                        RecipeImageFixture.DEFAULT.get());
+
+        List<RecipeIngredient> ingredients =
+                List.of(
+                        RecipeIngredientsFixture.DEFAULT.get(),
+                        RecipeIngredientsFixture.DEFAULT.get(),
+                        RecipeIngredientsFixture.DEFAULT.get());
+
+        List<RecipeDescription> descriptions =
+                List.of(
+                        RecipeDescriptionFixture.DEFAULT.get(),
+                        RecipeDescriptionFixture.DEFAULT.get(),
+                        RecipeDescriptionFixture.DEFAULT.get());
+
+        return RecipeFixture.DEFAULT.getWithName(
+                id, name, recipeTypes, recipeImages, ingredients, descriptions, member);
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#198)

## 요약
- `Recipe` 엔티티와 이와 연관된 `RecipeType`, `RecipeImage`, `RecipeIngredients`, `RecipeDescription` 엔티티를 구현하였습니다.
- `VegetarianType` 기반의 `Recipe` 목록 조회 기능을 구현하였습니다.
- `VegetarianType` 기반의 `Recipe` 목록 조회 기능을 테스트하였습니다.
- API를 문서화하였습니다.

## 변경 내용
`VegetarianType` enum에 `PESCO` 추가