### PR TITLE
[FEATURE] 알림 목록 조회 기능 API 문서 내용 추가

### DIFF
--- a/src/docs/asciidoc/sse.adoc
+++ b/src/docs/asciidoc/sse.adoc
@@ -40,6 +40,28 @@ include::{snippets}/sse-subscribe-connection-fail/http-response.adoc[]
 
 == 사용자 알림 목록 조회 API
 
+=== 알림 Type
+
+|===
+|Name|Description
+
+|`+INTAKE_OVER_30+`
+| 칼로리 섭취량 30% 초과
+
+|`+INTAKE_OVER_60+`
+| 칼로리 섭취량 60% 초과
+
+|`+COMMENT+`
+| 댓글 달림
+
+|`+COMMENT_LIKE+`
+| 댓글 좋아요
+
+|`+COMMENT+`
+| 댓글에 사용자 언급
+
+|===
+
 === Request
 
 ==== Header

--- a/src/test/java/com/konggogi/veganlife/notification/controller/SseControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/notification/controller/SseControllerTest.java
@@ -47,7 +47,9 @@ class SseControllerTest extends RestDocsTest {
                     NotificationFixture.COMMENT_LIKE.getWithDate(
                             member, LocalDateTime.now().minusDays(1)),
                     NotificationFixture.INTAKE_OVER_60.getWithDate(
-                            member, LocalDateTime.now().minusDays(2)));
+                            member, LocalDateTime.now().minusDays(2)),
+                    NotificationFixture.COMMENT.getWithDate(
+                            member, LocalDateTime.now().minusDays(5)));
 
     @Test
     @DisplayName("SSE 구독 API")
@@ -138,7 +140,7 @@ class SseControllerTest extends RestDocsTest {
                                 .queryParam("page", "0")
                                 .queryParam("size", "20"));
 
-        perform.andExpect(status().isOk()).andExpect(jsonPath("$.content.size()").value(4));
+        perform.andExpect(status().isOk()).andExpect(jsonPath("$.content.size()").value(5));
 
         perform.andDo(print())
                 .andDo(

--- a/src/test/java/com/konggogi/veganlife/notification/fixture/NotificationFixture.java
+++ b/src/test/java/com/konggogi/veganlife/notification/fixture/NotificationFixture.java
@@ -12,12 +12,13 @@ import org.springframework.util.ReflectionUtils;
 public enum NotificationFixture {
     SSE(NotificationType.SSE, NotificationMessage.SSE_CONNECTION.getMessage()),
     INTAKE_OVER_30(
-            NotificationType.INTAKE_OVER_30, NotificationMessage.OVER_INTAKE.getMessage(100)),
+            NotificationType.INTAKE_OVER_30, NotificationMessage.OVER_INTAKE.getMessage(300)),
     INTAKE_OVER_60(
-            NotificationType.INTAKE_OVER_60, NotificationMessage.OVER_INTAKE.getMessage(100)),
+            NotificationType.INTAKE_OVER_60, NotificationMessage.OVER_INTAKE.getMessage(600)),
     MENTION(NotificationType.MENTION, NotificationMessage.MENTION.getMessage("test1", "test2")),
+    COMMENT(NotificationType.COMMENT, NotificationMessage.ADD_COMMENT.getMessage("test1", "test2")),
     COMMENT_LIKE(
-            NotificationType.COMMENT,
+            NotificationType.COMMENT_LIKE,
             NotificationMessage.COMMENT_LIKE.getMessage("test1", "test2"));
 
     private final NotificationType type;


### PR DESCRIPTION
## 이슈 번호 (#282)

## 요약
- `NotificationFixture`에 fixture 추가
- 사용자 알림 목록 조회 API 문서에 `NotificationType` 정보 추가


