### PR TITLE
[FEAT] RestDocs와 Swagger UI 함께 사용하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,10 @@ buildscript {
     }
 }
 
-
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.3'
-    id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'com.diffplug.spotless' version '6.11.0'
     id 'jacoco'
     id 'com.epages.restdocs-api-spec' version "${restdocsApiSpecVersion}"
@@ -32,10 +30,6 @@ configurations {
 
 repositories {
     mavenCentral()
-}
-
-ext {
-    set('snippetsDir', file("build/generated-snippets"))
 }
 
 spotless {
@@ -117,7 +111,7 @@ bootJar {
     dependsOn(':openapi3')
 }
 
-// swagger ui 변환
+// swagger ui
 openapi3 {
     servers = [
             { url = 'http://localhost:8080' },

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,10 @@
+buildscript {
+    ext {
+        restdocsApiSpecVersion = '0.18.4'
+    }
+}
+
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.5'
@@ -5,6 +12,8 @@ plugins {
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'com.diffplug.spotless' version '6.11.0'
     id 'jacoco'
+    id 'com.epages.restdocs-api-spec' version "${restdocsApiSpecVersion}"
+    id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 group = 'com.konggogi'
@@ -59,6 +68,10 @@ dependencies {
     // spring rest docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation "com.epages:restdocs-api-spec-mockmvc:${restdocsApiSpecVersion}"
+
+    // swagger ui
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
     // RDB
     runtimeOnly 'com.h2database:h2'
@@ -97,21 +110,24 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    outputs.dir snippetsDir
     finalizedBy jacocoTestReport
 }
 
-asciidoctor {
-    inputs.dir snippetsDir
-    configurations 'asciidoctorExt'
-    dependsOn test
+bootJar {
+    dependsOn(':openapi3')
 }
 
-bootJar { // jar의 templates에 문서 복사
-    dependsOn asciidoctor
-    from ("${asciidoctor.outputDir}") {
-        into 'BOOT-INF/classes/templates'
-    }
+// swagger ui 변환
+openapi3 {
+    servers = [
+            { url = 'http://localhost:8080' },
+            { url = 'https://dev.konggogi.store' }
+    ]
+    title = 'Vegan Life API 문서'
+    description = 'Vegan Life API 문서'
+    version = '1.0.0'
+    outputFileNamePrefix = 'Vegan Life - 1.0.0'
+    format = 'yaml'
 }
 
 //jacoco setting

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,16 @@ openapi3 {
     format = 'yaml'
 }
 
+tasks.withType(GenerateSwaggerUI) {
+    dependsOn 'openapi3'
+
+    delete file('src/main/resources/static/docs/')
+    copy {
+        from "build/resources/main/static/docs"
+        into "src/main/resources/static/docs/"
+    }
+}
+
 //jacoco setting
 
 jacocoTestReport {

--- a/src/main/java/com/konggogi/veganlife/global/config/SecurityConfig.java
+++ b/src/main/java/com/konggogi/veganlife/global/config/SecurityConfig.java
@@ -51,8 +51,10 @@ public class SecurityConfig {
                                 authorize
                                         .requestMatchers(
                                                 new AntPathRequestMatcher(
+                                                        "/api/v1/docs/swagger*/**"),
+                                                new AntPathRequestMatcher("/v3/api-docs/**"),
+                                                new AntPathRequestMatcher(
                                                         "/api/v1/members/oauth/*/login"),
-                                                new AntPathRequestMatcher("/api/v1/docs"),
                                                 new AntPathRequestMatcher("/actuator/health"))
                                         .permitAll()
                                         .anyRequest()

--- a/src/main/java/com/konggogi/veganlife/global/config/SwaggerConfig.java
+++ b/src/main/java/com/konggogi/veganlife/global/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.konggogi.veganlife.global.config;
+
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI(@Value("${springdoc.version}") String version) {
+        String AUTH_SCHEME = "JWT Access Token";
+        Info info =
+                new Info()
+                        .title("Vegan Life API 문서")
+                        .version(version)
+                        .description("우측의 Authorize를 수행한 뒤, API를 테스트 해주세요");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(AUTH_SCHEME);
+        Components components =
+                new Components()
+                        .addSecuritySchemes(
+                                AUTH_SCHEME,
+                                new SecurityScheme()
+                                        .name(AUTH_SCHEME)
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .description("bearer는 제외하고 입력해주세요.")
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT"));
+
+        return new OpenAPI().components(components).addSecurityItem(securityRequirement).info(info);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,3 +24,14 @@ jwt:
   expiration: 7200
   refresh-token:
     expiration: 604800
+
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  version: 'v1'
+  swagger-ui:
+    operationsSorter: method
+    disable-swagger-default-url: true
+    path: /api/v1/docs/swagger
+  paths-to-match:
+    - /**

--- a/src/test/java/com/konggogi/veganlife/comment/controller/CommentLikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/comment/controller/CommentLikeControllerTest.java
@@ -1,12 +1,12 @@
 package com.konggogi.veganlife.comment.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;

--- a/src/test/java/com/konggogi/veganlife/mealdata/controller/MealDataControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/mealdata/controller/MealDataControllerTest.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.mealdata.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,7 +9,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.meallog.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
@@ -7,14 +8,13 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/konggogi/veganlife/member/controller/AuthControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/AuthControllerTest.java
@@ -1,12 +1,12 @@
 package com.konggogi.veganlife.member.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.member.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
@@ -7,7 +8,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/src/test/java/com/konggogi/veganlife/member/controller/MyPageControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MyPageControllerTest.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.member.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.member.domain.QMember.member;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
@@ -7,7 +8,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;

--- a/src/test/java/com/konggogi/veganlife/member/controller/NutrientsControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/NutrientsControllerTest.java
@@ -1,11 +1,11 @@
 package com.konggogi.veganlife.member.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;

--- a/src/test/java/com/konggogi/veganlife/member/controller/OauthControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/OauthControllerTest.java
@@ -1,11 +1,11 @@
 package com.konggogi.veganlife.member.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;

--- a/src/test/java/com/konggogi/veganlife/notification/controller/SseControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/notification/controller/SseControllerTest.java
@@ -1,12 +1,12 @@
 package com.konggogi.veganlife.notification.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostControllerTest.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.post.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.*;
@@ -7,7 +8,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostLikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostLikeControllerTest.java
@@ -1,12 +1,12 @@
 package com.konggogi.veganlife.post.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;

--- a/src/test/java/com/konggogi/veganlife/post/controller/PostSearchControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/post/controller/PostSearchControllerTest.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.post.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.junit.jupiter.api.Assertions.*;
@@ -7,7 +8,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;

--- a/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeControllerTest.java
@@ -1,5 +1,6 @@
 package com.konggogi.veganlife.recipe.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
@@ -7,7 +8,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;

--- a/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeLikeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeLikeControllerTest.java
@@ -1,11 +1,11 @@
 package com.konggogi.veganlife.recipe.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;

--- a/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/docs/RestDocsTest.java
@@ -1,7 +1,7 @@
 package com.konggogi.veganlife.support.docs;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;


### PR DESCRIPTION
## 이슈 번호 (#289 )

## 변경 내용
spring rest docs + Swagger UI를 연동하여 API 문서 자동화

**[기존]**
 spring rest docs만 사용했을 경우, Asciidoctor를 통해 문서를 생성

**[변경]**
1. 기존처럼 테스트 코드를 통해 생성된 결과물을 Open API 3스펙으로 변환
3. Open API 3스펙을 통해 Swagger UI 생성
