### PR TITLE
일일/주간/월간/연간 섭취량 조회 API 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured:5.3.2'
 
     //QueryDSL
+    implementation 'com.querydsl:querydsl-core:5.0.0'
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,12 @@ dependencies {
 
     // rest assured
     testImplementation 'io.rest-assured:rest-assured:5.3.2'
+
+    //QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 test {
@@ -106,6 +112,8 @@ bootJar { // jar의 templates에 문서 복사
         into 'BOOT-INF/classes/templates'
     }
 }
+
+//jacoco setting
 
 jacocoTestReport {
     reports {
@@ -159,4 +167,19 @@ private excludedClassFilesForReport(classDirectories) {
                 ])
             })
     )
+}
+
+//Querydsl setting
+def querydslDir = layout.buildDirectory.dir("/generated/querydsl")
+
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+sourceSets {
+    main.java.srcDirs += [ querydslDir ]
+}
+
+clean {
+    delete file(querydslDir)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -171,16 +171,6 @@ private excludedClassFilesForReport(classDirectories) {
 }
 
 //Querydsl setting
-def querydslDir = layout.buildDirectory.dir("/generated/querydsl")
-
-tasks.withType(JavaCompile) {
-    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
-}
-
-sourceSets {
-    main.java.srcDirs += [ querydslDir ]
-}
-
 clean {
-    delete file(querydslDir)
+    delete file('src/main/generated')
 }

--- a/src/docs/asciidoc/oauth.adoc
+++ b/src/docs/asciidoc/oauth.adoc
@@ -14,10 +14,6 @@ endif::[]
 
 === Request
 
-==== Header
-
-include::{snippets}/login/request-headers.adoc[]
-
 ==== Path Variable
 
 include::{snippets}/login/path-parameters.adoc[]

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -4,18 +4,7 @@ package com.konggogi.veganlife.meallog.domain;
 import com.konggogi.veganlife.global.domain.TimeStamped;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.ToIntFunction;
@@ -26,6 +15,11 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(
+        name = "meal_log",
+        indexes = {
+            @Index(name = "idx_meal_log_on_member_created_at", columnList = "member_id, createdAt")
+        })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MealLog extends TimeStamped {
 

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -72,7 +72,6 @@ public class MealLog extends TimeStamped {
     }
 
     public IntakeNutrients getTotalIntakeNutrients() {
-        // TODO: reduce를 사용했을 때와 성능 비교해보기
         return new IntakeNutrients(
                 calculateTotal(Meal::getCalorie, meals),
                 calculateTotal(Meal::getCarbs, meals),
@@ -81,7 +80,6 @@ public class MealLog extends TimeStamped {
     }
 
     private int calculateTotal(ToIntFunction<Meal> func, List<Meal> meals) {
-
         return meals.stream().mapToInt(func).sum();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -7,10 +7,10 @@ import com.konggogi.veganlife.meallog.domain.MealImage;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.member.domain.Member;
-import jakarta.persistence.Tuple;
-import java.util.EnumMap;
+import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Named;
@@ -37,15 +37,13 @@ public interface MealLogMapper {
             expression = "java(mealLog.getTotalIntakeNutrients())")
     MealLogDetailsResponse toMealLogDetailsResponse(MealLog mealLog);
 
-    default Map<MealType, Integer> toTotalCaloriesOfMealTypeMap(
-            List<Tuple> caloriesOfMealTypeTuples) {
-        Map<MealType, Integer> caloriesOfMealTypeMap = new EnumMap<>(MealType.class);
-        for (Tuple tuple : caloriesOfMealTypeTuples) {
-            MealType mealType = tuple.get(0, MealType.class);
-            Integer totalCalories = tuple.get(1, Long.class).intValue();
-            caloriesOfMealTypeMap.put(mealType, totalCalories);
-        }
-        return caloriesOfMealTypeMap;
+    default Map<MealType, Integer> toTotalCalorieOfMealTypeMap(
+            List<TotalCalorieOfMealType> totalCalorieOfMealTypes) {
+        return totalCalorieOfMealTypes.stream()
+                .collect(
+                        Collectors.toMap(
+                                TotalCalorieOfMealType::getMealType,
+                                TotalCalorieOfMealType::getTotalCalorie));
     }
 
     @Named("mealImageToImageUrl")

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -2,8 +2,8 @@ package com.konggogi.veganlife.meallog.repository;
 
 
 import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.repository.querydsl.MealLogCustomRepository;
 import com.konggogi.veganlife.member.domain.Member;
-import jakarta.persistence.Tuple;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -12,24 +12,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MealLogRepository extends JpaRepository<MealLog, Long> {
-    @Query(
-            "select ml.mealType as mealType, SUM(m.calorie) as totalCalories "
-                    + "from MealLog ml join ml.meals m "
-                    + "where ml.member.id = :memberId "
-                    + "and cast(ml.createdAt as localdate) = :date "
-                    + "group by ml.mealType")
-    List<Tuple> sumCaloriesOfMealTypeByMemberIdAndCreatedAt(Long memberId, LocalDate date);
-
-    @Query(
-            "select ml.mealType as mealType, SUM(m.calorie) as totalCalories "
-                    + "from MealLog ml join ml.meals m "
-                    + "where ml.member.id = :memberId "
-                    + "and cast(ml.createdAt as localdate) between :startDate and :endDate "
-                    + "group by ml.mealType")
-    List<Tuple> sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
-            Long memberId, LocalDate startDate, LocalDate endDate);
-
+public interface MealLogRepository extends JpaRepository<MealLog, Long>, MealLogCustomRepository {
     @Query(" select distinct m from MealLog m join fetch m.meals" + " where m.id = :id")
     Optional<MealLog> findById(Long id);
 

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepository.java
@@ -1,0 +1,12 @@
+package com.konggogi.veganlife.meallog.repository.querydsl;
+
+
+import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MealLogCustomRepository {
+
+    List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
+            Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepositoryImpl.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.konggogi.veganlife.meallog.repository.querydsl;
+
+import static com.konggogi.veganlife.meallog.domain.QMeal.meal;
+import static com.konggogi.veganlife.meallog.domain.QMealLog.mealLog;
+
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
+import com.querydsl.core.types.Projections;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class MealLogCustomRepositoryImpl extends QuerydslRepositorySupport
+        implements MealLogCustomRepository {
+    public MealLogCustomRepositoryImpl() {
+        super(MealLog.class);
+    }
+
+    @Override
+    public List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
+            Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+        return from(mealLog)
+                .join(mealLog.meals, meal)
+                .where(
+                        mealLog.member
+                                .id
+                                .eq(memberId)
+                                .and(mealLog.createdAt.between(startDateTime, endDateTime)))
+                .groupBy(mealLog.mealType)
+                .select(
+                        Projections.fields(
+                                TotalCalorieOfMealType.class,
+                                mealLog.mealType,
+                                meal.calorie.sum().as("totalCalorie")))
+                .fetch();
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
@@ -6,8 +6,9 @@ import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
-import jakarta.persistence.Tuple;
+import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -32,13 +33,9 @@ public class MealLogQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEAL_LOG));
     }
 
-    public List<Tuple> sumCaloriesOfMealTypeByMemberIdAndDate(Long memberId, LocalDate date) {
-        return mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAt(memberId, date);
-    }
-
-    public List<Tuple> sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-            Long memberId, LocalDate startDate, LocalDate endDate) {
+    public List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+            Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         return mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
-                memberId, startDate, endDate);
+                memberId, startDateTime, endDateTime);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/NutrientsController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/NutrientsController.java
@@ -51,12 +51,10 @@ public class NutrientsController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
             @RequestParam("endDate") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate) {
-        List<IntakeCalorie> mealCalories =
+        List<IntakeCalorie> intakeCalories =
                 intakeNutrientsService.searchWeeklyIntakeCalories(
                         userDetails.id(), startDate, endDate);
-        int totalCalorie = intakeNutrientsService.calcTotalCalorie(mealCalories);
-        return ResponseEntity.ok(
-                nutrientsMapper.toCalorieIntakeResponse(totalCalorie, mealCalories));
+        return ResponseEntity.ok(nutrientsMapper.toCalorieIntakeResponse(intakeCalories));
     }
 
     @GetMapping("/nutrients/month")
@@ -64,11 +62,9 @@ public class NutrientsController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd")
                     LocalDate startDate) {
-        List<IntakeCalorie> mealCalories =
+        List<IntakeCalorie> intakeCalories =
                 intakeNutrientsService.searchMonthlyIntakeCalories(userDetails.id(), startDate);
-        int totalCalorie = intakeNutrientsService.calcTotalCalorie(mealCalories);
-        return ResponseEntity.ok(
-                nutrientsMapper.toCalorieIntakeResponse(totalCalorie, mealCalories));
+        return ResponseEntity.ok(nutrientsMapper.toCalorieIntakeResponse(intakeCalories));
     }
 
     @GetMapping("/nutrients/year")
@@ -76,10 +72,8 @@ public class NutrientsController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam("startDate") @DateTimeFormat(pattern = "yyyy-MM-dd")
                     LocalDate startDate) {
-        List<IntakeCalorie> mealCalories =
+        List<IntakeCalorie> intakeCalories =
                 intakeNutrientsService.searchYearlyIntakeCalories(userDetails.id(), startDate);
-        int totalCalorie = intakeNutrientsService.calcTotalCalorie(mealCalories);
-        return ResponseEntity.ok(
-                nutrientsMapper.toCalorieIntakeResponse(totalCalorie, mealCalories));
+        return ResponseEntity.ok(nutrientsMapper.toCalorieIntakeResponse(intakeCalories));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/NutrientsMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/NutrientsMapper.java
@@ -18,7 +18,8 @@ public interface NutrientsMapper {
     @Mapping(target = "dailyCalorie", source = "member.AMR")
     RecommendNutrientsResponse toRecommendNutrientsResponse(Member member);
 
-    @Mapping(source = "intakeCalories", target = "periodicCalorie")
-    CalorieIntakeResponse toCalorieIntakeResponse(
-            int totalCalorie, List<IntakeCalorie> intakeCalories);
+    default CalorieIntakeResponse toCalorieIntakeResponse(List<IntakeCalorie> intakeCalories) {
+        int totalCalorie = intakeCalories.stream().mapToInt(IntakeCalorie::getTotalCalorie).sum();
+        return new CalorieIntakeResponse(totalCalorie, intakeCalories);
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
@@ -81,19 +81,6 @@ public class IntakeNutrientsService {
                 .toList();
     }
 
-    public int calcTotalCalorie(List<IntakeCalorie> intakeCalories) {
-        return intakeCalories.parallelStream()
-                .reduce(
-                        0,
-                        (accumulator, mealCalorie) ->
-                                accumulator
-                                        + mealCalorie.breakfast()
-                                        + mealCalorie.lunch()
-                                        + mealCalorie.dinner()
-                                        + mealCalorie.snack(),
-                        Integer::sum);
-    }
-
     private IntakeCalorie aggregateDailyCaloriesOfMealTypeForDay(Long memberId, LocalDate date) {
         List<TotalCalorieOfMealType> caloriesOfMeals =
                 mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(

--- a/src/main/java/com/konggogi/veganlife/member/service/dto/IntakeCalorie.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/dto/IntakeCalorie.java
@@ -1,3 +1,11 @@
 package com.konggogi.veganlife.member.service.dto;
 
-public record IntakeCalorie(Integer breakfast, Integer lunch, Integer dinner, Integer snack) {}
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public record IntakeCalorie(Integer breakfast, Integer lunch, Integer dinner, Integer snack) {
+    @JsonIgnore
+    public Integer getTotalCalorie() {
+        return breakfast + lunch + dinner + snack;
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/member/service/dto/IntakeNutrients.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/dto/IntakeNutrients.java
@@ -1,3 +1,11 @@
 package com.konggogi.veganlife.member.service.dto;
 
-public record IntakeNutrients(Integer calorie, Integer carbs, Integer protein, Integer fat) {}
+public record IntakeNutrients(Integer calorie, Integer carbs, Integer protein, Integer fat) {
+    public IntakeNutrients add(IntakeNutrients other) {
+        return new IntakeNutrients(
+                this.calorie + other.calorie,
+                this.carbs + other.carbs,
+                this.protein + other.protein,
+                this.fat + other.fat);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/member/service/dto/TotalCalorieOfMealType.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/dto/TotalCalorieOfMealType.java
@@ -1,0 +1,13 @@
+package com.konggogi.veganlife.member.service.dto;
+
+
+import com.konggogi.veganlife.meallog.domain.MealType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TotalCalorieOfMealType {
+    private MealType mealType;
+    private Integer totalCalorie;
+}

--- a/src/main/java/com/konggogi/veganlife/member/service/dto/TotalCalorieOfMealType.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/dto/TotalCalorieOfMealType.java
@@ -10,4 +10,9 @@ import lombok.NoArgsConstructor;
 public class TotalCalorieOfMealType {
     private MealType mealType;
     private Integer totalCalorie;
+
+    public TotalCalorieOfMealType(MealType mealType, Integer totalCalorie) {
+        this.mealType = mealType;
+        this.totalCalorie = totalCalorie;
+    }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepositoryImplTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepositoryImplTest.java
@@ -1,0 +1,122 @@
+package com.konggogi.veganlife.meallog.repository.querydsl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import com.konggogi.veganlife.mealdata.repository.MealDataRepository;
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.domain.MealType;
+import com.konggogi.veganlife.meallog.fixture.MealFixture;
+import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
+import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
+import com.konggogi.veganlife.meallog.repository.MealImageRepository;
+import com.konggogi.veganlife.meallog.repository.MealLogRepository;
+import com.konggogi.veganlife.meallog.repository.MealRepository;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.repository.MemberRepository;
+import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@DataJpaTest
+@EnableJpaAuditing(setDates = false)
+class MealLogCustomRepositoryImplTest {
+    @Autowired MealLogRepository mealLogRepository;
+    @Autowired MealRepository mealRepository;
+    @Autowired MealImageRepository mealImageRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired MealDataRepository mealDataRepository;
+
+    private final Member member = MemberFixture.DEFAULT_M.get();
+
+    List<MealData> mealData =
+            List.of(
+                    MealDataFixture.TOTAL_AMOUNT.get(member),
+                    MealDataFixture.TOTAL_AMOUNT.get(member),
+                    MealDataFixture.TOTAL_AMOUNT.get(member));
+
+    @BeforeEach
+    void setup() {
+        memberRepository.save(member);
+        mealDataRepository.saveAll(mealData);
+    }
+
+    @Test
+    @DisplayName("회원 id와 기간에 해당하는 MealLog를 MealType별로 합산")
+    void sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetweenTest() {
+        // given
+        LocalDate startDate = LocalDate.of(2024, 2, 18);
+        LocalDate endDate = LocalDate.of(2024, 2, 24);
+        startDate
+                .datesUntil(endDate.plusDays(1))
+                .forEach(
+                        date -> {
+                            Arrays.stream(MealLogFixture.values())
+                                    .forEach(
+                                            mealType -> {
+                                                MealLog mealLog =
+                                                        createMealLog(
+                                                                member, mealData, date, mealType);
+                                                mealLogRepository.save(mealLog);
+                                            });
+                        });
+        // when
+
+        List<TotalCalorieOfMealType> totalCaloriesOfMealTypes =
+                mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
+                        member.getId(), startDate.atStartOfDay(), endDate.atTime(23, 59, 59));
+        Map<MealType, Integer> totalCalorieOfMealTypeMap =
+                toTotalCalorieOfMealTypeMap(totalCaloriesOfMealTypes);
+        // then
+        int expectedCalorie =
+                MealFixture.DEFAULT.get(mealData.get(0)).getCalorie() * mealData.size() * 7;
+        assertThat(totalCalorieOfMealTypeMap.get(MealType.BREAKFAST)).isEqualTo(expectedCalorie);
+        assertThat(totalCalorieOfMealTypeMap.get(MealType.LUNCH)).isEqualTo(expectedCalorie);
+        assertThat(totalCalorieOfMealTypeMap.get(MealType.DINNER)).isEqualTo(expectedCalorie);
+        assertThat(totalCalorieOfMealTypeMap.get(MealType.BREAKFAST_SNACK))
+                .isEqualTo(expectedCalorie);
+        assertThat(totalCalorieOfMealTypeMap.get(MealType.LUNCH_SNACK)).isEqualTo(expectedCalorie);
+        assertThat(totalCalorieOfMealTypeMap.get(MealType.DINNER_SNACK)).isEqualTo(expectedCalorie);
+    }
+
+    private MealLog createMealLog(
+            Member member,
+            List<MealData> mealData,
+            LocalDate date,
+            MealLogFixture mealTypeOfFixture) {
+        List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
+        List<MealImage> mealImages =
+                IntStream.range(0, mealData.size())
+                        .mapToObj(idx -> MealImageFixture.DEFAULT.get())
+                        .toList();
+
+        if (date != null) {
+            return mealTypeOfFixture.getWithDate(date, meals, mealImages, member);
+        } else {
+            return mealTypeOfFixture.get(meals, mealImages, member);
+        }
+    }
+
+    private Map<MealType, Integer> toTotalCalorieOfMealTypeMap(
+            List<TotalCalorieOfMealType> totalCalorieOfMealTypes) {
+        return totalCalorieOfMealTypes.stream()
+                .collect(
+                        Collectors.toMap(
+                                TotalCalorieOfMealType::getMealType,
+                                TotalCalorieOfMealType::getTotalCalorie));
+    }
+}

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
@@ -19,6 +19,7 @@ import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -96,37 +97,19 @@ public class MealLogQueryServiceTest {
     }
 
     @Test
-    @DisplayName("회원 id와 날짜에 해당하는 MealLog를 MealType별로 합산")
-    void sumCaloriesOfMealTypeByMemberIdAndDateTest() {
-        // given
-        LocalDate date = LocalDate.of(2024, 2, 24);
-        given(
-                        mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAt(
-                                anyLong(), any(LocalDate.class)))
-                .willReturn(new ArrayList<>());
-
-        // when, then
-        assertThatNoException()
-                .isThrownBy(
-                        () ->
-                                mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDate(
-                                        member.getId(), date));
-    }
-
-    @Test
     @DisplayName("회원 id와 기간에 해당하는 MealLog를 MealType별로 합산")
     void sumCaloriesOfMealTypeByMemberIdAndDateBetweenTest() {
-        LocalDate startDate = LocalDate.of(2024, 2, 18);
-        LocalDate endDate = LocalDate.of(2024, 2, 24);
+        LocalDateTime startDateTime = LocalDate.of(2024, 2, 18).atStartOfDay();
+        LocalDateTime endDateTime = LocalDate.of(2024, 2, 24).atTime(23, 59, 59);
         given(
                         mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
-                                anyLong(), any(LocalDate.class), any(LocalDate.class)))
+                                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
                 .willReturn(new ArrayList<>());
 
         assertThatNoException()
                 .isThrownBy(
                         () ->
                                 mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-                                        member.getId(), startDate, endDate));
+                                        member.getId(), startDateTime, endDateTime));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/controller/NutrientsControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/NutrientsControllerTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.fixture.CaloriesOfMealTypeFixture;
+import com.konggogi.veganlife.member.fixture.IntakeCalorieFixture;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.service.IntakeNutrientsService;
 import com.konggogi.veganlife.member.service.MemberQueryService;
@@ -134,15 +134,13 @@ class NutrientsControllerTest extends RestDocsTest {
         List<IntakeCalorie> intakeCalories = new ArrayList<>();
         int days = 7;
         for (int i = 0; i < days; i++) {
-            intakeCalories.add(CaloriesOfMealTypeFixture.DEFAULT.get());
+            intakeCalories.add(IntakeCalorieFixture.DEFAULT.get());
         }
-        int calorieOfMealType = intakeCalories.get(0).breakfast();
-        int totalCalorie = (calorieOfMealType * 4) * days;
+        int calorie = intakeCalories.get(0).breakfast();
         given(
                         intakeNutrientsService.searchWeeklyIntakeCalories(
                                 anyLong(), any(LocalDate.class), any(LocalDate.class)))
                 .willReturn(intakeCalories);
-        given(intakeNutrientsService.calcTotalCalorie(anyList())).willReturn(totalCalorie);
         // when
         ResultActions perform =
                 mockMvc.perform(
@@ -152,11 +150,11 @@ class NutrientsControllerTest extends RestDocsTest {
                                 .queryParam("endDate", "2023-12-23"));
         // then
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalCalorie").value(totalCalorie))
-                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(calorieOfMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(calorieOfMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(calorieOfMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(calorieOfMealType));
+                .andExpect(jsonPath("$.totalCalorie").value((calorie * 4) * days))
+                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(calorie));
 
         perform.andDo(print())
                 .andDo(
@@ -198,13 +196,11 @@ class NutrientsControllerTest extends RestDocsTest {
         List<IntakeCalorie> intakeCalories = new ArrayList<>();
         int weeks = 5;
         for (int i = 0; i < weeks; i++) {
-            intakeCalories.add(CaloriesOfMealTypeFixture.DEFAULT.getWithIntake(100));
+            intakeCalories.add(IntakeCalorieFixture.DEFAULT.getWithIntake(100));
         }
-        int calorieOfMealType = intakeCalories.get(0).breakfast();
-        int totalCalorie = (calorieOfMealType * 4) * weeks;
+        int calorie = intakeCalories.get(0).breakfast();
         given(intakeNutrientsService.searchMonthlyIntakeCalories(anyLong(), any(LocalDate.class)))
                 .willReturn(intakeCalories);
-        given(intakeNutrientsService.calcTotalCalorie(anyList())).willReturn(totalCalorie);
         // when
         ResultActions perform =
                 mockMvc.perform(
@@ -213,11 +209,11 @@ class NutrientsControllerTest extends RestDocsTest {
                                 .queryParam("startDate", "2023-12-01"));
         // then
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalCalorie").value(totalCalorie))
-                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(calorieOfMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(calorieOfMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(calorieOfMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(calorieOfMealType));
+                .andExpect(jsonPath("$.totalCalorie").value((calorie * 4) * weeks))
+                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(calorie));
 
         perform.andDo(print())
                 .andDo(
@@ -256,13 +252,11 @@ class NutrientsControllerTest extends RestDocsTest {
         List<IntakeCalorie> intakeCalories = new ArrayList<>();
         int months = 12;
         for (int i = 0; i < months; i++) {
-            intakeCalories.add(CaloriesOfMealTypeFixture.DEFAULT.getWithIntake(300));
+            intakeCalories.add(IntakeCalorieFixture.DEFAULT.getWithIntake(300));
         }
-        int caloriePerMealType = intakeCalories.get(0).breakfast();
-        int totalCalorie = caloriePerMealType * 4 * months;
+        int calorie = intakeCalories.get(0).breakfast();
         given(intakeNutrientsService.searchYearlyIntakeCalories(anyLong(), any(LocalDate.class)))
                 .willReturn(intakeCalories);
-        given(intakeNutrientsService.calcTotalCalorie(anyList())).willReturn(totalCalorie);
         // when
         ResultActions perform =
                 mockMvc.perform(
@@ -271,11 +265,11 @@ class NutrientsControllerTest extends RestDocsTest {
                                 .queryParam("startDate", "2023-01-01"));
         // then
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalCalorie").value(totalCalorie))
-                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(caloriePerMealType))
-                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(caloriePerMealType));
+                .andExpect(jsonPath("$.totalCalorie").value(calorie * 4 * months))
+                .andExpect(jsonPath("$.periodicCalorie[0].breakfast").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].lunch").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].dinner").value(calorie))
+                .andExpect(jsonPath("$.periodicCalorie[0].snack").value(calorie));
 
         perform.andDo(print())
                 .andDo(

--- a/src/test/java/com/konggogi/veganlife/member/fixture/IntakeCalorieFixture.java
+++ b/src/test/java/com/konggogi/veganlife/member/fixture/IntakeCalorieFixture.java
@@ -3,14 +3,14 @@ package com.konggogi.veganlife.member.fixture;
 
 import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
 
-public enum CaloriesOfMealTypeFixture {
+public enum IntakeCalorieFixture {
     DEFAULT(10, 10, 10, 10);
     private final int breakfast;
     private final int lunch;
     private final int dinner;
     private final int snack;
 
-    CaloriesOfMealTypeFixture(int breakfast, int lunch, int dinner, int snack) {
+    IntakeCalorieFixture(int breakfast, int lunch, int dinner, int snack) {
         this.breakfast = breakfast;
         this.lunch = lunch;
         this.dinner = dinner;


### PR DESCRIPTION
## 이슈 번호 (#269 )

## 변경 내용
### 일일 섭취량 조회 API 
- MealLog의 `getTotalIntakeNutrients` 메서드를 사용하도록 변경 (코드 중복 제거)
- 기존 `getTotalIntakeNutrients` 로직과 reduce를 활용한 로직을 비교하였을 때, 기존 로직의 성능이 더 높으므로 기존 방식 채택 (TODO 삭제)

### 주간/월간/연간 섭취 칼로리 조회 API
- MealLog 테이블 복합 인덱스 설정
- 데이터베이스 조회 시, List<Tuple>로 반환 받지 않고, List<TotalCalorieOfMealType> 으로 반환 받도록 변경
- DTO Projection에 QueryDsl을 활용

### QueryDsl + DTO Projection 변경 이유
- Tuple은 런타임에 에러 발생, DTO Proejction은 컴파일 시점에 체크 가능
- Tuple 자체가 QueryDsl의 객체로 Repository가 아닌 서비스 계층으로의 전달은 적합하지 않음
- JPQL + DTO Projection 방식은 직접 pacakge 명을 작성해야 하므로 휴먼 에러 발생 가능성과, 가독성 문제
- QueryDsl을 사용하면 다양하고 간단한 방식으로 DTO Projection을 구현할 수 있음

## 성능 개선
### 일일 섭취량 조회 API
- TPS 71.2 > 82.5

### 주간 섭취 칼로리 조회 API
- 평균 응답 시간 40ms > 19ms
- TPS 23.9 > 48

### 월간 섭취 칼로리 조회 API
- 평균 응답 시간 32ms > 18ms
- TPS 29 > 51.4

### 연간 섭취 칼로리 조회 API
- 평균 응답 시간 81ms > 47ms
- TPS 11.9 > 20
