### PR TITLE
[REFACTOR/ENHANCEMENT] 주간 섭취 칼로리 조회 API 리팩토링

### DIFF
--- a/src/docs/asciidoc/nutrients.adoc
+++ b/src/docs/asciidoc/nutrients.adoc
@@ -54,7 +54,7 @@ include::{snippets}/daily-nutrients/http-response.adoc[]
 
 include::{snippets}/daily-nutrients-not-found-member/http-response.adoc[]
 
-== 주간 섭취량 조회 API
+== 주간 섭취 칼로리 조회 API
 
 === Request
 
@@ -79,7 +79,7 @@ include::{snippets}/weekly-intake/http-response.adoc[]
 
 include::{snippets}/weekly-intake-not-found/http-response.adoc[]
 
-== 월간 섭취량 조회 API
+== 월간 섭취 칼로리 조회 API
 
 === Request
 
@@ -96,7 +96,7 @@ include::{snippets}/monthly-intake/http-request.adoc[]
 === Response
 
 ==== 200 OK
-각 주차별 합산된 칼로리 값
+각 주차별 합산된 칼로리 값 (월별 주(week) 개수가 다를 수 있음)
 
 include::{snippets}/monthly-intake/http-response.adoc[]
 
@@ -104,7 +104,7 @@ include::{snippets}/monthly-intake/http-response.adoc[]
 
 include::{snippets}/monthly-intake-not-found/http-response.adoc[]
 
-== 연간 섭취량 조회 API
+== 연간 섭취 칼로리 조회 API
 
 === Request
 

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -7,6 +7,10 @@ import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.member.domain.Member;
+import jakarta.persistence.Tuple;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -32,6 +36,17 @@ public interface MealLogMapper {
             target = "totalIntakeNutrients",
             expression = "java(mealLog.getTotalIntakeNutrients())")
     MealLogDetailsResponse toMealLogDetailsResponse(MealLog mealLog);
+
+    default Map<MealType, Integer> toTotalCaloriesOfMealTypeMap(
+            List<Tuple> caloriesOfMealTypeTuples) {
+        Map<MealType, Integer> caloriesOfMealTypeMap = new EnumMap<>(MealType.class);
+        for (Tuple tuple : caloriesOfMealTypeTuples) {
+            MealType mealType = tuple.get(0, MealType.class);
+            Integer totalCalories = tuple.get(1, Long.class).intValue();
+            caloriesOfMealTypeMap.put(mealType, totalCalories);
+        }
+        return caloriesOfMealTypeMap;
+    }
 
     @Named("mealImageToImageUrl")
     static String mealImageToImageUrl(MealImage mealImage) {

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -3,8 +3,8 @@ package com.konggogi.veganlife.meallog.repository;
 
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.member.domain.Member;
+import jakarta.persistence.Tuple;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,8 +13,22 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MealLogRepository extends JpaRepository<MealLog, Long> {
-    List<MealLog> findAllByMemberIdAndCreatedAtBetween(
-            Long memberId, LocalDateTime startDate, LocalDateTime endDate);
+    @Query(
+            "select ml.mealType as mealType, SUM(m.calorie) as totalCalories "
+                    + "from MealLog ml join ml.meals m "
+                    + "where ml.member.id = :memberId "
+                    + "and cast(ml.createdAt as localdate) = :date "
+                    + "group by ml.mealType")
+    List<Tuple> sumCaloriesOfMealTypeByMemberIdAndCreatedAt(Long memberId, LocalDate date);
+
+    @Query(
+            "select ml.mealType as mealType, SUM(m.calorie) as totalCalories "
+                    + "from MealLog ml join ml.meals m "
+                    + "where ml.member.id = :memberId "
+                    + "and cast(ml.createdAt as localdate) between :startDate and :endDate "
+                    + "group by ml.mealType")
+    List<Tuple> sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
+            Long memberId, LocalDate startDate, LocalDate endDate);
 
     @Query(" select distinct m from MealLog m join fetch m.meals" + " where m.id = :id")
     Optional<MealLog> findById(Long id);

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
@@ -6,6 +6,7 @@ import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
+import jakarta.persistence.Tuple;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,15 @@ public class MealLogQueryService {
         return mealLogRepository
                 .findById(id)
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEAL_LOG));
+    }
+
+    public List<Tuple> sumCaloriesOfMealTypeByMemberIdAndDate(Long memberId, LocalDate date) {
+        return mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAt(memberId, date);
+    }
+
+    public List<Tuple> sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+            Long memberId, LocalDate startDate, LocalDate endDate) {
+        return mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
+                memberId, startDate, endDate);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/NutrientsController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/NutrientsController.java
@@ -9,7 +9,7 @@ import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.mapper.NutrientsMapper;
 import com.konggogi.veganlife.member.service.IntakeNutrientsService;
 import com.konggogi.veganlife.member.service.MemberQueryService;
-import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
+import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import java.time.LocalDate;
 import java.util.List;
@@ -51,7 +51,7 @@ public class NutrientsController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
             @RequestParam("endDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
-        List<CaloriesOfMealType> mealCalories =
+        List<IntakeCalorie> mealCalories =
                 intakeNutrientsService.searchWeeklyIntakeCalories(
                         userDetails.id(), startDate, endDate);
         int totalCalorie = intakeNutrientsService.calcTotalCalorie(mealCalories);
@@ -64,7 +64,7 @@ public class NutrientsController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd")
                     LocalDate startDate) {
-        List<CaloriesOfMealType> mealCalories =
+        List<IntakeCalorie> mealCalories =
                 intakeNutrientsService.searchMonthlyIntakeCalories(userDetails.id(), startDate);
         int totalCalorie = intakeNutrientsService.calcTotalCalorie(mealCalories);
         return ResponseEntity.ok(
@@ -76,7 +76,7 @@ public class NutrientsController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd")
                     LocalDate startDate) {
-        List<CaloriesOfMealType> mealCalories =
+        List<IntakeCalorie> mealCalories =
                 intakeNutrientsService.searchYearlyIntakeCalories(userDetails.id(), startDate);
         int totalCalorie = intakeNutrientsService.calcTotalCalorie(mealCalories);
         return ResponseEntity.ok(

--- a/src/main/java/com/konggogi/veganlife/member/controller/dto/response/CalorieIntakeResponse.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/dto/response/CalorieIntakeResponse.java
@@ -1,8 +1,7 @@
 package com.konggogi.veganlife.member.controller.dto.response;
 
 
-import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
+import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
 import java.util.List;
 
-public record CalorieIntakeResponse(
-        Integer totalCalorie, List<CaloriesOfMealType> periodicCalorie) {}
+public record CalorieIntakeResponse(Integer totalCalorie, List<IntakeCalorie> periodicCalorie) {}

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/NutrientsMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/NutrientsMapper.java
@@ -5,7 +5,7 @@ import com.konggogi.veganlife.member.controller.dto.response.CalorieIntakeRespon
 import com.konggogi.veganlife.member.controller.dto.response.DailyIntakeResponse;
 import com.konggogi.veganlife.member.controller.dto.response.RecommendNutrientsResponse;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
+import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import java.util.List;
 import org.mapstruct.Mapper;
@@ -18,7 +18,7 @@ public interface NutrientsMapper {
     @Mapping(target = "dailyCalorie", source = "member.AMR")
     RecommendNutrientsResponse toRecommendNutrientsResponse(Member member);
 
-    @Mapping(source = "caloriesOfMealTypes", target = "periodicCalorie")
+    @Mapping(source = "intakeCalories", target = "periodicCalorie")
     CalorieIntakeResponse toCalorieIntakeResponse(
-            int totalCalorie, List<CaloriesOfMealType> caloriesOfMealTypes);
+            int totalCalorie, List<IntakeCalorie> intakeCalories);
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
@@ -4,6 +4,7 @@ package com.konggogi.veganlife.member.service;
 import com.konggogi.veganlife.meallog.domain.Meal;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.meallog.domain.mapper.MealLogMapper;
 import com.konggogi.veganlife.meallog.service.MealLogQueryService;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class IntakeNutrientsService {
     private final MemberQueryService memberQueryService;
     private final MealLogQueryService mealLogQueryService;
+    private final MealLogMapper mealLogMapper;
 
     public IntakeNutrients searchDailyIntakeNutrients(Long memberId, LocalDate date) {
         Member member = memberQueryService.search(memberId);
@@ -116,17 +118,13 @@ public class IntakeNutrientsService {
     }
 
     private IntakeCalorie createCaloriesOfMealType(List<Tuple> caloriesOfMealTypeTuples) {
-        Map<MealType, Integer> caloriesOfMealTypeMap = new EnumMap<>(MealType.class);
-        for (Tuple tuple : caloriesOfMealTypeTuples) {
-            MealType mealType = tuple.get("mealType", MealType.class);
-            Integer totalCalories = tuple.get("totalCalories", Long.class).intValue();
-            caloriesOfMealTypeMap.put(mealType, totalCalories);
-        }
+        Map<MealType, Integer> totalCaloriesOfMealTypeMap =
+                mealLogMapper.toTotalCaloriesOfMealTypeMap(caloriesOfMealTypeTuples);
         return new IntakeCalorie(
-                caloriesOfMealTypeMap.getOrDefault(MealType.BREAKFAST, 0),
-                caloriesOfMealTypeMap.getOrDefault(MealType.LUNCH, 0),
-                caloriesOfMealTypeMap.getOrDefault(MealType.DINNER, 0),
-                sumSnackTotalCalorie(caloriesOfMealTypeMap));
+                totalCaloriesOfMealTypeMap.getOrDefault(MealType.BREAKFAST, 0),
+                totalCaloriesOfMealTypeMap.getOrDefault(MealType.LUNCH, 0),
+                totalCaloriesOfMealTypeMap.getOrDefault(MealType.DINNER, 0),
+                sumSnackTotalCalorie(totalCaloriesOfMealTypeMap));
     }
 
     private int sumSnackTotalCalorie(Map<MealType, Integer> caloriesByType) {

--- a/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
@@ -6,7 +6,7 @@ import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.meallog.service.MealLogQueryService;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
+import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import jakarta.persistence.Tuple;
 import java.time.LocalDate;
@@ -30,7 +30,7 @@ public class IntakeNutrientsService {
         return sumIntakeNutrients(searchAllMealByMemberAndCreatedAt(member, date));
     }
 
-    public List<CaloriesOfMealType> searchWeeklyIntakeCalories(
+    public List<IntakeCalorie> searchWeeklyIntakeCalories(
             Long memberId, LocalDate startDate, LocalDate endDate) {
         memberQueryService.search(memberId);
         return startDate
@@ -42,8 +42,7 @@ public class IntakeNutrientsService {
                 .toList();
     }
 
-    public List<CaloriesOfMealType> searchMonthlyIntakeCalories(
-            Long memberId, LocalDate startDate) {
+    public List<IntakeCalorie> searchMonthlyIntakeCalories(Long memberId, LocalDate startDate) {
         memberQueryService.search(memberId);
         startDate = YearMonth.from(startDate).atDay(1);
         LocalDate endDate = YearMonth.from(startDate).atEndOfMonth();
@@ -57,7 +56,7 @@ public class IntakeNutrientsService {
                 .toList();
     }
 
-    public List<CaloriesOfMealType> searchYearlyIntakeCalories(Long memberId, LocalDate startDate) {
+    public List<IntakeCalorie> searchYearlyIntakeCalories(Long memberId, LocalDate startDate) {
         memberQueryService.search(memberId);
         int year = startDate.getYear();
         startDate = LocalDate.of(year, 1, 1);
@@ -74,8 +73,8 @@ public class IntakeNutrientsService {
                 .toList();
     }
 
-    public int calcTotalCalorie(List<CaloriesOfMealType> caloriesOfMealTypes) {
-        return caloriesOfMealTypes.parallelStream()
+    public int calcTotalCalorie(List<IntakeCalorie> intakeCalories) {
+        return intakeCalories.parallelStream()
                 .reduce(
                         0,
                         (accumulator, mealCalorie) ->
@@ -102,13 +101,13 @@ public class IntakeNutrientsService {
         return new IntakeNutrients(totalCalorie, totalCarbs, totalProtein, totalFat);
     }
 
-    private CaloriesOfMealType aggregateDailyCaloriesOfMealType(Long memberId, LocalDate date) {
+    private IntakeCalorie aggregateDailyCaloriesOfMealType(Long memberId, LocalDate date) {
         List<Tuple> caloriesOfMeals =
                 mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDate(memberId, date);
         return createCaloriesOfMealType(caloriesOfMeals);
     }
 
-    private CaloriesOfMealType aggregateCaloriesOfMealTypeForPeriod(
+    private IntakeCalorie aggregateCaloriesOfMealTypeForPeriod(
             Long memberId, LocalDate startDate, LocalDate endDate) {
         List<Tuple> caloriesOfMeals =
                 mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
@@ -116,14 +115,14 @@ public class IntakeNutrientsService {
         return createCaloriesOfMealType(caloriesOfMeals);
     }
 
-    private CaloriesOfMealType createCaloriesOfMealType(List<Tuple> caloriesOfMealTypeTuples) {
+    private IntakeCalorie createCaloriesOfMealType(List<Tuple> caloriesOfMealTypeTuples) {
         Map<MealType, Integer> caloriesOfMealTypeMap = new EnumMap<>(MealType.class);
         for (Tuple tuple : caloriesOfMealTypeTuples) {
             MealType mealType = tuple.get("mealType", MealType.class);
             Integer totalCalories = tuple.get("totalCalories", Long.class).intValue();
             caloriesOfMealTypeMap.put(mealType, totalCalories);
         }
-        return new CaloriesOfMealType(
+        return new IntakeCalorie(
                 caloriesOfMealTypeMap.getOrDefault(MealType.BREAKFAST, 0),
                 caloriesOfMealTypeMap.getOrDefault(MealType.LUNCH, 0),
                 caloriesOfMealTypeMap.getOrDefault(MealType.DINNER, 0),

--- a/src/main/java/com/konggogi/veganlife/member/service/dto/CaloriesOfMealType.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/dto/CaloriesOfMealType.java
@@ -1,3 +1,0 @@
-package com.konggogi.veganlife.member.service.dto;
-
-public record CaloriesOfMealType(Integer breakfast, Integer lunch, Integer dinner, Integer snack) {}

--- a/src/main/java/com/konggogi/veganlife/member/service/dto/IntakeCalorie.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/dto/IntakeCalorie.java
@@ -1,0 +1,3 @@
+package com.konggogi.veganlife.member.service.dto;
+
+public record IntakeCalorie(Integer breakfast, Integer lunch, Integer dinner, Integer snack) {}

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
@@ -1,7 +1,8 @@
 package com.konggogi.veganlife.meallog.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
@@ -16,7 +17,9 @@ import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
 import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -34,7 +37,7 @@ public class MealLogQueryServiceTest {
     @Mock MealLogRepository mealLogRepository;
     @InjectMocks MealLogQueryService mealLogQueryService;
 
-    Member member = Member.builder().email("test123@test.com").build();
+    Member member = MemberFixture.DEFAULT_F.getWithId(1L);
     List<MealData> mealData =
             List.of(
                     MealDataFixture.TOTAL_AMOUNT.get(1L, member),
@@ -90,5 +93,40 @@ public class MealLogQueryServiceTest {
         assertThatThrownBy(() -> mealLogQueryService.search(1L))
                 .isInstanceOf(NotFoundEntityException.class)
                 .hasMessage(ErrorCode.NOT_FOUND_MEAL_LOG.getDescription());
+    }
+
+    @Test
+    @DisplayName("회원 id와 날짜에 해당하는 MealLog를 MealType별로 합산")
+    void sumCaloriesOfMealTypeByMemberIdAndDateTest() {
+        // given
+        LocalDate date = LocalDate.of(2024, 2, 24);
+        given(
+                        mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAt(
+                                anyLong(), any(LocalDate.class)))
+                .willReturn(new ArrayList<>());
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(
+                        () ->
+                                mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDate(
+                                        member.getId(), date));
+    }
+
+    @Test
+    @DisplayName("회원 id와 기간에 해당하는 MealLog를 MealType별로 합산")
+    void sumCaloriesOfMealTypeByMemberIdAndDateBetweenTest() {
+        LocalDate startDate = LocalDate.of(2024, 2, 18);
+        LocalDate endDate = LocalDate.of(2024, 2, 24);
+        given(
+                        mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
+                                anyLong(), any(LocalDate.class), any(LocalDate.class)))
+                .willReturn(new ArrayList<>());
+
+        assertThatNoException()
+                .isThrownBy(
+                        () ->
+                                mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+                                        member.getId(), startDate, endDate));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/controller/NutrientsControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/NutrientsControllerTest.java
@@ -20,7 +20,7 @@ import com.konggogi.veganlife.member.fixture.CaloriesOfMealTypeFixture;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.service.IntakeNutrientsService;
 import com.konggogi.veganlife.member.service.MemberQueryService;
-import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
+import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
 import java.time.LocalDate;
@@ -39,7 +39,7 @@ class NutrientsControllerTest extends RestDocsTest {
 
     @Test
     @DisplayName("권장 섭취량 조회 API")
-    void getMemberDailyNutrientsTest() throws Exception {
+    void getRecommendNutrientsTest() throws Exception {
         // given
         Member member = MemberFixture.DEFAULT_M.getWithId(1L);
         given(memberQueryService.search(anyLong())).willReturn(member);
@@ -63,8 +63,8 @@ class NutrientsControllerTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("권장 섭취량 조회 API - 없는 회원 예외 발생")
-    void getNotMemberDailyNutrientsTest() throws Exception {
+    @DisplayName("권장 섭취량 조회 API - Not Found Member")
+    void getRecommendNutrientsNotFoundMemberTest() throws Exception {
         // given
         given(memberQueryService.search(anyLong()))
                 .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
@@ -109,8 +109,8 @@ class NutrientsControllerTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("일일 섭취량 조회 API - 없는 회원 예외 발생")
-    void getDailyIntakeNotMemberTest() throws Exception {
+    @DisplayName("일일 섭취량 조회 API - Not Found Member")
+    void getDailyIntakeNotFoundMemberTest() throws Exception {
         // given
         given(intakeNutrientsService.searchDailyIntakeNutrients(anyLong(), any(LocalDate.class)))
                 .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
@@ -129,19 +129,19 @@ class NutrientsControllerTest extends RestDocsTest {
 
     @Test
     @DisplayName("주간 섭취량 조회 API")
-    void getWeeklyIntakeTest() throws Exception {
+    void getWeeklyIntakeCalorieTest() throws Exception {
         // given
-        List<CaloriesOfMealType> caloriesOfMealTypes = new ArrayList<>();
+        List<IntakeCalorie> intakeCalories = new ArrayList<>();
         int days = 7;
         for (int i = 0; i < days; i++) {
-            caloriesOfMealTypes.add(CaloriesOfMealTypeFixture.DEFAULT.get());
+            intakeCalories.add(CaloriesOfMealTypeFixture.DEFAULT.get());
         }
-        int caloriePerMealType = caloriesOfMealTypes.get(0).breakfast();
-        int totalCalorie = caloriePerMealType * 4 * days;
+        int calorieOfMealType = intakeCalories.get(0).breakfast();
+        int totalCalorie = (calorieOfMealType * 4) * days;
         given(
                         intakeNutrientsService.searchWeeklyIntakeCalories(
                                 anyLong(), any(LocalDate.class), any(LocalDate.class)))
-                .willReturn(caloriesOfMealTypes);
+                .willReturn(intakeCalories);
         given(intakeNutrientsService.calcTotalCalorie(anyList())).willReturn(totalCalorie);
         // when
         ResultActions perform =
@@ -153,10 +153,10 @@ class NutrientsControllerTest extends RestDocsTest {
         // then
         perform.andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCalorie").value(totalCalorie))
-                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(caloriePerMealType));
+                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(calorieOfMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(calorieOfMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(calorieOfMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(calorieOfMealType));
 
         perform.andDo(print())
                 .andDo(
@@ -171,8 +171,8 @@ class NutrientsControllerTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("주간 섭취량 조회 API - 없는 회원 예외 발생")
-    void getWeeklyIntakeNotMemberTest() throws Exception {
+    @DisplayName("주간 섭취량 조회 API - Not Found Member")
+    void getWeeklyIntakeCalorieNotFoundMemberTest() throws Exception {
         // given
         given(
                         intakeNutrientsService.searchWeeklyIntakeCalories(
@@ -193,17 +193,17 @@ class NutrientsControllerTest extends RestDocsTest {
 
     @Test
     @DisplayName("월간 섭취량 조회 API")
-    void getMonthlyIntakeTest() throws Exception {
+    void getMonthlyIntakeCalorieTest() throws Exception {
         // given
-        List<CaloriesOfMealType> caloriesOfMealTypes = new ArrayList<>();
-        int weeks = 6;
+        List<IntakeCalorie> intakeCalories = new ArrayList<>();
+        int weeks = 5;
         for (int i = 0; i < weeks; i++) {
-            caloriesOfMealTypes.add(CaloriesOfMealTypeFixture.DEFAULT.getWithIntake(100));
+            intakeCalories.add(CaloriesOfMealTypeFixture.DEFAULT.getWithIntake(100));
         }
-        int caloriePerMealType = caloriesOfMealTypes.get(0).breakfast();
-        int totalCalorie = caloriePerMealType * 4 * weeks;
+        int calorieOfMealType = intakeCalories.get(0).breakfast();
+        int totalCalorie = (calorieOfMealType * 4) * weeks;
         given(intakeNutrientsService.searchMonthlyIntakeCalories(anyLong(), any(LocalDate.class)))
-                .willReturn(caloriesOfMealTypes);
+                .willReturn(intakeCalories);
         given(intakeNutrientsService.calcTotalCalorie(anyList())).willReturn(totalCalorie);
         // when
         ResultActions perform =
@@ -214,10 +214,10 @@ class NutrientsControllerTest extends RestDocsTest {
         // then
         perform.andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCalorie").value(totalCalorie))
-                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(caloriePerMealType));
+                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(calorieOfMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(calorieOfMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(calorieOfMealType))
+                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(calorieOfMealType));
 
         perform.andDo(print())
                 .andDo(
@@ -232,8 +232,8 @@ class NutrientsControllerTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("월간 섭취량 조회 API - 없는 회원 예외 발생")
-    void getMonthlyIntakeNotMemberTest() throws Exception {
+    @DisplayName("월간 섭취량 조회 API - Not Found Member")
+    void getMonthlyIntakeCalorieNotFoundMemberTest() throws Exception {
         // given
         given(intakeNutrientsService.searchMonthlyIntakeCalories(anyLong(), any(LocalDate.class)))
                 .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
@@ -251,17 +251,17 @@ class NutrientsControllerTest extends RestDocsTest {
 
     @Test
     @DisplayName("연간 섭취량 조회 API")
-    void getYearlyIntakeTest() throws Exception {
+    void getYearlyIntakeCalorieTest() throws Exception {
         // given
-        List<CaloriesOfMealType> caloriesOfMealTypes = new ArrayList<>();
+        List<IntakeCalorie> intakeCalories = new ArrayList<>();
         int months = 12;
         for (int i = 0; i < months; i++) {
-            caloriesOfMealTypes.add(CaloriesOfMealTypeFixture.DEFAULT.getWithIntake(300));
+            intakeCalories.add(CaloriesOfMealTypeFixture.DEFAULT.getWithIntake(300));
         }
-        int caloriePerMealType = caloriesOfMealTypes.get(0).breakfast();
+        int caloriePerMealType = intakeCalories.get(0).breakfast();
         int totalCalorie = caloriePerMealType * 4 * months;
         given(intakeNutrientsService.searchYearlyIntakeCalories(anyLong(), any(LocalDate.class)))
-                .willReturn(caloriesOfMealTypes);
+                .willReturn(intakeCalories);
         given(intakeNutrientsService.calcTotalCalorie(anyList())).willReturn(totalCalorie);
         // when
         ResultActions perform =
@@ -290,8 +290,8 @@ class NutrientsControllerTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("연간 섭취량 조회 API - 없는 회원 예외 발생")
-    void getYearlyIntakeNotMemberTest() throws Exception {
+    @DisplayName("연간 섭취량 조회 API - Not Found Member")
+    void getYearlyIntakeCalorieNotFoundMemberTest() throws Exception {
         // given
         given(intakeNutrientsService.searchYearlyIntakeCalories(anyLong(), any(LocalDate.class)))
                 .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));

--- a/src/test/java/com/konggogi/veganlife/member/fixture/CaloriesOfMealTypeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/member/fixture/CaloriesOfMealTypeFixture.java
@@ -1,7 +1,7 @@
 package com.konggogi.veganlife.member.fixture;
 
 
-import com.konggogi.veganlife.member.service.dto.CaloriesOfMealType;
+import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
 
 public enum CaloriesOfMealTypeFixture {
     DEFAULT(10, 10, 10, 10);
@@ -17,11 +17,11 @@ public enum CaloriesOfMealTypeFixture {
         this.snack = snack;
     }
 
-    public CaloriesOfMealType get() {
-        return new CaloriesOfMealType(breakfast, lunch, dinner, snack);
+    public IntakeCalorie get() {
+        return new IntakeCalorie(breakfast, lunch, dinner, snack);
     }
 
-    public CaloriesOfMealType getWithIntake(int intake) {
-        return new CaloriesOfMealType(intake, intake, intake, intake);
+    public IntakeCalorie getWithIntake(int intake) {
+        return new IntakeCalorie(intake, intake, intake, intake);
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#264 )

## 변경 내용
- MealType별 calorie 합계 계산을 `IntakeNutrientsSerivce`에서 수행하지 않고, `MealLogRepository`에서 JPQL(`group by`와 `sum` 집계 함수를 사용)과 Tuple을 사용해 데이터를 가져오도록 변경
- 기존에는 LocalDateTime을 사용하였으나, `createdAt`을 `cast`를 사용하여 LocalDate 타입으로 변환하도록 변경
- 월간/연간 섭취 칼로리 조회 기능이 같은 메서드를 사용하여, 불가피하게 함께 코드 수정 발생
- 변경으로 인한 테스트 코드 수정

## 개선 결과
평균 응답 시간: 30ms -> 15ms (50% 개선)
TPS: 30/sec -> 60/sec (100% 개선)
해당 코드 변경으로, 월간 섭취 칼로리 조회 API도 응답 속도 30%(20ms -> 12ms), 처리량 44%(45/s -> 65/s) 향상