### PR TITLE
레시피 좋아요/좋아요 취소 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -33,3 +33,5 @@ include::{docdir}/src/docs/asciidoc/comment.adoc[]
 include::{docdir}/src/docs/asciidoc/comment-like.adoc[]
 
 include::{docdir}/src/docs/asciidoc/recipe.adoc[]
+
+include::{docdir}/src/docs/asciidoc/recipe-like.adoc[]

--- a/src/docs/asciidoc/recipe-like.adoc
+++ b/src/docs/asciidoc/recipe-like.adoc
@@ -1,0 +1,64 @@
+= Recipe Like API
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+
+== 레시피 좋아요 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/recipe-like-add/request-headers.adoc[]
+
+include::{snippets}/recipe-like-add/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/recipe-like-add/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/recipe-like-add-member-not-found/http-response.adoc[]
+
+include::{snippets}/recipe-like-add-recipe-not-found/http-response.adoc[]
+
+==== 409 CONFLICT
+
+include::{snippets}/recipe-like-add-duplicate/http-response.adoc[]
+
+== 레시피 좋아요 취소 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/recipe-like-remove/request-headers.adoc[]
+
+include::{snippets}/recipe-like-remove/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/recipe-like-remove/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/recipe-like-add-member-not-found/http-response.adoc[]
+
+include::{snippets}/recipe-like-add-recipe-not-found/http-response.adoc[]
+
+==== 409 CONFLICT
+
+include::{snippets}/recipe-like-remove-duplicate/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -57,7 +57,11 @@ public enum ErrorCode {
     ALREADY_COMMENT_UNLIKED("COMMENT_LIKE_002", "좋아요가 되어 있지 않은 댓글입니다."),
 
     // recipe
-    NOT_FOUND_RECIPE("RECIPE_001", "레시피를 찾을 수 없습니다.");
+    NOT_FOUND_RECIPE("RECIPE_001", "레시피를 찾을 수 없습니다."),
+
+    // recipe-like
+    ALREADY_RECIPE_LIKED("RECIPE_LIKE_001", "좋아요가 되어 있는 레시피입니다."),
+    ALREADY_RECIPE_UNLIKED("RECIPE_LIKE_002", "좋아요가 되어 있지 않은 레시피입니다.");
 
     private final String code;
     private final String description;

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
@@ -39,9 +39,10 @@ public class RecipeController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<RecipeDetailsResponse> getRecipeDetails(@PathVariable Long id) {
+    public ResponseEntity<RecipeDetailsResponse> getRecipeDetails(
+            @PathVariable("id") Long recipeId, UserDetailsImpl userDetails) {
 
-        return ResponseEntity.ok(recipeSearchService.search(id));
+        return ResponseEntity.ok(recipeSearchService.search(recipeId, userDetails.id()));
     }
 
     @PostMapping

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeLikeController.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeLikeController.java
@@ -1,0 +1,40 @@
+package com.konggogi.veganlife.recipe.controller;
+
+
+import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import com.konggogi.veganlife.recipe.service.RecipeLikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/recipes/{id}/likes")
+@RequiredArgsConstructor
+public class RecipeLikeController {
+
+    private final RecipeLikeService recipeLikeService;
+
+    @PostMapping
+    public ResponseEntity<Void> addRecipeLike(
+            @PathVariable("id") Long recipeId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        recipeLikeService.add(recipeId, userDetails.id());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> removeRecipeLike(
+            @PathVariable("id") Long recipeId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        recipeLikeService.remove(recipeId, userDetails.id());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeLike.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeLike.java
@@ -1,0 +1,42 @@
+package com.konggogi.veganlife.recipe.domain;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"recipe_id", "member_id"})})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RecipeLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "recipe_like_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "recipe_id")
+    private Recipe recipe;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    public RecipeLike(Long id, Recipe recipe, Member member) {
+        this.id = id;
+        this.recipe = recipe;
+        this.member = member;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeLikeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeLikeMapper.java
@@ -1,0 +1,16 @@
+package com.konggogi.veganlife.recipe.domain.mapper;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeLike;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface RecipeLikeMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(source = "member", target = "member")
+    RecipeLike toEntity(Recipe recipe, Member member);
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/repository/RecipeLikeRepository.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/repository/RecipeLikeRepository.java
@@ -1,0 +1,13 @@
+package com.konggogi.veganlife.recipe.repository;
+
+
+import com.konggogi.veganlife.recipe.domain.RecipeLike;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeLikeRepository extends JpaRepository<RecipeLike, Long> {
+
+    Optional<RecipeLike> findByRecipeIdAndMemberId(Long recipeId, Long memberId);
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeLikeQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeLikeQueryService.java
@@ -1,0 +1,22 @@
+package com.konggogi.veganlife.recipe.service;
+
+
+import com.konggogi.veganlife.recipe.domain.RecipeLike;
+import com.konggogi.veganlife.recipe.repository.RecipeLikeRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecipeLikeQueryService {
+
+    private final RecipeLikeRepository recipeLikeRepository;
+
+    public Optional<RecipeLike> searchByRecipeIdAndMemberId(Long recipeId, Long memberId) {
+
+        return recipeLikeRepository.findByRecipeIdAndMemberId(recipeId, memberId);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeLikeService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeLikeService.java
@@ -55,7 +55,7 @@ public class RecipeLikeService {
                 .searchByRecipeIdAndMemberId(recipeId, memberId)
                 .ifPresent(
                         r -> {
-                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_POST_LIKED);
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_RECIPE_LIKED);
                         });
     }
 
@@ -63,6 +63,7 @@ public class RecipeLikeService {
 
         return recipeLikeQueryService
                 .searchByRecipeIdAndMemberId(recipeId, memberId)
-                .orElseThrow(() -> new IllegalLikeStatusException(ErrorCode.ALREADY_POST_UNLIKED));
+                .orElseThrow(
+                        () -> new IllegalLikeStatusException(ErrorCode.ALREADY_RECIPE_UNLIKED));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeLikeService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeLikeService.java
@@ -1,0 +1,68 @@
+package com.konggogi.veganlife.recipe.service;
+
+
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeLike;
+import com.konggogi.veganlife.recipe.domain.mapper.RecipeLikeMapper;
+import com.konggogi.veganlife.recipe.repository.RecipeLikeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RecipeLikeService {
+
+    private final MemberQueryService memberQueryService;
+    private final RecipeQueryService recipeQueryService;
+    private final RecipeLikeQueryService recipeLikeQueryService;
+
+    private final RecipeLikeRepository recipeLikeRepository;
+    private final RecipeLikeMapper recipeLikeMapper;
+
+    public void add(Long recipeId, Long memberId) {
+
+        Recipe recipe = recipeQueryService.search(recipeId);
+        Member member = memberQueryService.search(memberId);
+
+        validateRecipeLikeIsExist(recipe.getId(), member.getId());
+
+        /** 쓰기 작업 전에 해당 레코드가 존재하는지 확인하는 로직만으로는 두 번 쓰기 작업을 시도하는 문제를 해결할 수 없다. */
+        recipeLikeRepository.save(recipeLikeMapper.toEntity(recipe, member));
+    }
+
+    public void remove(Long recipeId, Long memberId) {
+
+        Recipe recipe = recipeQueryService.search(recipeId);
+        Member member = memberQueryService.search(memberId);
+
+        RecipeLike recipeLike = validateRecipeLikeIsNotExist(recipe.getId(), member.getId());
+
+        /** 쓰기 작업 전에 해당 레코드가 존재하는지 확인하는 로직만으로는 두 번 쓰기 작업을 시도하는 문제를 해결할 수 없다. */
+        recipeLikeRepository.delete(recipeLike);
+    }
+
+    private void validateRecipeLikeIsExist(Long recipeId, Long memberId) {
+
+        recipeLikeQueryService
+                .searchByRecipeIdAndMemberId(recipeId, memberId)
+                .ifPresent(
+                        r -> {
+                            throw new IllegalLikeStatusException(ErrorCode.ALREADY_POST_LIKED);
+                        });
+    }
+
+    private RecipeLike validateRecipeLikeIsNotExist(Long recipeId, Long memberId) {
+
+        return recipeLikeQueryService
+                .searchByRecipeIdAndMemberId(recipeId, memberId)
+                .orElseThrow(() -> new IllegalLikeStatusException(ErrorCode.ALREADY_POST_UNLIKED));
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
@@ -28,6 +28,8 @@ public class RecipeSearchService {
 
     private final MemberQueryService memberQueryService;
     private final RecipeQueryService recipeQueryService;
+    private final RecipeLikeQueryService recipeLikeQueryService;
+
     private final RecipeMapper recipeMapper;
 
     public Page<RecipeResponse> searchAll(VegetarianType vegetarianType, Pageable pageable) {
@@ -37,10 +39,10 @@ public class RecipeSearchService {
                 .map(recipeMapper::toRecipeResponse);
     }
 
-    public RecipeDetailsResponse search(Long id) {
+    public RecipeDetailsResponse search(Long recipeId, Long memberId) {
 
-        // TODO: 사용자가 좋아요를 눌렀는지 확인하는 로직 추가
-        return recipeMapper.toRecipeDetailsResponse(recipeQueryService.search(id), false);
+        return recipeMapper.toRecipeDetailsResponse(
+                recipeQueryService.search(recipeId), isLikedRecipe(recipeId, memberId));
     }
 
     public List<RecipeResponse> searchRecommended(Long memberId) {
@@ -73,5 +75,10 @@ public class RecipeSearchService {
                 .stream()
                 .map(n -> PageRequest.of(n, PAGE_SIZE))
                 .toList();
+    }
+
+    private boolean isLikedRecipe(Long recipeId, Long memberId) {
+
+        return recipeLikeQueryService.searchByRecipeIdAndMemberId(recipeId, memberId).isPresent();
     }
 }

--- a/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeControllerTest.java
@@ -119,7 +119,7 @@ public class RecipeControllerTest extends RestDocsTest {
         Recipe recipe = createRecipe(1L, "표고버섯 탕수", RecipeTypeFixture.LACTO.get());
         RecipeDetailsResponse response = recipeMapper.toRecipeDetailsResponse(recipe, false);
 
-        given(recipeSearchService.search(anyLong())).willReturn(response);
+        given(recipeSearchService.search(anyLong(), anyLong())).willReturn(response);
 
         ResultActions perform =
                 mockMvc.perform(get("/api/v1/recipes/{id}", 1L).headers(authorizationHeader()));
@@ -147,7 +147,7 @@ public class RecipeControllerTest extends RestDocsTest {
     @DisplayName("레시피 상세 조회 API - 레시피 not found 예외")
     void getRecipeDetailsNotFoundExceptionTest() throws Exception {
 
-        given(recipeSearchService.search(anyLong()))
+        given(recipeSearchService.search(anyLong(), anyLong()))
                 .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_RECIPE));
 
         ResultActions perform =

--- a/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeLikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeLikeControllerTest.java
@@ -124,7 +124,7 @@ public class RecipeLikeControllerTest extends RestDocsTest {
         perform.andExpect(status().isConflict());
 
         perform.andDo(print())
-                .andDo(document("recipe-like-add-member-not-found", getDocumentResponse()));
+                .andDo(document("recipe-like-add-duplicate", getDocumentResponse()));
     }
 
     @Test
@@ -142,6 +142,6 @@ public class RecipeLikeControllerTest extends RestDocsTest {
         perform.andExpect(status().isConflict());
 
         perform.andDo(print())
-                .andDo(document("recipe-like-remove-member-not-found", getDocumentResponse()));
+                .andDo(document("recipe-like-remove-duplicate", getDocumentResponse()));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeLikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeLikeControllerTest.java
@@ -1,0 +1,147 @@
+package com.konggogi.veganlife.recipe.controller;
+
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
+import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.recipe.service.RecipeLikeService;
+import com.konggogi.veganlife.support.docs.RestDocsTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+@WebMvcTest(RecipeLikeController.class)
+public class RecipeLikeControllerTest extends RestDocsTest {
+
+    @MockBean RecipeLikeService recipeLikeService;
+
+    private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
+
+    @Test
+    @DisplayName("레시피 좋아요 API")
+    void addRecipeLikeTest() throws Exception {
+
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/recipes/{id}/likes", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isCreated());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "recipe-like-add",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("id").description("레시피 id"))));
+    }
+
+    @Test
+    @DisplayName("레시피 좋아요 취소 API")
+    void removeRecipeLikeTest() throws Exception {
+
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/recipes/{id}/likes", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isNoContent());
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "recipe-like-remove",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(parameterWithName("id").description("레시피 id"))));
+    }
+
+    @Test
+    @DisplayName("레시피 좋아요/좋아요 취소 API 예외 - Recipe Not Found")
+    void addRecipeLikeRecipeNotFoundExceptionTest() throws Exception {
+
+        willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_RECIPE))
+                .given(recipeLikeService)
+                .add(anyLong(), anyLong());
+
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/recipes/{id}/likes", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("recipe-like-add-recipe-not-found", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("레시피 좋아요/좋아요 취소 API 예외 - Member Not Found")
+    void addRecipeLikeMemberNotFoundExceptionTest() throws Exception {
+
+        willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER))
+                .given(recipeLikeService)
+                .add(anyLong(), anyLong());
+
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/recipes/{id}/likes", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isNotFound());
+
+        perform.andDo(print())
+                .andDo(document("recipe-like-add-member-not-found", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("레시피 좋아요 API 예외 - 중복 좋아요")
+    void addRecipeLikeDuplicateExceptionTest() throws Exception {
+
+        willThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_RECIPE_LIKED))
+                .given(recipeLikeService)
+                .add(anyLong(), anyLong());
+
+        ResultActions perform =
+                mockMvc.perform(
+                        post("/api/v1/recipes/{id}/likes", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isConflict());
+
+        perform.andDo(print())
+                .andDo(document("recipe-like-add-member-not-found", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("레시피 좋아요 취소 API 예외 - 중복 좋아요 취소")
+    void removeRecipeLikeDuplicateExceptionTest() throws Exception {
+
+        willThrow(new IllegalLikeStatusException(ErrorCode.ALREADY_RECIPE_UNLIKED))
+                .given(recipeLikeService)
+                .remove(anyLong(), anyLong());
+
+        ResultActions perform =
+                mockMvc.perform(
+                        delete("/api/v1/recipes/{id}/likes", 1L).headers(authorizationHeader()));
+
+        perform.andExpect(status().isConflict());
+
+        perform.andDo(print())
+                .andDo(document("recipe-like-remove-member-not-found", getDocumentResponse()));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeLikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeLikeControllerTest.java
@@ -123,8 +123,7 @@ public class RecipeLikeControllerTest extends RestDocsTest {
 
         perform.andExpect(status().isConflict());
 
-        perform.andDo(print())
-                .andDo(document("recipe-like-add-duplicate", getDocumentResponse()));
+        perform.andDo(print()).andDo(document("recipe-like-add-duplicate", getDocumentResponse()));
     }
 
     @Test

--- a/src/test/java/com/konggogi/veganlife/recipe/service/RecipeLikeServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/service/RecipeLikeServiceTest.java
@@ -1,0 +1,147 @@
+package com.konggogi.veganlife.recipe.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import com.konggogi.veganlife.global.exception.ErrorCode;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.service.MemberQueryService;
+import com.konggogi.veganlife.post.exception.IllegalLikeStatusException;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeDescription;
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
+import com.konggogi.veganlife.recipe.domain.RecipeLike;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
+import com.konggogi.veganlife.recipe.domain.mapper.RecipeLikeMapper;
+import com.konggogi.veganlife.recipe.domain.mapper.RecipeLikeMapperImpl;
+import com.konggogi.veganlife.recipe.fixture.RecipeDescriptionFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeImageFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeIngredientFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeTypeFixture;
+import com.konggogi.veganlife.recipe.repository.RecipeLikeRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class RecipeLikeServiceTest {
+
+    @Mock MemberQueryService memberQueryService;
+    @Mock RecipeQueryService recipeQueryService;
+    @Mock RecipeLikeQueryService recipeLikeQueryService;
+    @Mock RecipeLikeRepository recipeLikeRepository;
+    @Spy RecipeLikeMapper recipeLikeMapper = new RecipeLikeMapperImpl();
+    @InjectMocks RecipeLikeService recipeLikeService;
+
+    private final Member member = MemberFixture.DEFAULT_M.getWithId(1L);
+
+    @Test
+    @DisplayName("레시피 좋아요 테스트")
+    void addTest() {
+
+        Recipe recipe = createRecipe(1L, "표고버섯 탕수", RecipeTypeFixture.OVO.get());
+
+        given(recipeQueryService.search(1L)).willReturn(recipe);
+        given(memberQueryService.search(1L)).willReturn(member);
+        given(recipeLikeQueryService.searchByRecipeIdAndMemberId(1L, 1L))
+                .willReturn(Optional.empty());
+
+        recipeLikeService.add(1L, 1L);
+
+        then(recipeQueryService).should(times(1)).search(1L);
+        then(memberQueryService).should(times(1)).search(1L);
+        then(recipeLikeQueryService).should(times(1)).searchByRecipeIdAndMemberId(1L, 1L);
+        then(recipeLikeRepository).should(times(1)).save(any(RecipeLike.class));
+    }
+
+    @Test
+    @DisplayName("레시피 좋아요 테스트 - 중복 좋아요")
+    void addDuplicationTest() {
+
+        Recipe recipe = createRecipe(1L, "표고버섯 탕수", RecipeTypeFixture.OVO.get());
+        RecipeLike recipeLike = new RecipeLike(null, recipe, member);
+
+        given(recipeQueryService.search(1L)).willReturn(recipe);
+        given(memberQueryService.search(1L)).willReturn(member);
+        given(recipeLikeQueryService.searchByRecipeIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(recipeLike));
+
+        assertThatThrownBy(() -> recipeLikeService.add(1L, 1L))
+                .isInstanceOf(IllegalLikeStatusException.class)
+                .hasMessage(ErrorCode.ALREADY_RECIPE_LIKED.getDescription());
+    }
+
+    @Test
+    @DisplayName("레시피 좋아요 취소 테스트")
+    void removeTest() {
+
+        Recipe recipe = createRecipe(1L, "표고버섯 탕수", RecipeTypeFixture.OVO.get());
+        RecipeLike recipeLike = new RecipeLike(null, recipe, member);
+
+        given(recipeQueryService.search(1L)).willReturn(recipe);
+        given(memberQueryService.search(1L)).willReturn(member);
+        given(recipeLikeQueryService.searchByRecipeIdAndMemberId(1L, 1L))
+                .willReturn(Optional.of(recipeLike));
+
+        recipeLikeService.remove(1L, 1L);
+
+        then(recipeQueryService).should(times(1)).search(1L);
+        then(memberQueryService).should(times(1)).search(1L);
+        then(recipeLikeQueryService).should(times(1)).searchByRecipeIdAndMemberId(1L, 1L);
+        then(recipeLikeRepository).should(times(1)).delete(any(RecipeLike.class));
+    }
+
+    @Test
+    @DisplayName("레시피 좋아요 취소 테스트 - 중복 좋아요 취소")
+    void removeDuplicationTest() {
+
+        Recipe recipe = createRecipe(1L, "표고버섯 탕수", RecipeTypeFixture.OVO.get());
+
+        given(recipeQueryService.search(1L)).willReturn(recipe);
+        given(memberQueryService.search(1L)).willReturn(member);
+        given(recipeLikeQueryService.searchByRecipeIdAndMemberId(1L, 1L))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> recipeLikeService.remove(1L, 1L))
+                .isInstanceOf(IllegalLikeStatusException.class)
+                .hasMessage(ErrorCode.ALREADY_RECIPE_UNLIKED.getDescription());
+    }
+
+    private Recipe createRecipe(Long id, String name, RecipeType recipeType) {
+
+        List<RecipeType> recipeTypes = List.of(recipeType);
+
+        List<RecipeImage> recipeImages =
+                List.of(
+                        RecipeImageFixture.DEFAULT.get(),
+                        RecipeImageFixture.DEFAULT.get(),
+                        RecipeImageFixture.DEFAULT.get());
+
+        List<RecipeIngredient> ingredients =
+                List.of(
+                        RecipeIngredientFixture.DEFAULT.get(),
+                        RecipeIngredientFixture.DEFAULT.get(),
+                        RecipeIngredientFixture.DEFAULT.get());
+
+        List<RecipeDescription> descriptions =
+                List.of(
+                        RecipeDescriptionFixture.DEFAULT.get(),
+                        RecipeDescriptionFixture.DEFAULT.get(),
+                        RecipeDescriptionFixture.DEFAULT.get());
+
+        return RecipeFixture.DEFAULT.getWithName(
+                id, name, recipeTypes, recipeImages, ingredients, descriptions, member);
+    }
+}


### PR DESCRIPTION
## 이슈 번호 (#247)

## 요약
-  레시피 좋아요/좋아요 취소 API를 구현했습니다.
-  레시피 좋아요/좋아요 취소 기능 테스트했습니다.
- 테스트 내용을 문서화했습니다.

## 동시성 이슈

현재는 좋아요를 추가하기 전에 **좋아요를 눌렀는지 먼저 확인하는 로직을 거침으로써** 연속적으로 좋아요 요청이 발생하더라도 이를 처리할 수 있도록 하였습니다.

그러나 트랜잭션 격리 수준을 공부하면서 해당 로직이 제대로 동작하지 않을 것이라는 생각이 들었습니다.

<img width="500" alt="image" src="https://github.com/Vegan-Life/VeganLife-Backend/assets/74900921/9804ab37-f3f5-4bac-9733-cb37d001816c">

위의 사진과 같이 간발의 차이로 TA가 좋아요를 `save` 하기 전에 TB가 조회 로직을 수행한다면 TB 또한 좋아요가 되지 않은 것으로 간주하고 `add` 로직을 수행하게 될 것 입니다.

### 테스트

```java
        Runnable userA =
                () -> {
                    recipeLikeService.add(recipe.getId(), member.getId());
                };
        ...
        assertThatThrownBy(
                        () -> {
                            try {
                                Future<?> futureA = executorService.submit(threadA);
                                Future<?> futureB = executorService.submit(threadB);
                                futureA.get(); // 스레드의 작업이 끝날 때까지 메인 스레드는 대기, 스레드의 작업이 끝나면 결과 반환
                                futureB.get();
                            } catch (Exception e) {
                                e.printStackTrace();
                                throw e.getCause();
                            }
                        })
                .as("좋아요 요청을 동시에 처리하는 경우, 동시성 문제가 발생한다. (Unique index or primary key violation)")
                .isInstanceOf(DataIntegrityViolationException.class);
```

위와 같이 `add`(좋아요 여부 확인 + 좋아요 `save`)를 수행하는 스레드를 두 개 만들어 동시에 실행함으로써 테스트를 진행했습니다.

**결과**

<img width="376" alt="image" src="https://github.com/Vegan-Life/VeganLife-Backend/assets/74900921/908f2ee3-5fb2-4b15-82b6-4081decc9d32">

동시성 이슈가 발생하여 테스트가 통과한 것을 확인할 수 있었습니다.

### 사실 격리 수준 문제가 아니다!

처음에는 격리 수준에 대한 문제로 보고 ` @Transactional(isolation = Isolation.SERIALIZABLE)`과 같이 최고 격리 수준을 적용하면 트랜잭션이 순차적으로 실행되지 않을까? 라고 생각했습니다. (이해가 부족했던...^^)

결과적으로는 똑같이 동시성 문제가 발생했습니다.
`SERIALIZABLE` 격리 수준 또한 **읽기 잠금을 사용**하는 것이기 때문에 TB가 TA가 `add`를 완료하기 전 레코드를 읽어들이는 것을 막을 수는 없었습니다.
- 사실 데드락이 발생할 것이라고 예상했는데 왜 되는 걸까요...?

아무튼 (좋아요를 눌렀는지 확인하는 로직 + 가능하다면 좋아요를 `save`하는 로직)을 무조건 한 덩어리로 실행되도록 조치해야 했습니다.

### `synchronized` 사용

`add` 메서드 자체에 `synchronized` 키워드를 적용하여 여러 스레드가 동시에 접근하는 것을 막는 방법입니다.

해당 키워드를 사용하면 원하는 목적을 달성할 수는 있었습니다.
그러나 해당 메서드에 한해서는 싱글 스레드로 동작하는 것이기 때문에 매우 저조한 퍼포먼스를 보여주었습니다.

10000개의 스레드 요청을 처리할 때의 퍼포먼스를 비교해보았습니다.

`synchronized` 키워드 X

<img width="300" alt="image" src="https://github.com/Vegan-Life/VeganLife-Backend/assets/74900921/06f30073-60bd-43bf-bc5e-ab88b4cffca3">

`synchronized` 키워드 O

<img width="300" alt="image" src="https://github.com/Vegan-Life/VeganLife-Backend/assets/74900921/e2d759c5-75de-41bd-a3c7-8a1b4535572f">

약 2배 이상의 성능 차이가 나는 것을 확인할 수 있었습니다.

## 낙관적 락? 비관적 락?

`synchronized` 키워드를 사용하여 원하는 목적을 달성할 수 있었지만, 거즘 싱글 스레드로 작동한다는 단점이 있었습니다.
이러한 현상을 해결하기 위해서 Locking 기법을 사용할 수 있다고 하는데, 다음에는 이에 대해 조사하여 공유하도록 하겠습니다!