### PR TITLE
레시피 상세 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/recipe.adoc
+++ b/src/docs/asciidoc/recipe.adoc
@@ -29,3 +29,28 @@ include::{snippets}/recipe-get-recipe-list/http-request.adoc[]
 ==== 200 OK
 
 include::{snippets}/recipe-get-recipe-list/http-response.adoc[]
+
+== 레시피 상세 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/recipe-get-recipe-details/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/recipe-get-recipe-details/path-parameters.adoc[]
+
+include::{snippets}/recipe-get-recipe-details/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/recipe-get-recipe-details/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/recipe-get-recipe-details-not-found/http-response.adoc[]
+

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -54,7 +54,10 @@ public enum ErrorCode {
 
     // comment-like
     ALREADY_COMMENT_LIKED("COMMENT_LIKE_001", "좋아요가 되어 있는 댓글입니다."),
-    ALREADY_COMMENT_UNLIKED("COMMENT_LIKE_002", "좋아요가 되어 있지 않은 댓글입니다.");
+    ALREADY_COMMENT_UNLIKED("COMMENT_LIKE_002", "좋아요가 되어 있지 않은 댓글입니다."),
+
+    // recipe
+    NOT_FOUND_RECIPE("RECIPE_001", "레시피를 찾을 수 없습니다.");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.recipe.controller;
 
 
 import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeDetailsResponse;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
 import com.konggogi.veganlife.recipe.service.RecipeSearchService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,5 +26,11 @@ public class RecipeController {
             VegetarianType vegetarianType, Pageable pageable) {
 
         return ResponseEntity.ok(recipeSearchService.searchAll(vegetarianType, pageable));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<RecipeDetailsResponse> getRecipeDetails(@PathVariable Long id) {
+
+        return ResponseEntity.ok(recipeSearchService.search(id));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDescriptionDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDescriptionDetailsResponse.java
@@ -1,4 +1,0 @@
-package com.konggogi.veganlife.recipe.controller.dto.response;
-
-public record RecipeDescriptionDetailsResponse(Integer sequence,
-                                               String description) {}

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDescriptionDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDescriptionDetailsResponse.java
@@ -1,0 +1,4 @@
+package com.konggogi.veganlife.recipe.controller.dto.response;
+
+public record RecipeDescriptionDetailsResponse(Integer sequence,
+                                               String description) {}

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDetailsResponse.java
@@ -1,11 +1,13 @@
 package com.konggogi.veganlife.recipe.controller.dto.response;
 
+
 import com.konggogi.veganlife.member.domain.VegetarianType;
 import java.util.List;
 
-public record RecipeDetailsResponse(boolean isLiked,
-                                    String name,
-                                    List<VegetarianType> recipeTypes,
-                                    List<String> imageUrls,
-                                    List<String> ingredients,
-                                    List<RecipeDescriptionDetailsResponse> descriptions) {}
+public record RecipeDetailsResponse(
+        boolean isLiked,
+        String name,
+        List<VegetarianType> recipeTypes,
+        List<String> imageUrls,
+        List<String> ingredients,
+        List<String> descriptions) {}

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDetailsResponse.java
@@ -1,0 +1,11 @@
+package com.konggogi.veganlife.recipe.controller.dto.response;
+
+import com.konggogi.veganlife.member.domain.VegetarianType;
+import java.util.List;
+
+public record RecipeDetailsResponse(boolean isLiked,
+                                    String name,
+                                    List<VegetarianType> recipeTypes,
+                                    List<String> imageUrls,
+                                    List<String> ingredients,
+                                    List<RecipeDescriptionDetailsResponse> descriptions) {}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -42,6 +43,7 @@ public class Recipe extends TimeStamped {
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecipeIngredient> ingredients = new ArrayList<>();
 
+    @OrderBy("sequence")
     @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecipeDescription> descriptions = new ArrayList<>();
 

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
@@ -3,7 +3,6 @@ package com.konggogi.veganlife.recipe.domain;
 
 import com.konggogi.veganlife.global.domain.TimeStamped;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.domain.VegetarianType;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -57,17 +56,12 @@ public class Recipe extends TimeStamped {
         this.member = member;
     }
 
-    public String getThumbnailUrl() {
+    public RecipeImage getThumbnailUrl() {
 
         if (recipeImages.isEmpty()) {
             return null;
         }
-        return recipeImages.get(0).getImageUrl();
-    }
-
-    public List<VegetarianType> getRecipeTypes() {
-
-        return recipeTypes.stream().map(RecipeType::getVegetarianType).toList();
+        return recipeImages.get(0);
     }
 
     public void update(

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeIngredient.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeIngredient.java
@@ -28,22 +28,14 @@ public class RecipeIngredient extends TimeStamped {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
-    private Integer amount;
-
-    @Column(nullable = false)
-    private String unit;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "recipe_id")
     private Recipe recipe;
 
     @Builder
-    public RecipeIngredient(Long id, String name, Integer amount, String unit, Recipe recipe) {
+    public RecipeIngredient(Long id, String name, Recipe recipe) {
         this.id = id;
         this.name = name;
-        this.amount = amount;
-        this.unit = unit;
         this.recipe = recipe;
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
@@ -1,15 +1,35 @@
 package com.konggogi.veganlife.recipe.domain.mapper;
 
 
+import com.konggogi.veganlife.member.domain.VegetarianType;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
 import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
 public interface RecipeMapper {
 
-    @Mapping(target = "thumbnailUrl", expression = "java(recipe.getThumbnailUrl())")
-    @Mapping(target = "recipeTypes", expression = "java(recipe.getRecipeTypes())")
+    @Mapping(
+            target = "thumbnailUrl",
+            expression = "java(RecipeMapper.recipeImageToImageUrl(recipe.getThumbnailUrl()))")
+    @Mapping(
+            source = "recipe.recipeTypes",
+            target = "recipeTypes",
+            qualifiedByName = "recipeTypeToVegetarianType")
     RecipeListResponse toRecipeListResponse(Recipe recipe);
+
+    static String recipeImageToImageUrl(RecipeImage recipeImage) {
+
+        return recipeImage.getImageUrl();
+    }
+
+    @Named("recipeTypeToVegetarianType")
+    static VegetarianType recipeTypeToVegetarianType(RecipeType recipeType) {
+
+        return recipeType.getVegetarianType();
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
@@ -2,7 +2,6 @@ package com.konggogi.veganlife.recipe.domain.mapper;
 
 
 import com.konggogi.veganlife.member.domain.VegetarianType;
-import com.konggogi.veganlife.recipe.controller.dto.response.RecipeDescriptionDetailsResponse;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeDetailsResponse;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
 import com.konggogi.veganlife.recipe.domain.Recipe;
@@ -27,13 +26,22 @@ public interface RecipeMapper {
             qualifiedByName = "recipeTypeToVegetarianType")
     RecipeListResponse toRecipeListResponse(Recipe recipe);
 
-
     @Mapping(
             source = "recipe.recipeTypes",
             target = "recipeTypes",
             qualifiedByName = "recipeTypeToVegetarianType")
-    @Mapping(source = "recipe.recipeImages", target = "imageUrls", qualifiedByName = "recipeImageToImageUrl")
-    @Mapping(source = "recipe.ingredients", target = "ingredients", qualifiedByName = "recipeIngredientsToString")
+    @Mapping(
+            source = "recipe.recipeImages",
+            target = "imageUrls",
+            qualifiedByName = "recipeImageToImageUrl")
+    @Mapping(
+            source = "recipe.ingredients",
+            target = "ingredients",
+            qualifiedByName = "recipeIngredientToString")
+    @Mapping(
+            source = "recipe.descriptions",
+            target = "descriptions",
+            qualifiedByName = "recipeDescriptionToString")
     RecipeDetailsResponse toRecipeDetailsResponse(Recipe recipe, boolean isLiked);
 
     @Named("recipeImageToImageUrl")
@@ -48,9 +56,15 @@ public interface RecipeMapper {
         return recipeType.getVegetarianType();
     }
 
-    @Named("recipeIngredientsToString")
-    static String recipeIngredientsToString(RecipeIngredient ingredient) {
+    @Named("recipeIngredientToString")
+    static String recipeIngredientToString(RecipeIngredient ingredient) {
 
         return ingredient.getName();
+    }
+
+    @Named("recipeDescriptionToString")
+    static String recipeDescriptionToString(RecipeDescription description) {
+
+        return description.getDescription();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
@@ -2,9 +2,13 @@ package com.konggogi.veganlife.recipe.domain.mapper;
 
 
 import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeDescriptionDetailsResponse;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeDetailsResponse;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
 import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeDescription;
 import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
 import com.konggogi.veganlife.recipe.domain.RecipeType;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -14,14 +18,25 @@ import org.mapstruct.Named;
 public interface RecipeMapper {
 
     @Mapping(
+            source = "recipe.thumbnailUrl",
             target = "thumbnailUrl",
-            expression = "java(RecipeMapper.recipeImageToImageUrl(recipe.getThumbnailUrl()))")
+            qualifiedByName = "recipeImageToImageUrl")
     @Mapping(
             source = "recipe.recipeTypes",
             target = "recipeTypes",
             qualifiedByName = "recipeTypeToVegetarianType")
     RecipeListResponse toRecipeListResponse(Recipe recipe);
 
+
+    @Mapping(
+            source = "recipe.recipeTypes",
+            target = "recipeTypes",
+            qualifiedByName = "recipeTypeToVegetarianType")
+    @Mapping(source = "recipe.recipeImages", target = "imageUrls", qualifiedByName = "recipeImageToImageUrl")
+    @Mapping(source = "recipe.ingredients", target = "ingredients", qualifiedByName = "recipeIngredientsToString")
+    RecipeDetailsResponse toRecipeDetailsResponse(Recipe recipe, boolean isLiked);
+
+    @Named("recipeImageToImageUrl")
     static String recipeImageToImageUrl(RecipeImage recipeImage) {
 
         return recipeImage.getImageUrl();
@@ -31,5 +46,11 @@ public interface RecipeMapper {
     static VegetarianType recipeTypeToVegetarianType(RecipeType recipeType) {
 
         return recipeType.getVegetarianType();
+    }
+
+    @Named("recipeIngredientsToString")
+    static String recipeIngredientsToString(RecipeIngredient ingredient) {
+
+        return ingredient.getName();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeQueryService.java
@@ -26,7 +26,8 @@ public class RecipeQueryService {
 
     public Recipe search(Long id) {
 
-        return recipeRepository.findById(id)
+        return recipeRepository
+                .findById(id)
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_RECIPE));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeQueryService.java
@@ -1,6 +1,8 @@
 package com.konggogi.veganlife.recipe.service;
 
 
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.member.domain.VegetarianType;
 import com.konggogi.veganlife.recipe.domain.Recipe;
 import com.konggogi.veganlife.recipe.repository.RecipeRepository;
@@ -20,5 +22,11 @@ public class RecipeQueryService {
     public Page<Recipe> searchAllByRecipeType(VegetarianType vegetarianType, Pageable pageable) {
 
         return recipeRepository.findAllByRecipeTypes(vegetarianType, pageable);
+    }
+
+    public Recipe search(Long id) {
+
+        return recipeRepository.findById(id)
+                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_RECIPE));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.recipe.service;
 
 
 import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeDetailsResponse;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
 import com.konggogi.veganlife.recipe.domain.mapper.RecipeMapper;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,11 @@ public class RecipeSearchService {
         return recipeQueryService
                 .searchAllByRecipeType(vegetarianType, pageable)
                 .map(recipeMapper::toRecipeListResponse);
+    }
+
+    public RecipeDetailsResponse search(Long id) {
+
+        // TODO: 사용자가 좋아요를 눌렀는지 확인하는 로직 추가
+        return recipeMapper.toRecipeDetailsResponse(recipeQueryService.search(id), false);
     }
 }

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeDescriptionFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeDescriptionFixture.java
@@ -27,4 +27,9 @@ public enum RecipeDescriptionFixture {
                 .description(description)
                 .build();
     }
+
+    public RecipeDescription getWithDesc(Integer sequence, String description) {
+
+        return RecipeDescription.builder().sequence(sequence).description(description).build();
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeIngredientFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeIngredientFixture.java
@@ -3,12 +3,12 @@ package com.konggogi.veganlife.recipe.fixture;
 
 import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
 
-public enum RecipeIngredientsFixture {
+public enum RecipeIngredientFixture {
     DEFAULT("올리브유 1 tbsp");
 
     private String name;
 
-    RecipeIngredientsFixture(String name) {
+    RecipeIngredientFixture(String name) {
         this.name = name;
     }
 
@@ -20,5 +20,10 @@ public enum RecipeIngredientsFixture {
     public RecipeIngredient get(Long id) {
 
         return RecipeIngredient.builder().id(id).name(name).build();
+    }
+
+    public RecipeIngredient getWithName(String name) {
+
+        return RecipeIngredient.builder().name(name).build();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeIngredientsFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeIngredientsFixture.java
@@ -4,25 +4,21 @@ package com.konggogi.veganlife.recipe.fixture;
 import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
 
 public enum RecipeIngredientsFixture {
-    DEFAULT("올리브유", 1, "tbsp");
+    DEFAULT("올리브유 1 tbsp");
 
     private String name;
-    private Integer amount;
-    private String unit;
 
-    RecipeIngredientsFixture(String name, Integer amount, String unit) {
+    RecipeIngredientsFixture(String name) {
         this.name = name;
-        this.amount = amount;
-        this.unit = unit;
     }
 
     public RecipeIngredient get() {
 
-        return RecipeIngredient.builder().name(name).amount(amount).unit(unit).build();
+        return RecipeIngredient.builder().name(name).build();
     }
 
     public RecipeIngredient get(Long id) {
 
-        return RecipeIngredient.builder().id(id).name(name).amount(amount).unit(unit).build();
+        return RecipeIngredient.builder().id(id).name(name).build();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/recipe/repository/RecipeRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/repository/RecipeRepositoryTest.java
@@ -14,7 +14,7 @@ import com.konggogi.veganlife.recipe.domain.RecipeType;
 import com.konggogi.veganlife.recipe.fixture.RecipeDescriptionFixture;
 import com.konggogi.veganlife.recipe.fixture.RecipeFixture;
 import com.konggogi.veganlife.recipe.fixture.RecipeImageFixture;
-import com.konggogi.veganlife.recipe.fixture.RecipeIngredientsFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeIngredientFixture;
 import com.konggogi.veganlife.recipe.fixture.RecipeTypeFixture;
 import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
@@ -84,6 +84,21 @@ public class RecipeRepositoryTest {
         assertThat(recipes.getNumberOfElements()).isEqualTo(2);
     }
 
+    @Test
+    @DisplayName("id 기반으로 Recipe 레코드를 조회한다. - RecipeDescription은 sequence로 정렬된다.")
+    void findByIdTest() {
+
+        Recipe recipe = createRecipe(List.of(RecipeTypeFixture.OVO.get()));
+        recipeRepository.save(recipe);
+        em.clear();
+
+        Recipe found = recipeRepository.findById(recipe.getId()).get();
+
+        assertThat(found.getDescriptions().get(0).getSequence()).isEqualTo(1);
+        assertThat(found.getDescriptions().get(1).getSequence()).isEqualTo(2);
+        assertThat(found.getDescriptions().get(2).getSequence()).isEqualTo(3);
+    }
+
     private Recipe createRecipe(List<RecipeType> recipeType) {
 
         List<RecipeType> recipeTypes = new ArrayList<>(recipeType);
@@ -96,15 +111,15 @@ public class RecipeRepositoryTest {
 
         List<RecipeIngredient> ingredients =
                 List.of(
-                        RecipeIngredientsFixture.DEFAULT.get(),
-                        RecipeIngredientsFixture.DEFAULT.get(),
-                        RecipeIngredientsFixture.DEFAULT.get());
+                        RecipeIngredientFixture.DEFAULT.get(),
+                        RecipeIngredientFixture.DEFAULT.get(),
+                        RecipeIngredientFixture.DEFAULT.get());
 
         List<RecipeDescription> descriptions =
                 List.of(
-                        RecipeDescriptionFixture.DEFAULT.get(),
-                        RecipeDescriptionFixture.DEFAULT.get(),
-                        RecipeDescriptionFixture.DEFAULT.get());
+                        RecipeDescriptionFixture.DEFAULT.getWithDesc(2, "표고버섯을 튀긴다."),
+                        RecipeDescriptionFixture.DEFAULT.getWithDesc(1, "표고버섯을 먹기 좋은 크기로 썬다."),
+                        RecipeDescriptionFixture.DEFAULT.getWithDesc(3, "탕수육 소스와 버무린다."));
 
         return RecipeFixture.DEFAULT.get(
                 recipeTypes, recipeImages, ingredients, descriptions, member);

--- a/src/test/java/com/konggogi/veganlife/recipe/service/RecipeSearchServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/service/RecipeSearchServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.VegetarianType;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeDetailsResponse;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeListResponse;
 import com.konggogi.veganlife.recipe.domain.Recipe;
 import com.konggogi.veganlife.recipe.domain.RecipeDescription;
@@ -62,14 +63,15 @@ public class RecipeSearchServiceTest {
 
         assertThat(response.getNumberOfElements()).isEqualTo(2);
         assertThat(response.getContent().get(0).thumbnailUrl())
-                .isEqualTo(recipes.get(0).getThumbnailUrl());
+                .isEqualTo(recipes.get(0).getThumbnailUrl().getImageUrl());
         assertThat(response.getContent().get(1).thumbnailUrl())
-                .isEqualTo(recipes.get(1).getThumbnailUrl());
+                .isEqualTo(recipes.get(1).getThumbnailUrl().getImageUrl());
         assertThat(response.getContent().get(0).recipeTypes())
-                .containsAll(recipes.get(0).getRecipeTypes());
+                .containsAll(recipes.get(0).getRecipeTypes().stream().map(RecipeType::getVegetarianType).toList());
         assertThat(response.getContent().get(1).recipeTypes())
-                .containsAll(recipes.get(1).getRecipeTypes());
+                .containsAll(recipes.get(0).getRecipeTypes().stream().map(RecipeType::getVegetarianType).toList());
     }
+
 
     private Recipe createRecipe(Long id, String name, RecipeType recipeType) {
 


### PR DESCRIPTION
## 이슈 번호 (#211 )

## 요약
-  Recipe 상세 조회 기능을 구현하였습니다.
  - `@OrderBy` 어노테이션을 통해 자식 엔티티를 정렬하여 가져오도록 하였습니다.
-  Recipe 상세 조회 기능을 테스트하였습니다.
-  테스트한 API를 문서화하였습니다.

