### PR TITLE
[BUG] MealLogMapper에서 MealImage 매핑 시 오류 수정

### DIFF
--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -36,6 +36,9 @@ public interface MealLogMapper {
     @Named("mealImageToImageUrl")
     static String mealImageToImageUrl(MealImage mealImage) {
 
+        if (mealImage == null) {
+            return null;
+        }
         return mealImage.getImageUrl();
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#265)

## 요약
`MealLogMapper.mealImageToImageUrl`의 매개변수로 null값이 들어왔을 경우 예외 처리를 통해 오류 해결
