### PR TITLE
swagger UI HTTP요청 시 CORS 문제 해결

### DIFF
--- a/src/main/java/com/konggogi/veganlife/global/config/SwaggerConfig.java
+++ b/src/main/java/com/konggogi/veganlife/global/config/SwaggerConfig.java
@@ -1,6 +1,8 @@
 package com.konggogi.veganlife.global.config;
 
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
@@ -10,27 +12,37 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+@OpenAPIDefinition(
+        servers = {
+            @Server(url = "https://dev.konggogi.store", description = "개발 서버"),
+            @Server(url = "http://localhost:8080", description = "로컬 서버")
+        })
 @Configuration
 public class SwaggerConfig {
+    private final String AUTH_SCHEME_NAME = "JWT Access Token";
+    private final String AUTH_SCHEME = "bearer";
+    private final String BEARER_FORMAT = "JWT";
+
     @Bean
     public OpenAPI openAPI(@Value("${springdoc.version}") String version) {
-        String AUTH_SCHEME = "JWT Access Token";
         Info info =
                 new Info()
-                        .title("Vegan Life API 문서")
+                        .title("Vegan Life API Documentation")
                         .version(version)
                         .description("우측의 Authorize를 수행한 뒤, API를 테스트 해주세요");
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(AUTH_SCHEME);
+
+        SecurityRequirement securityRequirement =
+                new SecurityRequirement().addList(AUTH_SCHEME_NAME);
         Components components =
                 new Components()
                         .addSecuritySchemes(
-                                AUTH_SCHEME,
+                                AUTH_SCHEME_NAME,
                                 new SecurityScheme()
-                                        .name(AUTH_SCHEME)
+                                        .name(AUTH_SCHEME_NAME)
                                         .type(SecurityScheme.Type.HTTP)
                                         .description("bearer는 제외하고 입력해주세요.")
-                                        .scheme("bearer")
-                                        .bearerFormat("JWT"));
+                                        .scheme(AUTH_SCHEME)
+                                        .bearerFormat(BEARER_FORMAT));
 
         return new OpenAPI().components(components).addSecurityItem(securityRequirement).info(info);
     }


### PR DESCRIPTION
## 이슈 번호 (#291 )

## 설명
**[문제]**
서버 도메인이 https를 사용하지만, Swagger UI로 요청 시 http로 요청

**[원인]**
Swagger UI가 HTTP 요청 시 기본적으로 http를 사용하기 때문

**[해결]**
`SwaggerConfig`에서 `@OpenAPIDefinition` 애노테이션의 servers 속성을 사용하여 API가 호스팅 되는 서버 목록 정의

- 개발 서버: `https://dev.konggogi.store/`
- 로컬 서버: `http://localhost:8080/`

(상황에 따라 API 호출할 서버를 선택해 사용하면 됩니다)
