### PR TITLE
액세스 토큰 재발급시 리프레시 토큰 재발급 및 로직 변경

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -10,7 +10,7 @@ ifndef::snippets[]
 :snippets: ./build/generated-snippets
 endif::[]
 
-== 액세스 토큰 재발급 API
+== 토큰 재발급 API
 
 === Request
 
@@ -30,16 +30,8 @@ include::{snippets}/reissue-token/http-response.adoc[]
 
 ==== 401 UNAUTHORIZED
 
-include::{snippets}/reissue-token-invalid-token/http-response.adoc[]
-
 include::{snippets}/reissue-token-not-found-user-info/http-response.adoc[]
-
-==== 404 NOT FOUND
-
-include::{snippets}/reissue-token-not-found-member/http-response.adoc[]
-
-include::{snippets}/reissue-token-not-found-token/http-response.adoc[]
 
 ==== 400 BAD REQUEST
 
-include::{snippets}/reissue-token-mismatch/http-response.adoc[]
+include::{snippets}/reissue-token-not-found-match-token/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
+++ b/src/main/java/com/konggogi/veganlife/global/exception/ErrorCode.java
@@ -18,8 +18,7 @@ public enum ErrorCode {
     UNSUPPORTED_TOKEN("AUTH_004", "지원되지 않는 JWT 토큰입니다."),
     UNEXPECTED_TOKEN("AUTH_005", "JWT 처리 중 예상치 못한 오류가 발생했습니다."),
     NOT_FOUND_USER_INFO_TOKEN("AUTH_006", "JWT 사용자 정보를 가져올 수 없습니다."),
-    NOT_FOUND_REFRESH_TOKEN("AUTH_007", "RefreshToken이 존재하지 않습니다."),
-    MISMATCH_REFRESH_TOKEN("AUTH_008", "RefreshToken이 일치하지 않습니다."),
+    NOT_FOUND_MATCH_REFRESH_TOKEN("AUTH_007", "일치하는 RefreshToken이 없습니다."),
     AUTHENTICATION_REQUIRED("AUTH_009", "인증이 필요한 URI입니다."),
     ACCESS_DENIED("AUTH_010", "Resource에 접근할 수 있는 권한이 없습니다."),
 

--- a/src/main/java/com/konggogi/veganlife/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/konggogi/veganlife/global/security/jwt/JwtProvider.java
@@ -32,7 +32,7 @@ public class JwtProvider {
         key = jwtUtils.getSignInKey();
     }
 
-    public String createToken(String email) {
+    public String createAccessToken(String email) {
         return createToken(email, TOKEN_EXPIRATION);
     }
 

--- a/src/main/java/com/konggogi/veganlife/member/controller/AuthController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/AuthController.java
@@ -2,23 +2,23 @@ package com.konggogi.veganlife.member.controller;
 
 
 import com.konggogi.veganlife.member.controller.dto.response.ReissueTokenResponse;
-import com.konggogi.veganlife.member.domain.mapper.AuthMapper;
 import com.konggogi.veganlife.member.service.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/auth")
 public class AuthController {
     private final RefreshTokenService refreshTokenService;
-    private final AuthMapper authMapper;
 
     @PostMapping("/reissue")
     public ResponseEntity<ReissueTokenResponse> reissueToken(
             @RequestAttribute("refreshToken") String refreshToken) {
-        String accessToken = refreshTokenService.reissueAccessToken(refreshToken);
-        return ResponseEntity.ok(authMapper.toReissueTokenResponse(accessToken));
+        return ResponseEntity.ok(refreshTokenService.reissueToken(refreshToken));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/OauthController.java
@@ -3,7 +3,7 @@ package com.konggogi.veganlife.member.controller;
 
 import com.konggogi.veganlife.member.controller.dto.request.OauthRequest;
 import com.konggogi.veganlife.member.controller.dto.response.OauthLoginResponse;
-import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
+import com.konggogi.veganlife.member.domain.mapper.AuthMapper;
 import com.konggogi.veganlife.member.domain.oauth.OauthProvider;
 import com.konggogi.veganlife.member.service.MemberService;
 import com.konggogi.veganlife.member.service.OauthService;
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 public class OauthController {
     private final OauthService oauthService;
     private final MemberService memberService;
-    private final MemberMapper memberMapper;
+    private final AuthMapper authMapper;
 
     @PostMapping("/{provider}/login")
     public ResponseEntity<OauthLoginResponse> login(
@@ -26,6 +26,6 @@ public class OauthController {
                 oauthService
                         .userAttributesToMember(provider, oauthRequest.accessToken())
                         .getEmail();
-        return ResponseEntity.ok(memberMapper.toOauthLoginResponse(memberService.login(userEmail)));
+        return ResponseEntity.ok(authMapper.toOauthLoginResponse(memberService.login(userEmail)));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/dto/response/ReissueTokenResponse.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/dto/response/ReissueTokenResponse.java
@@ -1,3 +1,3 @@
 package com.konggogi.veganlife.member.controller.dto.response;
 
-public record ReissueTokenResponse(String accessToken) {}
+public record ReissueTokenResponse(String accessToken, String refreshToken) {}

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/AuthMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/AuthMapper.java
@@ -1,10 +1,21 @@
 package com.konggogi.veganlife.member.domain.mapper;
 
 
+import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+import com.konggogi.veganlife.member.controller.dto.response.OauthLoginResponse;
 import com.konggogi.veganlife.member.controller.dto.response.ReissueTokenResponse;
+import com.konggogi.veganlife.member.service.dto.MemberLoginDto;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface AuthMapper {
-    ReissueTokenResponse toReissueTokenResponse(String accessToken);
+    @Mapping(target = "id", ignore = true)
+    RefreshToken toRefreshToken(Long memberId, String token);
+
+    ReissueTokenResponse toReissueTokenResponse(String accessToken, String refreshToken);
+
+    @Mapping(target = "email", source = "memberLoginDto.member.email")
+    @Mapping(target = "hasAdditionalInfo", source = "memberLoginDto.member.hasAdditionalInfo")
+    OauthLoginResponse toOauthLoginResponse(MemberLoginDto memberLoginDto);
 }

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
@@ -1,10 +1,8 @@
 package com.konggogi.veganlife.member.domain.mapper;
 
 
-import com.konggogi.veganlife.global.security.jwt.RefreshToken;
 import com.konggogi.veganlife.member.controller.dto.response.AdditionalInfoUpdateResponse;
 import com.konggogi.veganlife.member.controller.dto.response.MemberProfileResponse;
-import com.konggogi.veganlife.member.controller.dto.response.OauthLoginResponse;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.dto.MemberLoginDto;
 import org.mapstruct.Mapper;
@@ -17,13 +15,6 @@ public interface MemberMapper {
     }
 
     MemberLoginDto toMemberLoginDto(Member member, String accessToken, String refreshToken);
-
-    @Mapping(target = "id", ignore = true)
-    RefreshToken toRefreshToken(Long memberId, String token);
-
-    @Mapping(target = "email", source = "memberLoginDto.member.email")
-    @Mapping(target = "hasAdditionalInfo", source = "memberLoginDto.member.hasAdditionalInfo")
-    OauthLoginResponse toOauthLoginResponse(MemberLoginDto memberLoginDto);
 
     @Mapping(target = "imageUrl", source = "member.profileImageUrl")
     MemberProfileResponse toMemberProfileResponse(Member member);

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
 
     public MemberLoginDto login(String email) {
         Member member = addIfNotPresent(email);
-        String accessToken = jwtProvider.createToken(email);
+        String accessToken = jwtProvider.createAccessToken(email);
         String refreshToken = jwtProvider.createRefreshToken(email);
         refreshTokenService.addOrUpdate(member.getId(), refreshToken);
         return memberMapper.toMemberLoginDto(member, accessToken, refreshToken);

--- a/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/RefreshTokenService.java
@@ -2,12 +2,12 @@ package com.konggogi.veganlife.member.service;
 
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
-import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.global.security.exception.MismatchTokenException;
 import com.konggogi.veganlife.global.security.jwt.JwtProvider;
 import com.konggogi.veganlife.global.security.jwt.RefreshToken;
+import com.konggogi.veganlife.member.controller.dto.response.ReissueTokenResponse;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
+import com.konggogi.veganlife.member.domain.mapper.AuthMapper;
 import com.konggogi.veganlife.member.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,41 +22,40 @@ public class RefreshTokenService {
     private final MemberQueryService memberQueryService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
-    private final MemberMapper memberMapper;
+    private final AuthMapper authMapper;
 
     public void addOrUpdate(Long memberId, String bearerRefreshToken) {
         memberQueryService
                 .searchRefreshToken(memberId)
                 .ifPresentOrElse(
-                        storedToken -> {
-                            storedToken.update(bearerRefreshToken);
-                            log.debug("Refresh token updated for memberId: {}", memberId);
-                        },
-                        () -> {
-                            add(memberId, bearerRefreshToken);
-                            log.debug("New refresh token created for memberId: {}", memberId);
-                        });
+                        storedToken -> update(storedToken, bearerRefreshToken),
+                        () -> add(memberId, bearerRefreshToken));
     }
 
-    public String reissueAccessToken(String refreshToken) {
+    public ReissueTokenResponse reissueToken(String refreshToken) {
         Member member = memberQueryService.searchByToken(refreshToken);
+        RefreshToken storedToken = findMatchingRefreshToken(member.getId(), refreshToken);
+        String newRefreshToken = jwtProvider.createRefreshToken(member.getEmail());
+        String newAccessToken = jwtProvider.createAccessToken(member.getEmail());
+        update(storedToken, newRefreshToken);
+        return authMapper.toReissueTokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    private void add(Long memberId, String bearerRefreshToken) {
+        refreshTokenRepository.save(authMapper.toRefreshToken(memberId, bearerRefreshToken));
+        log.debug("New refresh token created for memberId: {}", memberId);
+    }
+
+    private void update(RefreshToken refreshToken, String bearerRefreshToken) {
+        refreshToken.update(bearerRefreshToken);
+        log.debug("Refresh token updated for memberId: {}", refreshToken.getMemberId());
+    }
+
+    private RefreshToken findMatchingRefreshToken(Long memberId, String refreshToken) {
         return memberQueryService
-                .searchRefreshToken(member.getId())
-                .map(
-                        storedToken -> {
-                            validateIsSameToken(storedToken, refreshToken);
-                            return jwtProvider.createToken(member.getEmail());
-                        })
-                .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_REFRESH_TOKEN));
-    }
-
-    private void add(Long memberId, String refreshToken) {
-        refreshTokenRepository.save(memberMapper.toRefreshToken(memberId, refreshToken));
-    }
-
-    private void validateIsSameToken(RefreshToken refreshToken, String token) {
-        if (!refreshToken.isSameToken(token)) {
-            throw new MismatchTokenException(ErrorCode.MISMATCH_REFRESH_TOKEN);
-        }
+                .searchRefreshToken(memberId)
+                .filter(storedToken -> storedToken.isSameToken(refreshToken))
+                .orElseThrow(
+                        () -> new MismatchTokenException(ErrorCode.NOT_FOUND_MATCH_REFRESH_TOKEN));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
@@ -65,7 +65,7 @@ class MemberServiceTest {
         String refreshToken = "refreshToken";
         given(memberRepository.findByEmail(anyString())).willReturn(Optional.empty());
         given(memberRepository.save(any(Member.class))).willReturn(member);
-        given(jwtProvider.createToken(anyString())).willReturn(accessToken);
+        given(jwtProvider.createAccessToken(anyString())).willReturn(accessToken);
         given(jwtProvider.createRefreshToken(anyString())).willReturn(refreshToken);
         doNothing().when(refreshTokenService).addOrUpdate(anyLong(), anyString());
         // when
@@ -84,7 +84,7 @@ class MemberServiceTest {
         String accessToken = "accessToken";
         String refreshToken = "refreshToken";
         given(memberRepository.findByEmail(anyString())).willReturn(Optional.of(member));
-        given(jwtProvider.createToken(anyString())).willReturn(accessToken);
+        given(jwtProvider.createAccessToken(anyString())).willReturn(accessToken);
         given(jwtProvider.createRefreshToken(anyString())).willReturn(refreshToken);
         doNothing().when(refreshTokenService).addOrUpdate(anyLong(), anyString());
         // when

--- a/src/test/java/com/konggogi/veganlife/support/restassured/IntegrationTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/restassured/IntegrationTest.java
@@ -42,6 +42,6 @@ public class IntegrationTest {
 
     protected String getAccessToken() {
 
-        return jwtProvider.createToken(member.getEmail());
+        return jwtProvider.createAccessToken(member.getEmail());
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#244 )

## 변경 내용
- 액세스 토큰 재발급시 리프레시 토큰 재발급 로직 추가
- 토큰 재발급을 위해 DB의 리프레시 토큰과 일치하는지 검증하는 과정을 `filter`를 사용하도록 변경
