### PR TITLE
내가 쓴 댓글의 피드 조회 API 구현 및 테스트

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -242,3 +242,29 @@ include::{snippets}/get-my-post/http-response.adoc[]
 ==== 404 NOT FOUND
 
 include::{snippets}/get-my-post-not-found-member/http-response.adoc[]
+
+== 내가 쓴 댓글의 피드 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/get-post-containing-my-comments/request-headers.adoc[]
+
+==== Path Variable
+
+include::{snippets}/get-post-containing-my-comments/query-parameters.adoc[]
+
+==== Body
+
+include::{snippets}/get-post-containing-my-comments/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/get-post-containing-my-comments/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/get-post-containing-my-comments-not-found-member/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/comment/domain/mapper/CommentMapper.java
+++ b/src/main/java/com/konggogi/veganlife/comment/domain/mapper/CommentMapper.java
@@ -32,6 +32,7 @@ public interface CommentMapper {
     CommentDetailsDto toCommentDetailsDto(
             Comment comment, List<SubCommentDetailsDto> subComments, boolean isLike);
 
+    @Mapping(target = "id", source = "commentDetailsDto.comment.id")
     @Mapping(target = "author", source = "commentDetailsDto.comment.member.nickname")
     @Mapping(target = "content", source = "commentDetailsDto.comment.content")
     @Mapping(target = "createdAt", source = "commentDetailsDto.comment.createdAt")

--- a/src/main/java/com/konggogi/veganlife/comment/service/dto/CommentDetailsDto.java
+++ b/src/main/java/com/konggogi/veganlife/comment/service/dto/CommentDetailsDto.java
@@ -5,7 +5,6 @@ import com.konggogi.veganlife.comment.domain.Comment;
 import java.util.List;
 
 public record CommentDetailsDto(
-        Long id,
         Comment comment,
         boolean isLike,
         Integer likeCount,

--- a/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
@@ -130,4 +130,14 @@ public class MemberController {
                         .map(postMapper::toPostSimpleResponse);
         return ResponseEntity.ok(postSimpleResponses);
     }
+
+    @GetMapping("/me/posts-with-comments")
+    public ResponseEntity<Page<PostSimpleResponse>> getPostListContainingMyComment(
+            Pageable pageable, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        Page<PostSimpleResponse> postSimpleResponses =
+                postSearchService
+                        .searchByMemberComments(userDetails.id(), pageable)
+                        .map(postMapper::toPostSimpleResponse);
+        return ResponseEntity.ok(postSimpleResponses);
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/post/repository/PostRepository.java
+++ b/src/main/java/com/konggogi/veganlife/post/repository/PostRepository.java
@@ -27,4 +27,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findByKeyword(String keyword, Pageable pageable);
 
     Page<Post> findAllByMemberId(Long memberId, Pageable pageable);
+
+    @Query("select distinct p from Post p join p.comments c where c.member.id = :memberId")
+    Page<Post> findByMemberComments(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostQueryService.java
@@ -45,6 +45,10 @@ public class PostQueryService {
         return postRepository.findByKeyword(keyword, pageable);
     }
 
+    public Page<Post> searchByMemberComments(Long memberId, Pageable pageable) {
+        return postRepository.findByMemberComments(memberId, pageable);
+    }
+
     public List<Tag> searchPopularTags() {
         return tagRepository.findPopularTags();
     }

--- a/src/main/java/com/konggogi/veganlife/post/service/PostSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/post/service/PostSearchService.java
@@ -53,6 +53,13 @@ public class PostSearchService {
                 .map(post -> postMapper.toPostSimpleDto(post, post.getImageUrls()));
     }
 
+    public Page<PostSimpleDto> searchByMemberComments(Long memberId, Pageable pageable) {
+        memberQueryService.search(memberId);
+        return postQueryService
+                .searchByMemberComments(memberId, pageable)
+                .map(post -> postMapper.toPostSimpleDto(post, post.getImageUrls()));
+    }
+
     private List<CommentDetailsDto> getAllCommentDetails(Long memberId, Post post) {
         return post.getComments().stream()
                 .filter(comment -> comment.getParent().isEmpty())

--- a/src/test/java/com/konggogi/veganlife/comment/controller/CommentControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/controller/CommentControllerTest.java
@@ -204,7 +204,7 @@ class CommentControllerTest extends RestDocsTest {
         SubCommentDetailsDto subComment2 =
                 new SubCommentDetailsDto(3L, "콩고기F", "오오 꿀팁이네요ㅎㅎ", false, 3, LocalDateTime.now());
         CommentDetailsDto detailsDto =
-                new CommentDetailsDto(1L, comment, true, 53, List.of(subComment1, subComment2));
+                new CommentDetailsDto(comment, true, 53, List.of(subComment1, subComment2));
         given(commentSearchService.searchDetailsById(anyLong(), anyLong(), anyLong()))
                 .willReturn(detailsDto);
         // when
@@ -214,7 +214,7 @@ class CommentControllerTest extends RestDocsTest {
                                 .headers(authorizationHeader()));
         // then
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(detailsDto.id()))
+                .andExpect(jsonPath("$.id").value(comment.getId()))
                 .andExpect(
                         jsonPath("$.author").value(detailsDto.comment().getMember().getNickname()))
                 .andExpect(jsonPath("$.content").value(detailsDto.comment().getContent()))

--- a/src/test/java/com/konggogi/veganlife/comment/service/CommentSearchServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/service/CommentSearchServiceTest.java
@@ -56,7 +56,6 @@ class CommentSearchServiceTest {
                 commentSearchService.searchDetailsById(
                         member.getId(), post.getId(), comment.getId());
         // then
-        assertThat(result.id()).isEqualTo(comment.getId());
         assertThat(result.comment()).isEqualTo(comment);
         assertThat(result.isLike()).isTrue();
         assertThat(result.likeCount()).isEqualTo(1);

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -130,9 +130,8 @@ class PostControllerTest extends RestDocsTest {
                 new SubCommentDetailsDto(
                         3L, "콩고기M", "작심이틀로 태그 바꿔주세요~", true, 11, LocalDateTime.now());
         CommentDetailsDto commentDetailsDto1 =
-                new CommentDetailsDto(1L, comment1, true, 53, List.of(subComment1));
-        CommentDetailsDto commentDetailsDto2 =
-                new CommentDetailsDto(2L, comment2, false, 3, List.of());
+                new CommentDetailsDto(comment1, true, 53, List.of(subComment1));
+        CommentDetailsDto commentDetailsDto2 = new CommentDetailsDto(comment2, false, 3, List.of());
         List<CommentDetailsDto> commentDetailsDtos =
                 List.of(commentDetailsDto1, commentDetailsDto2);
 

--- a/src/test/java/com/konggogi/veganlife/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/repository/PostRepositoryTest.java
@@ -2,6 +2,9 @@ package com.konggogi.veganlife.post.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.konggogi.veganlife.comment.domain.Comment;
+import com.konggogi.veganlife.comment.fixture.CommentFixture;
+import com.konggogi.veganlife.comment.repository.CommentRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
@@ -26,6 +29,7 @@ class PostRepositoryTest {
     @Autowired MemberRepository memberRepository;
     @Autowired PostRepository postRepository;
     @Autowired PostTagRepository postTagRepository;
+    @Autowired CommentRepository commentRepository;
     @Autowired TagRepository tagRepository;
     private final Member member = MemberFixture.DEFAULT_M.get();
     private final Post post = PostFixture.BAKERY.get(member);
@@ -131,6 +135,26 @@ class PostRepositoryTest {
         Pageable pageable = PageRequest.of(0, 10);
         // when
         Page<Post> result = postRepository.findAllByMemberId(member.getId(), pageable);
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("회원 Id로 작성된 댓글이 있는 게시글 모두 조회")
+    void findByMemberCommentsTest() {
+        // given
+        Member otherMember = MemberFixture.DEFAULT_F.get();
+        memberRepository.save(otherMember);
+        Post otherPost = PostFixture.BAKERY.get(otherMember);
+        postRepository.save(otherPost);
+        Comment comment = CommentFixture.DEFAULT.getTopComment(member, post);
+        Comment subComment = CommentFixture.DEFAULT.getSubComment(otherMember, post, comment);
+        commentRepository.save(comment);
+        commentRepository.save(subComment);
+        Pageable pageable = PageRequest.of(0, 10);
+        // when
+        Page<Post> result = postRepository.findByMemberComments(member.getId(), pageable);
         // then
         assertThat(result).hasSize(1);
         assertThat(result.getTotalElements()).isEqualTo(1);

--- a/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/PostQueryServiceTest.java
@@ -146,4 +146,20 @@ class PostQueryServiceTest {
         assertThat(result).hasSize(posts.size());
         then(postRepository).should().findAllByMemberId(anyLong(), any(Pageable.class));
     }
+
+    @Test
+    @DisplayName("회원 Id로 작성된 댓글이 있는 게시글 모두 조회")
+    void searchByMemberCommentsTest() {
+        // given
+        List<Post> posts = List.of(post);
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Post> foundPosts = PageableExecutionUtils.getPage(posts, pageable, posts::size);
+        given(postRepository.findByMemberComments(anyLong(), any(Pageable.class)))
+                .willReturn(foundPosts);
+        // when
+        Page<Post> result = postQueryService.searchByMemberComments(member.getId(), pageable);
+        // then
+        assertThat(result).hasSize(posts.size());
+        then(postRepository).should().findByMemberComments(anyLong(), any(Pageable.class));
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/post/service/PostSearchServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/service/PostSearchServiceTest.java
@@ -126,4 +126,21 @@ class PostSearchServiceTest {
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
     }
+
+    @Test
+    @DisplayName("회원 id로 작성된 댓글이 있는 게시글 모두 조회")
+    void searchByMemberCommentsTest() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Post> posts = List.of(post);
+        Page<Post> foundPosts = PageableExecutionUtils.getPage(posts, pageable, posts::size);
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(postQueryService.searchByMemberComments(anyLong(), any(Pageable.class)))
+                .willReturn(foundPosts);
+        // when
+        Page<PostSimpleDto> result =
+                postSearchService.searchByMemberComments(member.getId(), pageable);
+        // then
+        assertThat(result).hasSize(posts.size());
+    }
 }


### PR DESCRIPTION
## 이슈 번호 (#232 )

## 요약
회원이 쓴 댓글의 피드 조회 기능 구현
회원이 쓴 댓글의 피드 조회 API 구현
관련 기능 테스트

## 논의
기존에 내가 쓴 게시글을 반환하는 API의 엔드포인트가 `api/v1/members/me/posts`입니다.
그래서 이 API도 내가 쓴 댓글을 반환하는 기능이라고 생각해, 엔드포인트를 `api/v1/members/me/comments`로 생각했습니다.
그런데 댓글을 반환하는 것이 아닌, 회원이 작성한 **댓글이 있는 게시글 목록**을 반환하는 것이라고 하네요.

여러 엔드포인트를 고려해보았습니다만,

`api/v1/members/me/comments/posts`
> 이 경우는 계층 구조가 맞지 않음

`api/v1/members/me/posts/comments`
> 이 경우는 댓글 목록을 반환한다고 여겨짐

그래서 현재는 현재는 엔드포인트가 `api/v1/members/me/posts-with-comments`라고 되어 있습니다.

사실 이것도 명확하게 기능의 의미를 반환하는지는 잘 모르겠습니다. 의견이 있으시다면 알려주세요! 😥





