### PR TITLE
[FIX] 레시피 UI 수정에 따른 API Response 수정

### DIFF
--- a/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/RecipeController.java
@@ -33,9 +33,12 @@ public class RecipeController {
 
     @GetMapping
     public ResponseEntity<Page<RecipeResponse>> getRecipeList(
-            VegetarianType vegetarianType, Pageable pageable) {
+            VegetarianType vegetarianType,
+            Pageable pageable,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        return ResponseEntity.ok(recipeSearchService.searchAll(vegetarianType, pageable));
+        return ResponseEntity.ok(
+                recipeSearchService.searchAll(vegetarianType, pageable, userDetails.id()));
     }
 
     @GetMapping("/{id}")
@@ -64,8 +67,11 @@ public class RecipeController {
 
     @GetMapping("/search")
     public ResponseEntity<Page<RecipeResponse>> getRecipeListByKeyword(
-            String keyword, Pageable pageable) {
+            String keyword,
+            Pageable pageable,
+            @AuthenticationPrincipal UserDetailsImpl userDetails) {
 
-        return ResponseEntity.ok(recipeSearchService.searchAllByKeyword(keyword, pageable));
+        return ResponseEntity.ok(
+                recipeSearchService.searchAllByKeyword(keyword, pageable, userDetails.id()));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeAuthorResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeAuthorResponse.java
@@ -1,0 +1,6 @@
+package com.konggogi.veganlife.recipe.controller.dto.response;
+
+
+import com.konggogi.veganlife.member.domain.VegetarianType;
+
+public record RecipeAuthorResponse(Long id, String nickname, VegetarianType vegetarianType) {}

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeDetailsResponse.java
@@ -5,9 +5,10 @@ import com.konggogi.veganlife.member.domain.VegetarianType;
 import java.util.List;
 
 public record RecipeDetailsResponse(
-        boolean isLiked,
         String name,
         List<VegetarianType> recipeTypes,
         List<String> imageUrls,
         List<String> ingredients,
-        List<String> descriptions) {}
+        List<String> descriptions,
+        RecipeAuthorResponse author,
+        boolean isLiked) {}

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeResponse.java
@@ -5,4 +5,9 @@ import com.konggogi.veganlife.member.domain.VegetarianType;
 import java.util.List;
 
 public record RecipeResponse(
-        Long id, String name, String thumbnailUrl, List<VegetarianType> recipeTypes) {}
+        Long id,
+        String name,
+        String thumbnailUrl,
+        List<VegetarianType> recipeTypes,
+        RecipeAuthorResponse author,
+        boolean isLiked) {}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
@@ -28,7 +28,8 @@ public interface RecipeMapper {
             source = "recipe.recipeTypes",
             target = "recipeTypes",
             qualifiedByName = "recipeTypeToVegetarianType")
-    RecipeResponse toRecipeResponse(Recipe recipe);
+    @Mapping(source = "recipe.member", target = "author")
+    RecipeResponse toRecipeResponse(Recipe recipe, boolean isLiked);
 
     @Mapping(
             source = "recipe.recipeTypes",
@@ -46,10 +47,12 @@ public interface RecipeMapper {
             source = "recipe.descriptions",
             target = "descriptions",
             qualifiedByName = "recipeDescriptionToString")
+    @Mapping(source = "recipe.member", target = "author")
     RecipeDetailsResponse toRecipeDetailsResponse(Recipe recipe, boolean isLiked);
 
     default Recipe toEntity(RecipeAddRequest request, Member member) {
 
+        // TODO: 이 로직이 매핑 로직인지, 서비스 로직인지 모호함, 리팩토링 단계에서 추가적으로 고민
         Recipe recipe = Recipe.builder().name(request.name()).member(member).build();
 
         List<RecipeType> recipeTypes =
@@ -72,6 +75,7 @@ public interface RecipeMapper {
                                                 idx + 1, request.descriptions().get(idx), recipe))
                         .toList();
 
+        // TODO: update 내부에서 Recipe와 Recipe 하위 엔티티의 관계를 설정하도록 수정
         recipe.update(recipeTypes, recipeImages, ingredients, descriptions);
 
         return recipe;

--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
@@ -32,18 +32,27 @@ public class RecipeSearchService {
 
     private final RecipeMapper recipeMapper;
 
-    public Page<RecipeResponse> searchAll(VegetarianType vegetarianType, Pageable pageable) {
+    public Page<RecipeResponse> searchAll(
+            VegetarianType vegetarianType, Pageable pageable, Long memberId) {
 
+        // TODO: 조회하는 레시피의 개수만큼 좋아요를 했는지 확인하는 쿼리 발생, 개선이 필요하다.
         return recipeQueryService
                 .searchAllByRecipeType(vegetarianType, pageable)
-                .map(recipeMapper::toRecipeResponse);
+                .map(
+                        recipe ->
+                                recipeMapper.toRecipeResponse(
+                                        recipe, isLikedRecipe(recipe.getId(), memberId)));
     }
 
-    public Page<RecipeResponse> searchAllByKeyword(String keyword, Pageable pageable) {
+    public Page<RecipeResponse> searchAllByKeyword(
+            String keyword, Pageable pageable, Long memberId) {
 
         return recipeQueryService
                 .searchAllByKeyword(keyword, pageable)
-                .map(recipeMapper::toRecipeResponse);
+                .map(
+                        recipe ->
+                                recipeMapper.toRecipeResponse(
+                                        recipe, isLikedRecipe(recipe.getId(), memberId)));
     }
 
     public RecipeDetailsResponse search(Long recipeId, Long memberId) {
@@ -56,7 +65,12 @@ public class RecipeSearchService {
 
         Member member = memberQueryService.search(memberId);
 
-        return getRecommendRecipes(member).stream().map(recipeMapper::toRecipeResponse).toList();
+        return getRecommendRecipes(member).stream()
+                .map(
+                        recipe ->
+                                recipeMapper.toRecipeResponse(
+                                        recipe, isLikedRecipe(recipe.getId(), memberId)))
+                .toList();
     }
 
     // TODO: 랜덤 조회를 위해 5개의 쿼리가 발생, 성능 측정 필요

--- a/src/test/java/com/konggogi/veganlife/recipe/service/RecipeSearchServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/service/RecipeSearchServiceTest.java
@@ -69,7 +69,7 @@ public class RecipeSearchServiceTest {
                 .willReturn(result);
 
         Page<RecipeResponse> response =
-                recipeSearchService.searchAll(VegetarianType.OVO, Pageable.ofSize(20));
+                recipeSearchService.searchAll(VegetarianType.OVO, Pageable.ofSize(20), 1L);
 
         assertThat(response.getNumberOfElements()).isEqualTo(2);
         assertThat(response.getContent().get(0).thumbnailUrl())


### PR DESCRIPTION
## 이슈 번호 (#256)

## 요약
- `Recipe` 목록 조회, 상세 조회 API의 Response Body에 필요한 필드들을 추가했습니다.

## 변경 내용
- `Recipe` 목록 조회 Response에 작성자 정보(`id`, `nickname`, `vegetarianType`)와 좋아요 여부를 추가했습니다.
- `Recipe` 상세 조회 Response에 작성자 정보를 추가했습니다.
- 변경된 Response를 검증하는 테스트 코드를 추가했습니다.

