### PR TITLE
[REFACTOR] 피드 상세 조회 응답에 작성자 프로필 URL 필드 추가

### DIFF
--- a/src/main/java/com/konggogi/veganlife/post/controller/dto/response/PostDetailsResponse.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/dto/response/PostDetailsResponse.java
@@ -10,6 +10,7 @@ public record PostDetailsResponse(
         Long id,
         String author,
         VegetarianType vegetarianType,
+        String profileImageUrl,
         String title,
         String content,
         LocalDateTime createdAt,

--- a/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/mapper/PostMapper.java
@@ -37,6 +37,7 @@ public interface PostMapper {
 
     @Mapping(target = "author", source = "postDetailsDto.post.member.nickname")
     @Mapping(target = "vegetarianType", source = "postDetailsDto.post.member.vegetarianType")
+    @Mapping(target = "profileImageUrl", source = "postDetailsDto.post.member.profileImageUrl")
     @Mapping(target = "imageUrls", source = "postDetailsDto.imageUrls")
     @Mapping(target = "commentCount", expression = "java(postDetailsDto.post().countComments())")
     @Mapping(target = "tags", source = "postDetailsDto.tags")

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -114,7 +114,6 @@ class PostControllerTest extends RestDocsTest {
         // given
         Post post = PostFixture.CHALLENGE.getWithId(1L, member);
         Comment comment1 = CommentFixture.DEFAULT.getTopCommentWithId(1L, member, post);
-        Comment subComment = CommentFixture.DEFAULT.getSubCommentWithId(3L, member, post, comment1);
         Comment comment2 = CommentFixture.DEFAULT.getTopCommentWithId(2L, member, post);
         List<String> imageUrls =
                 List.of(
@@ -142,6 +141,7 @@ class PostControllerTest extends RestDocsTest {
                 .andExpect(jsonPath("$.author").value(member.getNickname()))
                 .andExpect(
                         jsonPath("$.vegetarianType").value(member.getVegetarianType().toString()))
+                .andExpect(jsonPath("$.profileImageUrl").value(member.getProfileImageUrl()))
                 .andExpect(jsonPath("$.title").value(post.getTitle()))
                 .andExpect(jsonPath("$.content").value(post.getContent()))
                 .andExpect(jsonPath("$.createdAt").isNotEmpty())


### PR DESCRIPTION
## 이슈 번호 (#285)

## 변경 내용
- aos 요청에 따라 피드 상세 조회 reponse에 작성자 프로필 URL 필드 추가
- 이에 따른 테스트 수정

