### PR TITLE
게시글 수정 API 구현 및 테스트

### DIFF
--- a/src/docs/asciidoc/post.adoc
+++ b/src/docs/asciidoc/post.adoc
@@ -82,6 +82,34 @@ include::{snippets}/all-post/http-request.adoc[]
 
 include::{snippets}/all-post/http-response.adoc[]
 
+== 피드 수정 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/modify-post/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/modify-post/path-parameters.adoc[]
+
+==== Body
+
+include::{snippets}/modify-post/http-request.adoc[]
+
+=== Response
+
+==== 201 CREATED
+
+include::{snippets}/modify-post/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/modify-post-not-found-member/http-response.adoc[]
+
+include::{snippets}/modify-post-not-found-post/http-response.adoc[]
+
 == 인기 태그 조회 API
 
 === Request

--- a/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
@@ -2,7 +2,7 @@ package com.konggogi.veganlife.post.controller;
 
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
-import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
+import com.konggogi.veganlife.post.controller.dto.request.PostFormRequest;
 import com.konggogi.veganlife.post.controller.dto.response.PopularTagsResponse;
 import com.konggogi.veganlife.post.controller.dto.response.PostAddResponse;
 import com.konggogi.veganlife.post.controller.dto.response.PostDetailsResponse;
@@ -37,9 +37,9 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<PostAddResponse> addPost(
-            @RequestBody @Valid PostAddRequest postAddRequest,
+            @RequestBody @Valid PostFormRequest postFormRequest,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        Post post = postService.add(userDetails.id(), postAddRequest);
+        Post post = postService.add(userDetails.id(), postFormRequest);
         return ResponseEntity.ok(postMapper.toPostAddResponse(post));
     }
 
@@ -61,9 +61,9 @@ public class PostController {
     @PutMapping("/{postId}")
     public ResponseEntity<Void> modifyPost(
             @PathVariable Long postId,
-            @RequestBody PostAddRequest postAddRequest,
+            @RequestBody PostFormRequest postFormRequest,
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        postService.modify(userDetails.id(), postId, postAddRequest);
+        postService.modify(userDetails.id(), postId, postFormRequest);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/PostController.java
@@ -58,6 +58,15 @@ public class PostController {
         return ResponseEntity.ok(postSimpleResponsePage);
     }
 
+    @PutMapping("/{postId}")
+    public ResponseEntity<Void> modifyPost(
+            @PathVariable Long postId,
+            @RequestBody PostAddRequest postAddRequest,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        postService.modify(userDetails.id(), postId, postAddRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
     @GetMapping("/tags")
     public ResponseEntity<PopularTagsResponse> getPopularTags() {
         List<Tag> topTags = postQueryService.searchPopularTags();

--- a/src/main/java/com/konggogi/veganlife/post/controller/dto/request/PostFormRequest.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/dto/request/PostFormRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 import org.hibernate.validator.constraints.Length;
 
-public record PostAddRequest(
+public record PostFormRequest(
         @NotBlank @Length(min = 1, max = 20) String title,
         @NotBlank @Length(min = 1, max = 1000) String content,
         @Size(max = 5) List<String> imageUrls,

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -82,4 +82,22 @@ public class Post extends TimeStamped {
     public int countComments() {
         return comments.size();
     }
+
+    public void update(
+            String title, String content, List<PostImage> imageUrls, List<PostTag> tags) {
+        this.title = title;
+        this.content = content;
+        updateImageUrls(imageUrls);
+        updateTags(tags);
+    }
+
+    private void updateImageUrls(List<PostImage> imageUrls) {
+        this.imageUrls.clear();
+        imageUrls.forEach(this::addPostImage);
+    }
+
+    private void updateTags(List<PostTag> tags) {
+        this.tags.clear();
+        tags.forEach(this::addPostTag);
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
@@ -4,7 +4,7 @@ package com.konggogi.veganlife.post.domain.mapper;
 import com.konggogi.veganlife.comment.domain.mapper.CommentMapper;
 import com.konggogi.veganlife.comment.service.dto.CommentDetailsDto;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
+import com.konggogi.veganlife.post.controller.dto.request.PostFormRequest;
 import com.konggogi.veganlife.post.controller.dto.response.PopularTagsResponse;
 import com.konggogi.veganlife.post.controller.dto.response.PostAddResponse;
 import com.konggogi.veganlife.post.controller.dto.response.PostDetailsResponse;
@@ -23,7 +23,7 @@ import org.mapstruct.Named;
 @Mapper(componentModel = "spring", uses = CommentMapper.class)
 public interface PostMapper {
     @Mapping(target = "id", ignore = true)
-    Post toEntity(Member member, PostAddRequest postAddRequest);
+    Post toEntity(Member member, PostFormRequest postFormRequest);
 
     @Mapping(target = "postId", source = "post.id")
     PostAddResponse toPostAddResponse(Post post);

--- a/src/main/java/com/konggogi/veganlife/post/service/PostService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostService.java
@@ -3,7 +3,7 @@ package com.konggogi.veganlife.post.service;
 
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
-import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
+import com.konggogi.veganlife.post.controller.dto.request.PostFormRequest;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.domain.PostImage;
 import com.konggogi.veganlife.post.domain.PostTag;
@@ -30,11 +30,11 @@ public class PostService {
     private final TagMapper tagMapper;
     private final PostImageMapper postImageMapper;
 
-    public Post add(Long memberId, PostAddRequest postAddRequest) {
+    public Post add(Long memberId, PostFormRequest postFormRequest) {
         Member member = memberQueryService.search(memberId);
-        Post post = postMapper.toEntity(member, postAddRequest);
-        mapToPostTag(postAddRequest.tags()).forEach(post::addPostTag);
-        mapToPostImage(postAddRequest.imageUrls()).forEach(post::addPostImage);
+        Post post = postMapper.toEntity(member, postFormRequest);
+        mapToPostTag(postFormRequest.tags()).forEach(post::addPostTag);
+        mapToPostImage(postFormRequest.imageUrls()).forEach(post::addPostImage);
         return postRepository.save(post);
     }
 
@@ -42,12 +42,12 @@ public class PostService {
         postRepository.setMemberToNull(memberId);
     }
 
-    public void modify(Long memberId, Long postId, PostAddRequest postAddRequest) {
+    public void modify(Long memberId, Long postId, PostFormRequest postFormRequest) {
         memberQueryService.search(memberId);
         Post post = postQueryService.search(postId);
-        List<PostImage> postImages = mapToPostImage(postAddRequest.imageUrls());
-        List<PostTag> tags = mapToPostTag(postAddRequest.tags());
-        post.update(postAddRequest.title(), postAddRequest.content(), postImages, tags);
+        List<PostImage> postImages = mapToPostImage(postFormRequest.imageUrls());
+        List<PostTag> tags = mapToPostTag(postFormRequest.tags());
+        post.update(postFormRequest.title(), postFormRequest.content(), postImages, tags);
     }
 
     private List<PostTag> mapToPostTag(List<String> tagNames) {

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -243,6 +243,90 @@ class PostControllerTest extends RestDocsTest {
     }
 
     @Test
+    @DisplayName("게시글 수정 API")
+    void modifyPostTest() throws Exception {
+        // then
+        Post post = PostFixture.BAKERY.get();
+        List<String> imageUrls =
+                List.of(
+                        PostImageFixture.DEFAULT.getImageUrl(),
+                        PostImageFixture.DEFAULT.getImageUrl());
+        List<String> tags = List.of("신사동", "맛집", "비건");
+        PostFormRequest request =
+                new PostFormRequest(post.getTitle(), post.getContent(), imageUrls, tags);
+        doNothing().when(postService).modify(anyLong(), anyLong(), any(PostFormRequest.class));
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        put("/api/v1/posts/{postId}", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isCreated());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "modify-post",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("postId").description("게시글 번호"))));
+    }
+
+    @Test
+    @DisplayName("게시글 수정 API - 없는 회원 예외 발생")
+    void modifyPostNotFoundMemberTest() throws Exception {
+        // then
+        Post post = PostFixture.BAKERY.get();
+        List<String> imageUrls = List.of(PostImageFixture.DEFAULT.getImageUrl());
+        List<String> tags = List.of("신사동", "맛집", "비건");
+        PostFormRequest request =
+                new PostFormRequest(post.getTitle(), post.getContent(), imageUrls, tags);
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
+                .when(postService)
+                .modify(anyLong(), anyLong(), any(PostFormRequest.class));
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        put("/api/v1/posts/{postId}", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("modify-post-not-found-member", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("게시글 수정 API - 없는 게시글 예외 발생")
+    void modifyPostNotFoundPostTest() throws Exception {
+        // then
+        Post post = PostFixture.BAKERY.get();
+        List<String> imageUrls = List.of(PostImageFixture.DEFAULT.getImageUrl());
+        List<String> tags = List.of("신사동", "맛집", "비건");
+        PostFormRequest request =
+                new PostFormRequest(post.getTitle(), post.getContent(), imageUrls, tags);
+        doThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_POST))
+                .when(postService)
+                .modify(anyLong(), anyLong(), any(PostFormRequest.class));
+        // when
+        ResultActions perform =
+                mockMvc.perform(
+                        put("/api/v1/posts/{postId}", 1L)
+                                .headers(authorizationHeader())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJson(request)));
+        // then
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print()).andDo(document("modify-post-not-found-post", getDocumentResponse()));
+    }
+
+    @Test
     @DisplayName("인기 태그 조회 API")
     void getPopularTagsTest() throws Exception {
         // given

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -22,7 +22,7 @@ import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
-import com.konggogi.veganlife.post.controller.dto.request.PostAddRequest;
+import com.konggogi.veganlife.post.controller.dto.request.PostFormRequest;
 import com.konggogi.veganlife.post.domain.Post;
 import com.konggogi.veganlife.post.domain.Tag;
 import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
@@ -65,9 +65,9 @@ class PostControllerTest extends RestDocsTest {
         Post post = PostFixture.BAKERY.getWithId(1L, member);
         List<String> imageUrls = List.of(PostImageFixture.DEFAULT.getImageUrl());
         List<String> tags = List.of("#맛집");
-        PostAddRequest request =
-                new PostAddRequest(post.getTitle(), post.getContent(), imageUrls, tags);
-        given(postService.add(anyLong(), any(PostAddRequest.class))).willReturn(post);
+        PostFormRequest request =
+                new PostFormRequest(post.getTitle(), post.getContent(), imageUrls, tags);
+        given(postService.add(anyLong(), any(PostFormRequest.class))).willReturn(post);
         // when
         ResultActions perform =
                 mockMvc.perform(
@@ -96,9 +96,9 @@ class PostControllerTest extends RestDocsTest {
         Post post = PostFixture.BAKERY.getWithId(1L, member);
         List<String> imageUrls = List.of(PostImageFixture.DEFAULT.getImageUrl());
         List<String> tags = List.of("#맛집");
-        PostAddRequest request =
-                new PostAddRequest(post.getTitle(), post.getContent(), imageUrls, tags);
-        given(postService.add(anyLong(), any(PostAddRequest.class)))
+        PostFormRequest request =
+                new PostFormRequest(post.getTitle(), post.getContent(), imageUrls, tags);
+        given(postService.add(anyLong(), any(PostFormRequest.class)))
                 .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
         // when
         ResultActions perform =


### PR DESCRIPTION
## 이슈 번호 (#218 )

## 요약
게시글 수정 기능 구현
게시글 수정 API 구현
관련 기능 테스트

## 변경 내용
재 사용성을 위해 기존 `addTags`와 `addImages` 메서드를 리팩토링하여 `mapToPostTag`, `mapToPostImage`로 변경
