### PR TITLE
소셜 로그인 API 리팩토링

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/security/jwt/RefreshToken.java
+++ b/src/main/java/com/konggogi/veganlife/global/security/jwt/RefreshToken.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,9 +24,11 @@ public class RefreshToken {
     private String token;
     private Long memberId;
 
-    public RefreshToken(String token, Long memberId) {
-        this.token = token;
+    @Builder
+    public RefreshToken(Long id, Long memberId, String token) {
+        this.id = id;
         this.memberId = memberId;
+        this.token = token;
     }
 
     public void update(String token) {

--- a/src/main/java/com/konggogi/veganlife/global/security/jwt/RefreshToken.java
+++ b/src/main/java/com/konggogi/veganlife/global/security/jwt/RefreshToken.java
@@ -23,12 +23,12 @@ public class RefreshToken {
     private String token;
     private Long memberId;
 
-    public RefreshToken(String token, Long id) {
+    public RefreshToken(String token, Long memberId) {
         this.token = token;
-        this.memberId = id;
+        this.memberId = memberId;
     }
 
-    public void updateToken(String token) {
+    public void update(String token) {
         this.token = token;
     }
 

--- a/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
@@ -9,6 +9,7 @@ import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
 import com.konggogi.veganlife.member.domain.oauth.OauthProvider;
 import com.konggogi.veganlife.member.service.MemberService;
 import com.konggogi.veganlife.member.service.OauthService;
+import com.konggogi.veganlife.member.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,17 +20,19 @@ import org.springframework.web.bind.annotation.*;
 public class OauthController {
     private final OauthService oauthService;
     private final MemberService memberService;
+    private final RefreshTokenService refreshTokenService;
     private final JwtProvider jwtProvider;
     private final MemberMapper memberMapper;
 
     @PostMapping("/{provider}/login")
     public ResponseEntity<OauthLoginResponse> login(
             @PathVariable OauthProvider provider, @RequestBody OauthRequest oauthRequest) {
-        Member member = oauthService.createMember(provider, oauthRequest.accessToken());
-        Member savedMember = memberService.add(member.getEmail());
-        String accessToken = jwtProvider.createToken(savedMember.getEmail());
-        String refreshToken = jwtProvider.createRefreshToken(savedMember.getEmail());
-        memberService.saveRefreshToken(savedMember.getId(), refreshToken);
+        String userEmail =
+                oauthService.createMember(provider, oauthRequest.accessToken()).getEmail();
+        Member savedMember = memberService.add(userEmail);
+        String accessToken = jwtProvider.createToken(userEmail);
+        String refreshToken = jwtProvider.createRefreshToken(userEmail);
+        refreshTokenService.add(savedMember.getId(), refreshToken);
         return ResponseEntity.ok(
                 memberMapper.toOauthLoginResponse(savedMember, accessToken, refreshToken));
     }

--- a/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
@@ -28,7 +28,9 @@ public class OauthController {
     public ResponseEntity<OauthLoginResponse> login(
             @PathVariable OauthProvider provider, @RequestBody OauthRequest oauthRequest) {
         String userEmail =
-                oauthService.createMember(provider, oauthRequest.accessToken()).getEmail();
+                oauthService
+                        .userAttributesToMember(provider, oauthRequest.accessToken())
+                        .getEmail();
         Member member = memberService.addIfNotPresent(userEmail);
         String accessToken = jwtProvider.createToken(userEmail);
         String refreshToken = jwtProvider.createRefreshToken(userEmail);

--- a/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
@@ -25,7 +25,7 @@ public class OauthController {
     @PostMapping("/{provider}/login")
     public ResponseEntity<OauthLoginResponse> login(
             @PathVariable OauthProvider provider, @RequestBody OauthRequest oauthRequest) {
-        Member member = oauthService.createMemberFromToken(provider, oauthRequest.accessToken());
+        Member member = oauthService.createMember(provider, oauthRequest.accessToken());
         Member savedMember = memberService.add(member.getEmail());
         String accessToken = jwtProvider.createToken(savedMember.getEmail());
         String refreshToken = jwtProvider.createRefreshToken(savedMember.getEmail());

--- a/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
@@ -32,7 +32,7 @@ public class OauthController {
         Member savedMember = memberService.add(userEmail);
         String accessToken = jwtProvider.createToken(userEmail);
         String refreshToken = jwtProvider.createRefreshToken(userEmail);
-        refreshTokenService.add(savedMember.getId(), refreshToken);
+        refreshTokenService.addOrUpdate(savedMember.getId(), refreshToken);
         return ResponseEntity.ok(
                 memberMapper.toOauthLoginResponse(savedMember, accessToken, refreshToken));
     }

--- a/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
@@ -26,7 +26,7 @@ public class OauthController {
     public ResponseEntity<OauthLoginResponse> login(
             @PathVariable OauthProvider provider, @RequestBody OauthRequest oauthRequest) {
         Member member = oauthService.createMemberFromToken(provider, oauthRequest.accessToken());
-        Member savedMember = memberService.addMember(member.getEmail());
+        Member savedMember = memberService.add(member.getEmail());
         String accessToken = jwtProvider.createToken(savedMember.getEmail());
         String refreshToken = jwtProvider.createRefreshToken(savedMember.getEmail());
         memberService.saveRefreshToken(savedMember.getId(), refreshToken);

--- a/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
@@ -29,11 +29,11 @@ public class OauthController {
             @PathVariable OauthProvider provider, @RequestBody OauthRequest oauthRequest) {
         String userEmail =
                 oauthService.createMember(provider, oauthRequest.accessToken()).getEmail();
-        Member savedMember = memberService.add(userEmail);
+        Member member = memberService.addIfNotPresent(userEmail);
         String accessToken = jwtProvider.createToken(userEmail);
         String refreshToken = jwtProvider.createRefreshToken(userEmail);
-        refreshTokenService.addOrUpdate(savedMember.getId(), refreshToken);
+        refreshTokenService.addOrUpdate(member.getId(), refreshToken);
         return ResponseEntity.ok(
-                memberMapper.toOauthLoginResponse(savedMember, accessToken, refreshToken));
+                memberMapper.toOauthLoginResponse(member, accessToken, refreshToken));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package com.konggogi.veganlife.member.domain.mapper;
 
 
+import com.konggogi.veganlife.global.security.jwt.RefreshToken;
 import com.konggogi.veganlife.member.controller.dto.response.MemberInfoResponse;
 import com.konggogi.veganlife.member.controller.dto.response.MemberProfileResponse;
 import com.konggogi.veganlife.member.controller.dto.response.OauthLoginResponse;
@@ -11,6 +12,8 @@ import org.mapstruct.Mapping;
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
     Member toMember(String email);
+
+    RefreshToken toRefreshToken(Long memberId, String token);
 
     OauthLoginResponse toOauthLoginResponse(Member member, String accessToken, String refreshToken);
 

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
@@ -15,6 +15,7 @@ public interface MemberMapper {
         return Member.builder().email(email).build();
     }
 
+    @Mapping(target = "id", ignore = true)
     RefreshToken toRefreshToken(Long memberId, String token);
 
     OauthLoginResponse toOauthLoginResponse(Member member, String accessToken, String refreshToken);

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
@@ -10,6 +10,8 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
+    Member toMember(String email);
+
     OauthLoginResponse toOauthLoginResponse(Member member, String accessToken, String refreshToken);
 
     @Mapping(target = "imageUrl", source = "member.profileImageUrl")

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
@@ -11,7 +11,9 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface MemberMapper {
-    Member toMember(String email);
+    default Member toMember(String email) {
+        return Member.builder().email(email).build();
+    }
 
     RefreshToken toRefreshToken(Long memberId, String token);
 

--- a/src/main/java/com/konggogi/veganlife/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/konggogi/veganlife/member/repository/RefreshTokenRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findRefreshTokenByMemberId(Long memberId);
+    Optional<RefreshToken> findByMemberId(Long memberId);
 
     void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
@@ -31,10 +31,8 @@ public class MemberQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
-    public Member search(String email) {
-        return memberRepository
-                .findByEmail(email)
-                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
+    public Optional<Member> search(String email) {
+        return memberRepository.findByEmail(email);
     }
 
     public Optional<RefreshToken> searchRefreshToken(Long memberId) {
@@ -61,7 +59,13 @@ public class MemberQueryService {
 
     public Member findMemberByToken(String token) {
         return jwtUtils.extractUserEmail(token)
-                .map(this::search)
+                .map(
+                        email ->
+                                search(email)
+                                        .orElseThrow(
+                                                () ->
+                                                        new NotFoundEntityException(
+                                                                ErrorCode.NOT_FOUND_MEMBER)))
                 .orElseThrow(() -> new InvalidJwtException(ErrorCode.NOT_FOUND_USER_INFO_TOKEN));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
@@ -6,10 +6,12 @@ import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.global.security.exception.InvalidJwtException;
 import com.konggogi.veganlife.global.security.exception.MismatchTokenException;
 import com.konggogi.veganlife.global.security.jwt.JwtProvider;
+import com.konggogi.veganlife.global.security.jwt.RefreshToken;
 import com.konggogi.veganlife.global.util.JwtUtils;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,11 +37,15 @@ public class MemberQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
+    public Optional<RefreshToken> searchRefreshToken(Long memberId) {
+        return refreshTokenRepository.findByMemberId(memberId);
+    }
+
     public String reissueToken(String refreshToken) {
         jwtUtils.validateToken(refreshToken);
         Member member = findMemberByToken(refreshToken);
         return refreshTokenRepository
-                .findRefreshTokenByMemberId(member.getId())
+                .findByMemberId(member.getId())
                 .map(
                         token -> {
                             if (!token.isSameToken(refreshToken)) {

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
@@ -31,9 +31,9 @@ public class MemberQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
-    public Member searchByEmail(String userEmail) {
+    public Member search(String email) {
         return memberRepository
-                .findByEmail(userEmail)
+                .findByEmail(email)
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
@@ -61,7 +61,7 @@ public class MemberQueryService {
 
     public Member findMemberByToken(String token) {
         return jwtUtils.extractUserEmail(token)
-                .map(this::searchByEmail)
+                .map(this::search)
                 .orElseThrow(() -> new InvalidJwtException(ErrorCode.NOT_FOUND_USER_INFO_TOKEN));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberQueryService.java
@@ -31,8 +31,10 @@ public class MemberQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
-    public Optional<Member> search(String email) {
-        return memberRepository.findByEmail(email);
+    public Member search(String email) {
+        return memberRepository
+                .findByEmail(email)
+                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
     }
 
     public Optional<RefreshToken> searchRefreshToken(Long memberId) {
@@ -59,13 +61,7 @@ public class MemberQueryService {
 
     public Member findMemberByToken(String token) {
         return jwtUtils.extractUserEmail(token)
-                .map(
-                        email ->
-                                search(email)
-                                        .orElseThrow(
-                                                () ->
-                                                        new NotFoundEntityException(
-                                                                ErrorCode.NOT_FOUND_MEMBER)))
+                .map(this::search)
                 .orElseThrow(() -> new InvalidJwtException(ErrorCode.NOT_FOUND_USER_INFO_TOKEN));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -4,6 +4,7 @@ package com.konggogi.veganlife.member.service;
 import com.konggogi.veganlife.comment.service.CommentLikeService;
 import com.konggogi.veganlife.comment.service.CommentService;
 import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.mealdata.service.MealDataService;
 import com.konggogi.veganlife.meallog.service.MealLogService;
 import com.konggogi.veganlife.member.controller.dto.request.MemberInfoRequest;
@@ -37,13 +38,11 @@ public class MemberService {
     private final MemberMapper memberMapper;
 
     public Member addIfNotPresent(String email) {
-        return memberRepository
-                .findByEmail(email)
-                .orElseGet(
-                        () -> {
-                            Member member = memberMapper.toMember(email);
-                            return memberRepository.save(member);
-                        });
+        try {
+            return memberQueryService.search(email);
+        } catch (NotFoundEntityException e) {
+            return memberRepository.save(memberMapper.toMember(email));
+        }
     }
 
     public void removeMember(Long memberId) {

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -36,7 +36,7 @@ public class MemberService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberMapper memberMapper;
 
-    public Member add(String email) {
+    public Member addIfNotPresent(String email) {
         return memberRepository
                 .findByEmail(email)
                 .orElseGet(

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -4,7 +4,6 @@ package com.konggogi.veganlife.member.service;
 import com.konggogi.veganlife.comment.service.CommentLikeService;
 import com.konggogi.veganlife.comment.service.CommentService;
 import com.konggogi.veganlife.global.exception.ErrorCode;
-import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.mealdata.service.MealDataService;
 import com.konggogi.veganlife.meallog.service.MealLogService;
 import com.konggogi.veganlife.member.controller.dto.request.MemberInfoRequest;
@@ -38,11 +37,9 @@ public class MemberService {
     private final MemberMapper memberMapper;
 
     public Member addIfNotPresent(String email) {
-        try {
-            return memberQueryService.search(email);
-        } catch (NotFoundEntityException e) {
-            return memberRepository.save(memberMapper.toMember(email));
-        }
+        return memberQueryService
+                .search(email)
+                .orElseGet(() -> memberRepository.save(memberMapper.toMember(email)));
     }
 
     public void removeMember(Long memberId) {

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -37,8 +37,8 @@ public class MemberService {
     private final MemberMapper memberMapper;
 
     public Member addIfNotPresent(String email) {
-        return memberQueryService
-                .search(email)
+        return memberRepository
+                .findByEmail(email)
                 .orElseGet(() -> memberRepository.save(memberMapper.toMember(email)));
     }
 

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -4,7 +4,6 @@ package com.konggogi.veganlife.member.service;
 import com.konggogi.veganlife.comment.service.CommentLikeService;
 import com.konggogi.veganlife.comment.service.CommentService;
 import com.konggogi.veganlife.global.exception.ErrorCode;
-import com.konggogi.veganlife.global.security.jwt.RefreshToken;
 import com.konggogi.veganlife.mealdata.service.MealDataService;
 import com.konggogi.veganlife.meallog.service.MealLogService;
 import com.konggogi.veganlife.member.controller.dto.request.MemberInfoRequest;
@@ -64,17 +63,6 @@ public class MemberService {
                 infoRequest.height(),
                 infoRequest.weight());
         return member;
-    }
-
-    public void saveRefreshToken(Long memberId, String token) {
-        refreshTokenRepository
-                .findRefreshTokenByMemberId(memberId)
-                .ifPresentOrElse(
-                        refreshToken -> refreshToken.updateToken(token),
-                        () -> {
-                            RefreshToken newRefreshToken = new RefreshToken(token, memberId);
-                            refreshTokenRepository.save(newRefreshToken);
-                        });
     }
 
     public Member modifyMemberProfile(Long memberId, MemberProfileRequest profileRequest) {

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -10,6 +10,7 @@ import com.konggogi.veganlife.meallog.service.MealLogService;
 import com.konggogi.veganlife.member.controller.dto.request.MemberInfoRequest;
 import com.konggogi.veganlife.member.controller.dto.request.MemberProfileRequest;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
 import com.konggogi.veganlife.member.exception.DuplicatedNicknameException;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
@@ -34,13 +35,14 @@ public class MemberService {
     private final MealDataService mealDataService;
     private final MealLogService mealLogService;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberMapper memberMapper;
 
     public Member add(String email) {
         return memberRepository
                 .findByEmail(email)
                 .orElseGet(
                         () -> {
-                            Member member = Member.builder().email(email).build();
+                            Member member = memberMapper.toMember(email);
                             return memberRepository.save(member);
                         });
     }

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -35,7 +35,7 @@ public class MemberService {
     private final MealLogService mealLogService;
     private final RefreshTokenRepository refreshTokenRepository;
 
-    public Member addMember(String email) {
+    public Member add(String email) {
         return memberRepository
                 .findByEmail(email)
                 .orElseGet(

--- a/src/main/java/com/konggogi/veganlife/member/service/OauthService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/OauthService.java
@@ -4,6 +4,7 @@ package com.konggogi.veganlife.member.service;
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.security.exception.InvalidOauthTokenException;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
 import com.konggogi.veganlife.member.domain.oauth.OauthProvider;
 import com.konggogi.veganlife.member.domain.oauth.OauthUserInfo;
 import com.konggogi.veganlife.member.exception.UnsupportedProviderException;
@@ -19,6 +20,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 @RequiredArgsConstructor
 public class OauthService {
     private final OauthUserInfoFactory oauthUserInfoFactory;
+    private final MemberMapper memberMapper;
 
     @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
     private String KAKAO_USER_INFO_URI;
@@ -31,7 +33,7 @@ public class OauthService {
         OauthUserInfo oauthUserInfo =
                 oauthUserInfoFactory.createOauthUserInfo(provider, userAttributes);
         String email = oauthUserInfo.getEmail();
-        return Member.builder().email(email).build();
+        return memberMapper.toMember(email);
     }
 
     private Map<String, Object> getUserAttributes(OauthProvider provider, String oauthToken) {

--- a/src/main/java/com/konggogi/veganlife/member/service/OauthService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/OauthService.java
@@ -26,21 +26,21 @@ public class OauthService {
     @Value("${spring.security.oauth2.client.provider.naver.user-info-uri}")
     private String NAVER_USER_INFO_URI;
 
-    public Member createMemberFromToken(OauthProvider provider, String token) {
-        Map<String, Object> userAttributes = getUserAttributesByToken(provider, token);
+    public Member createMember(OauthProvider provider, String oauthToken) {
+        Map<String, Object> userAttributes = getUserAttributes(provider, oauthToken);
         OauthUserInfo oauthUserInfo =
                 oauthUserInfoFactory.createOauthUserInfo(provider, userAttributes);
         String email = oauthUserInfo.getEmail();
         return Member.builder().email(email).build();
     }
 
-    private Map<String, Object> getUserAttributesByToken(OauthProvider provider, String token) {
+    private Map<String, Object> getUserAttributes(OauthProvider provider, String oauthToken) {
         String userInfoUri = getUserInfoUri(provider);
         try {
             return WebClient.create()
                     .get()
                     .uri(userInfoUri)
-                    .headers(httpHeaders -> httpHeaders.setBearerAuth(token))
+                    .headers(httpHeaders -> httpHeaders.setBearerAuth(oauthToken))
                     .retrieve()
                     .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
                     .block();

--- a/src/main/java/com/konggogi/veganlife/member/service/OauthService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/OauthService.java
@@ -28,7 +28,7 @@ public class OauthService {
     @Value("${spring.security.oauth2.client.provider.naver.user-info-uri}")
     private String NAVER_USER_INFO_URI;
 
-    public Member createMember(OauthProvider provider, String oauthToken) {
+    public Member userAttributesToMember(OauthProvider provider, String oauthToken) {
         Map<String, Object> userAttributes = getUserAttributes(provider, oauthToken);
         OauthUserInfo oauthUserInfo =
                 oauthUserInfoFactory.createOauthUserInfo(provider, userAttributes);

--- a/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
@@ -1,0 +1,26 @@
+package com.konggogi.veganlife.member.service;
+
+
+import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public void add(Long memberId, String token) {
+        refreshTokenRepository
+                .findRefreshTokenByMemberId(memberId)
+                .ifPresentOrElse(
+                        refreshToken -> refreshToken.updateToken(token),
+                        () -> {
+                            RefreshToken newRefreshToken = new RefreshToken(token, memberId);
+                            refreshTokenRepository.save(newRefreshToken);
+                        });
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
@@ -11,11 +11,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class RefreshTokenService {
+    private final MemberQueryService memberQueryService;
     private final RefreshTokenRepository refreshTokenRepository;
 
     public void add(Long memberId, String token) {
-        refreshTokenRepository
-                .findRefreshTokenByMemberId(memberId)
+        memberQueryService
+                .searchRefreshToken(memberId)
                 .ifPresentOrElse(
                         refreshToken -> refreshToken.updateToken(token),
                         () -> {

--- a/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
@@ -2,6 +2,7 @@ package com.konggogi.veganlife.member.service;
 
 
 import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,15 +14,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class RefreshTokenService {
     private final MemberQueryService memberQueryService;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberMapper memberMapper;
 
-    public void add(Long memberId, String token) {
+    public void addOrUpdate(Long memberId, String token) {
         memberQueryService
                 .searchRefreshToken(memberId)
                 .ifPresentOrElse(
-                        refreshToken -> refreshToken.updateToken(token),
+                        refreshToken -> refreshToken.update(token),
                         () -> {
-                            RefreshToken newRefreshToken = new RefreshToken(token, memberId);
-                            refreshTokenRepository.save(newRefreshToken);
+                            RefreshToken newToken = memberMapper.toRefreshToken(memberId, token);
+                            refreshTokenRepository.save(newToken);
                         });
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
@@ -26,9 +26,12 @@ public class RefreshTokenService {
                             log.debug("Refresh token updated for memberId: {}", memberId);
                         },
                         () -> {
-                            refreshTokenRepository.save(
-                                    memberMapper.toRefreshToken(memberId, token));
+                            add(memberId, token);
                             log.debug("New refresh token created for memberId: {}", memberId);
                         });
+    }
+
+    private void add(Long memberId, String token) {
+        refreshTokenRepository.save(memberMapper.toRefreshToken(memberId, token));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
@@ -1,16 +1,17 @@
 package com.konggogi.veganlife.member.service;
 
 
-import com.konggogi.veganlife.global.security.jwt.RefreshToken;
 import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class RefreshTokenService {
     private final MemberQueryService memberQueryService;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -20,10 +21,14 @@ public class RefreshTokenService {
         memberQueryService
                 .searchRefreshToken(memberId)
                 .ifPresentOrElse(
-                        refreshToken -> refreshToken.update(token),
+                        refreshToken -> {
+                            refreshToken.update(token);
+                            log.debug("Refresh token updated for memberId: {}", memberId);
+                        },
                         () -> {
-                            RefreshToken newToken = memberMapper.toRefreshToken(memberId, token);
-                            refreshTokenRepository.save(newToken);
+                            refreshTokenRepository.save(
+                                    memberMapper.toRefreshToken(memberId, token));
+                            log.debug("New refresh token created for memberId: {}", memberId);
                         });
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/fixture/RefreshTokenFixture.java
+++ b/src/test/java/com/konggogi/veganlife/member/fixture/RefreshTokenFixture.java
@@ -1,0 +1,29 @@
+package com.konggogi.veganlife.member.fixture;
+
+
+import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+
+public enum RefreshTokenFixture {
+    DEFAULT("token");
+    private final String token;
+
+    RefreshTokenFixture(String token) {
+        this.token = token;
+    }
+
+    public RefreshToken get(Long memberId) {
+        return RefreshToken.builder().memberId(memberId).token(token).build();
+    }
+
+    public RefreshToken getWithToken(Long memberId, String token) {
+        return RefreshToken.builder().memberId(memberId).token(token).build();
+    }
+
+    public RefreshToken getWithId(Long id, Long memberId) {
+        return RefreshToken.builder().id(id).memberId(memberId).token(token).build();
+    }
+
+    public RefreshToken getWithIdAndToken(Long id, Long memberId, String token) {
+        return RefreshToken.builder().id(id).memberId(memberId).token(token).build();
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/repository/MemberRepositoryTest.java
@@ -13,8 +13,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 class MemberRepositoryTest {
-    @Autowired private MemberRepository memberRepository;
-
+    @Autowired MemberRepository memberRepository;
     private final Member member = MemberFixture.DEFAULT_F.get();
 
     @BeforeEach

--- a/src/test/java/com/konggogi/veganlife/member/repository/RefreshTokenRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/repository/RefreshTokenRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.konggogi.veganlife.member.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+import com.konggogi.veganlife.member.fixture.RefreshTokenFixture;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class RefreshTokenRepositoryTest {
+    @Autowired RefreshTokenRepository refreshTokenRepository;
+    private final Long memberId = 1L;
+    private final RefreshToken refreshToken = RefreshTokenFixture.DEFAULT.get(memberId);
+
+    @BeforeEach
+    void setup() {
+        refreshTokenRepository.save(refreshToken);
+    }
+
+    @Test
+    @DisplayName("회원 Id로 RefreshToken 조회")
+    void findByMemberIdTest() {
+        // when
+        Optional<RefreshToken> result = refreshTokenRepository.findByMemberId(memberId);
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().getMemberId()).isEqualTo(memberId);
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/member/service/MemberQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/MemberQueryServiceTest.java
@@ -1,9 +1,7 @@
 package com.konggogi.veganlife.member.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.doNothing;
@@ -18,6 +16,7 @@ import com.konggogi.veganlife.global.security.jwt.RefreshToken;
 import com.konggogi.veganlife.global.util.JwtUtils;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.fixture.RefreshTokenFixture;
 import com.konggogi.veganlife.member.repository.MemberRepository;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
 import java.util.Optional;
@@ -38,21 +37,21 @@ class MemberQueryServiceTest {
     private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
 
     @Test
-    @DisplayName("회원 번호로 조회")
-    void searchTest() {
+    @DisplayName("회원 Id로 Member 조회")
+    void searchByIdTest() {
         // given
         Long memberId = member.getId();
-        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
+        given(memberRepository.findById(anyLong())).willReturn(Optional.of(member));
         // when
-        Member foundMember = memberQueryService.search(memberId);
+        Member result = memberQueryService.search(memberId);
         // then
+        assertThat(result).isEqualTo(member);
         then(memberRepository).should().findById(memberId);
-        assertThat(foundMember).isEqualTo(member);
     }
 
     @Test
-    @DisplayName("없는 회원 번호로 조회 시 예외 발생")
-    void searchNotMemberTest() {
+    @DisplayName("회원 Id로 Member 조회 - Not Found Member")
+    void searchByIdNotFoundMemberTest() {
         // given
         Long memberId = member.getId();
         given(memberRepository.findById(anyLong())).willReturn(Optional.empty());
@@ -60,32 +59,41 @@ class MemberQueryServiceTest {
         assertThatThrownBy(() -> memberQueryService.search(memberId))
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
-        then(memberRepository).should().findById(memberId);
+        then(memberRepository).should().findById(eq(memberId));
     }
 
     @Test
-    @DisplayName("이메일로 회원 조회")
+    @DisplayName("회원 email로 Member 조회")
     void searchByEmailTest() {
         // given
         String email = member.getEmail();
         given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
         // when
-        Member foundMember = memberQueryService.searchByEmail(email);
+        Member result = memberQueryService.search(email);
         // then
-        assertThat(foundMember).isEqualTo(member);
+        assertThat(result).isEqualTo(member);
+        then(memberRepository).should().findByEmail(eq(email));
     }
 
     @Test
-    @DisplayName("이메일로 회원 조회 실패")
-    void searchByEmailNotFoundTest() {
+    @DisplayName("회원 email로 Member 조회 - Not Found Member")
+    void searchByEmailNotFoundMemberTest() {
         // given
         String email = member.getEmail();
         given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
         // when, then
-        assertThatThrownBy(() -> memberQueryService.searchByEmail(email))
+        assertThatThrownBy(() -> memberQueryService.search(email))
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
-        then(memberRepository).should().findByEmail(anyString());
+        then(memberRepository).should().findByEmail(eq(email));
+    }
+
+    @Test
+    @DisplayName("회원 RefreshToken 조회")
+    void searchRefreshToken() {
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> memberQueryService.searchRefreshToken(member.getId()));
     }
 
     @Test
@@ -97,18 +105,18 @@ class MemberQueryServiceTest {
         String token = "refreshToken";
         String bearerToken = JwtUtils.BEARER_PREFIX + token;
         String accessToken = "accessToken";
-        RefreshToken refreshToken = new RefreshToken(bearerToken, memberId);
+        RefreshToken refreshToken = RefreshTokenFixture.DEFAULT.getWithToken(memberId, bearerToken);
         doNothing().when(jwtUtils).validateToken(token);
         given(jwtUtils.extractUserEmail(token)).willReturn(Optional.of(email));
         given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
-        given(refreshTokenRepository.findRefreshTokenByMemberId(memberId))
+        given(refreshTokenRepository.findByMemberId(memberId))
                 .willReturn(Optional.of(refreshToken));
         given(jwtProvider.createToken(email)).willReturn(accessToken);
         // when
         String reissueToken = memberQueryService.reissueToken(token);
         // then
         assertThat(reissueToken).isEqualTo(accessToken);
-        then(refreshTokenRepository).should().findRefreshTokenByMemberId(memberId);
+        then(refreshTokenRepository).should().findByMemberId(memberId);
         then(jwtProvider).should().createToken(email);
     }
 
@@ -122,13 +130,12 @@ class MemberQueryServiceTest {
         doNothing().when(jwtUtils).validateToken(token);
         given(jwtUtils.extractUserEmail(token)).willReturn(Optional.of(email));
         given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
-        given(refreshTokenRepository.findRefreshTokenByMemberId(memberId))
-                .willReturn(Optional.empty());
+        given(refreshTokenRepository.findByMemberId(memberId)).willReturn(Optional.empty());
         // when, then
         assertThatThrownBy(() -> memberQueryService.reissueToken(token))
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_REFRESH_TOKEN.getDescription());
-        then(refreshTokenRepository).should().findRefreshTokenByMemberId(memberId);
+        then(refreshTokenRepository).should().findByMemberId(memberId);
         then(jwtProvider).should(never()).createToken(email);
     }
 
@@ -140,17 +147,17 @@ class MemberQueryServiceTest {
         String email = member.getEmail();
         String token = "refreshToken";
         String bearerToken = JwtUtils.BEARER_PREFIX + "mismatch" + token;
-        RefreshToken refreshToken = new RefreshToken(bearerToken, memberId);
+        RefreshToken refreshToken = RefreshTokenFixture.DEFAULT.getWithToken(memberId, bearerToken);
         doNothing().when(jwtUtils).validateToken(token);
         given(jwtUtils.extractUserEmail(token)).willReturn(Optional.of(email));
         given(memberRepository.findByEmail(email)).willReturn(Optional.of(member));
-        given(refreshTokenRepository.findRefreshTokenByMemberId(memberId))
+        given(refreshTokenRepository.findByMemberId(memberId))
                 .willReturn(Optional.of(refreshToken));
         // when, then
         assertThatThrownBy(() -> memberQueryService.reissueToken(token))
                 .isInstanceOf(MismatchTokenException.class)
                 .hasMessageContaining(ErrorCode.MISMATCH_REFRESH_TOKEN.getDescription());
-        then(refreshTokenRepository).should().findRefreshTokenByMemberId(memberId);
+        then(refreshTokenRepository).should().findByMemberId(memberId);
         then(jwtProvider).should(never()).createToken(email);
     }
 
@@ -167,7 +174,7 @@ class MemberQueryServiceTest {
         assertThatThrownBy(() -> memberQueryService.reissueToken(token))
                 .isInstanceOf(InvalidJwtException.class)
                 .hasMessageContaining(ErrorCode.NOT_FOUND_USER_INFO_TOKEN.getDescription());
-        then(refreshTokenRepository).should(never()).findRefreshTokenByMemberId(memberId);
+        then(refreshTokenRepository).should(never()).findByMemberId(memberId);
         then(jwtProvider).should(never()).createToken(email);
     }
 
@@ -225,23 +232,5 @@ class MemberQueryServiceTest {
                 .hasMessageContaining(ErrorCode.NOT_FOUND_USER_INFO_TOKEN.getDescription());
         then(jwtUtils).should().extractUserEmail(anyString());
         then(memberRepository).should(never()).findByEmail(anyString());
-    }
-
-    @Test
-    @DisplayName("토큰에서 추출한 이메일로 회원 조회 시 회원을 찾을 수 없으면 예외 발생")
-    void findMemberByTokenNotFoundMemberTest() {
-        // given
-        String email = member.getEmail();
-        String token = "accessToken";
-        given(jwtUtils.extractUserEmail(anyString())).willReturn(Optional.of(email));
-        given(memberRepository.findByEmail(anyString()))
-                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
-        // when, then
-        assertThatThrownBy(() -> memberQueryService.findMemberByToken(token))
-                .isInstanceOf(NotFoundEntityException.class)
-                .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
-        // then
-        then(jwtUtils).should().extractUserEmail(anyString());
-        then(memberRepository).should().findByEmail(anyString());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/RefreshTokenServiceTest.java
@@ -1,0 +1,58 @@
+package com.konggogi.veganlife.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
+import com.konggogi.veganlife.member.domain.mapper.MemberMapperImpl;
+import com.konggogi.veganlife.member.fixture.RefreshTokenFixture;
+import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+    @Mock RefreshTokenRepository refreshTokenRepository;
+    @Mock MemberQueryService memberQueryService;
+    @Spy MemberMapper memberMapper = new MemberMapperImpl();
+    @InjectMocks RefreshTokenService refreshTokenService;
+    private final Long memberId = 1L;
+
+    @Test
+    @DisplayName("RefreshToken 저장 - 기존 토큰 업데이트")
+    void updateRefreshTokenTest() {
+        // given
+        RefreshToken refreshToken = RefreshTokenFixture.DEFAULT.get(memberId);
+        String newToken = "new";
+        given(memberQueryService.searchRefreshToken(anyLong()))
+                .willReturn(Optional.of(refreshToken));
+        // when
+        refreshTokenService.addOrUpdate(memberId, newToken);
+        // then
+        assertThat(refreshToken.getToken()).isEqualTo(newToken);
+        then(memberQueryService).should().searchRefreshToken(eq(memberId));
+        then(refreshTokenRepository).should(never()).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("RefreshToken 저장 - 새로운 토큰 저장")
+    void saveRefreshTokenTest() {
+        // given
+        given(memberQueryService.searchRefreshToken(anyLong())).willReturn(Optional.empty());
+        // when
+        refreshTokenService.addOrUpdate(memberId, "new");
+        // then
+        then(memberQueryService).should().searchRefreshToken(eq(memberId));
+        then(refreshTokenRepository).should().save(any(RefreshToken.class));
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#241 )

## 변경 내용
- `OauthService`의 `createMemberFromToken` -> `userAttributesToMember`
> 기존 메서드명은 회원을 저장한다는 오해를 부를 수 있어 메서드명을 수정함
- Member 객체 생성을 `MemberMapper`의 `toMember` 메서드를 사용도록 변경
- `MemberService`의 `addMember` -> `addIfNotPresent`
> 회원이 존재하지 않는 경우에만 add하므로 메서드명을 명시적으로 수정함
- `RefreshTokenService` 생성 및 기존 `MemberService`의 `saveRefreshToken` 메서드 이동
- `saveRefreshToken` -> `addOrUpdate`
> 리프레시 토큰이 존재할 경우 갱신하고, 존재 하지 않을 경우 새로 추가하므로 메서드명을 명시적으로 수정함

## 기타 사항
`MemberQueryService`의 `reissueToken` 메서드도 `RefreshTokenService`로 이동해야 하지만,
소셜 로그인 API에만 집중하여 리팩토링하였으므로 추후 개선될 예정