### PR TITLE
[FIX] 프로필 수정 시 기존 닉네임과 같으면 중복 처리되는 문제 해결

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -10,28 +10,6 @@ ifndef::snippets[]
 :snippets: ./build/generated-snippets
 endif::[]
 
-== 회원 추가 정보 등록 API
-
-=== Request
-
-==== Header
-
-include::{snippets}/update-additional-info/request-headers.adoc[]
-
-==== Body
-
-include::{snippets}/update-additional-info/http-request.adoc[]
-
-=== Response
-
-==== 200 OK
-
-include::{snippets}/update-additional-info/http-response.adoc[]
-
-==== 409 CONFLICT
-
-include::{snippets}/update-additional-info-duplicated-nickname/http-response.adoc[]
-
 == 회원 탈퇴 API
 
 === Request

--- a/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
@@ -2,32 +2,19 @@ package com.konggogi.veganlife.member.controller;
 
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
-import com.konggogi.veganlife.member.controller.dto.request.AdditionalInfoUpdateRequest;
-import com.konggogi.veganlife.member.controller.dto.response.AdditionalInfoUpdateResponse;
-import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
 import com.konggogi.veganlife.member.service.MemberService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/members")
 public class MemberController {
     private final MemberService memberService;
-    private final MemberMapper memberMapper;
-
-    @PostMapping()
-    public ResponseEntity<AdditionalInfoUpdateResponse> modifyAdditionalInfo(
-            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestBody @Valid AdditionalInfoUpdateRequest additionalInfoUpdateRequest) {
-        Member member =
-                memberService.updateAdditionalInfo(userDetails.id(), additionalInfoUpdateRequest);
-        return ResponseEntity.ok(memberMapper.toAdditionalInfoUpdateResponse(member));
-    }
 
     @DeleteMapping()
     public ResponseEntity<Void> removeMember(@AuthenticationPrincipal UserDetailsImpl userDetails) {

--- a/src/main/java/com/konggogi/veganlife/member/domain/Member.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/Member.java
@@ -79,17 +79,6 @@ public class Member extends TimeStamped {
         this.hasAdditionalInfo = false;
     }
 
-    public void updateAdditionalInfo(
-            String nickname,
-            Gender gender,
-            VegetarianType vegetarianType,
-            Integer birthYear,
-            Integer height,
-            Integer weight) {
-        updateProfile(nickname, vegetarianType, gender, birthYear, height, weight);
-        this.hasAdditionalInfo = true;
-    }
-
     public void modifyProfile(
             String nickname,
             String profileImageUrl,
@@ -98,8 +87,15 @@ public class Member extends TimeStamped {
             Integer birthYear,
             Integer height,
             Integer weight) {
-        updateProfile(nickname, vegetarianType, gender, birthYear, height, weight);
+        this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
+        this.vegetarianType = vegetarianType;
+        this.gender = gender;
+        this.birthYear = birthYear;
+        this.height = height;
+        this.weight = weight;
+        this.hasAdditionalInfo = true;
+        updateDailyIntake();
     }
 
     private void updateDailyIntake() {
@@ -123,21 +119,5 @@ public class Member extends TimeStamped {
         LocalDate now = LocalDate.now();
         int currentYear = now.getYear();
         return (currentYear - birthYear);
-    }
-
-    private void updateProfile(
-            String nickname,
-            VegetarianType vegetarianType,
-            Gender gender,
-            Integer birthYear,
-            Integer height,
-            Integer weight) {
-        this.nickname = nickname;
-        this.vegetarianType = vegetarianType;
-        this.gender = gender;
-        this.birthYear = birthYear;
-        this.height = height;
-        this.weight = weight;
-        updateDailyIntake();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -9,7 +9,6 @@ import com.konggogi.veganlife.global.util.AwsS3Folders;
 import com.konggogi.veganlife.global.util.AwsS3Uploader;
 import com.konggogi.veganlife.mealdata.service.MealDataService;
 import com.konggogi.veganlife.meallog.service.MealLogService;
-import com.konggogi.veganlife.member.controller.dto.request.AdditionalInfoUpdateRequest;
 import com.konggogi.veganlife.member.controller.dto.request.ProfileModifyRequest;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
@@ -42,7 +41,6 @@ public class MemberService {
     private final RefreshTokenService refreshTokenService;
     private final RefreshTokenRepository refreshTokenRepository;
     private final MemberMapper memberMapper;
-
     private final AwsS3Uploader awsS3Uploader;
 
     public MemberLoginDto login(String email) {
@@ -59,32 +57,19 @@ public class MemberService {
         memberRepository.delete(member);
     }
 
-    public Member updateAdditionalInfo(Long memberId, AdditionalInfoUpdateRequest infoRequest) {
-        validateNickname(infoRequest.nickname());
-        Member member = memberQueryService.search(memberId);
-        member.updateAdditionalInfo(
-                infoRequest.nickname(),
-                infoRequest.gender(),
-                infoRequest.vegetarianType(),
-                infoRequest.birthYear(),
-                infoRequest.height(),
-                infoRequest.weight());
-        return member;
-    }
-
     public Member modifyProfile(
-            Long memberId, ProfileModifyRequest profileRequest, MultipartFile profileImage) {
-        validateNickname(profileRequest.nickname());
-        String profileImageUrl = awsS3Uploader.uploadFile(AwsS3Folders.PROFILE, profileImage);
+            Long memberId, ProfileModifyRequest request, MultipartFile profileImage) {
         Member member = memberQueryService.search(memberId);
+        validateNickname(member.getNickname(), request.nickname());
+        String profileImageUrl = awsS3Uploader.uploadFile(AwsS3Folders.PROFILE, profileImage);
         member.modifyProfile(
-                profileRequest.nickname(),
+                request.nickname(),
                 profileImageUrl,
-                profileRequest.vegetarianType(),
-                profileRequest.gender(),
-                profileRequest.birthYear(),
-                profileRequest.height(),
-                profileRequest.weight());
+                request.vegetarianType(),
+                request.gender(),
+                request.birthYear(),
+                request.height(),
+                request.weight());
         return member;
     }
 
@@ -94,13 +79,16 @@ public class MemberService {
                 .orElseGet(() -> memberRepository.save(memberMapper.toMember(email)));
     }
 
-    private void validateNickname(String nickname) {
-        memberRepository
-                .findByNickname(nickname)
-                .ifPresent(
-                        member -> {
-                            throw new DuplicatedNicknameException(ErrorCode.DUPLICATED_NICKNAME);
-                        });
+    private void validateNickname(String nickname, String newNickname) {
+        if (nickname == null || !nickname.equals(newNickname)) {
+            memberRepository
+                    .findByNickname(newNickname)
+                    .ifPresent(
+                            member -> {
+                                throw new DuplicatedNicknameException(
+                                        ErrorCode.DUPLICATED_NICKNAME);
+                            });
+        }
     }
 
     private void removeRelatedData(Long memberId) {

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -3,93 +3,26 @@ package com.konggogi.veganlife.member.controller;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
-import com.konggogi.veganlife.member.controller.dto.request.AdditionalInfoUpdateRequest;
-import com.konggogi.veganlife.member.domain.Gender;
-import com.konggogi.veganlife.member.domain.Member;
-import com.konggogi.veganlife.member.domain.VegetarianType;
-import com.konggogi.veganlife.member.exception.DuplicatedNicknameException;
-import com.konggogi.veganlife.member.fixture.MemberFixture;
 import com.konggogi.veganlife.member.service.MemberService;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(MemberController.class)
 class MemberControllerTest extends RestDocsTest {
     @MockBean MemberService memberService;
-
-    @Test
-    @DisplayName("추가 정보 입력 API")
-    void updateAdditionalInfoTest() throws Exception {
-        // given
-        Member member = MemberFixture.DEFAULT_M.getWithId(1L);
-        AdditionalInfoUpdateRequest request =
-                new AdditionalInfoUpdateRequest(
-                        member.getNickname(), Gender.M, VegetarianType.LACTO, 1990, 180, 83);
-        given(memberService.updateAdditionalInfo(anyLong(), any(AdditionalInfoUpdateRequest.class)))
-                .willReturn(member);
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        post("/api/v1/members")
-                                .headers(authorizationHeader())
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(toJson(request)));
-        // then
-        perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.nickname").value(request.nickname()));
-
-        perform.andDo(print())
-                .andDo(
-                        document(
-                                "update-additional-info",
-                                getDocumentRequest(),
-                                getDocumentResponse(),
-                                requestHeaders(authorizationDesc())));
-    }
-
-    @Test
-    @DisplayName("추가 정보 입력 API - Duplicated Nickname")
-    void updateAdditionalInfoDuplicatedNicknameTest() throws Exception {
-        // given
-        AdditionalInfoUpdateRequest request =
-                new AdditionalInfoUpdateRequest(
-                        "비건라이프", Gender.M, VegetarianType.LACTO, 1990, 180, 83);
-        given(memberService.updateAdditionalInfo(anyLong(), any(AdditionalInfoUpdateRequest.class)))
-                .willThrow(new DuplicatedNicknameException(ErrorCode.DUPLICATED_NICKNAME));
-        // when
-        ResultActions perform =
-                mockMvc.perform(
-                        post("/api/v1/members")
-                                .headers(authorizationHeader())
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(toJson(request)));
-        // then
-        perform.andExpect(status().isConflict());
-
-        perform.andDo(print())
-                .andDo(
-                        document(
-                                "update-additional-info-duplicated-nickname",
-                                getDocumentResponse()));
-    }
 
     @Test
     @DisplayName("회원 탈퇴 API")

--- a/src/test/java/com/konggogi/veganlife/member/domain/MemberTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/domain/MemberTest.java
@@ -8,34 +8,6 @@ import org.junit.jupiter.api.Test;
 
 class MemberTest {
     @Test
-    @DisplayName("추가 정보 업데이트")
-    void updateMemberInfoTest() {
-        // given
-        Member member = MemberFixture.DEFAULT_M.getOnlyEmailWithId(1L);
-        Member expectedMember = MemberFixture.DEFAULT_F.get();
-        // when
-        member.updateAdditionalInfo(
-                expectedMember.getNickname(),
-                expectedMember.getGender(),
-                expectedMember.getVegetarianType(),
-                expectedMember.getBirthYear(),
-                expectedMember.getHeight(),
-                expectedMember.getWeight());
-        // then
-        assertThat(member.getNickname()).isEqualTo(expectedMember.getNickname());
-        assertThat(member.getGender()).isEqualTo(expectedMember.getGender());
-        assertThat(member.getVegetarianType()).isEqualTo(expectedMember.getVegetarianType());
-        assertThat(member.getBirthYear()).isEqualTo(expectedMember.getBirthYear());
-        assertThat(member.getHeight()).isEqualTo(expectedMember.getHeight());
-        assertThat(member.getWeight()).isEqualTo(expectedMember.getWeight());
-        assertThat(member.isHasAdditionalInfo()).isTrue();
-        assertThat(member.getAMR()).isEqualTo(expectedMember.getAMR());
-        assertThat(member.getDailyCarbs()).isEqualTo(expectedMember.getDailyCarbs());
-        assertThat(member.getDailyProtein()).isEqualTo(expectedMember.getDailyProtein());
-        assertThat(member.getDailyFat()).isEqualTo(expectedMember.getDailyFat());
-    }
-
-    @Test
     @DisplayName("회원 프로필 수정")
     void modifyMemberProfileTest() {
         // given
@@ -52,6 +24,7 @@ class MemberTest {
                 nickname, profileImageUrl, vegetarianType, gender, birthYear, height, weight);
         // then
         assertThat(member.getNickname()).isEqualTo(nickname);
+        assertThat(member.getProfileImageUrl()).isEqualTo(profileImageUrl);
         assertThat(member.getGender()).isEqualTo(gender);
         assertThat(member.getVegetarianType()).isEqualTo(vegetarianType);
         assertThat(member.getBirthYear()).isEqualTo(birthYear);

--- a/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
@@ -4,21 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.*;
 
 import com.konggogi.veganlife.comment.service.CommentLikeService;
 import com.konggogi.veganlife.comment.service.CommentService;
 import com.konggogi.veganlife.global.exception.ErrorCode;
-import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.global.security.jwt.JwtProvider;
 import com.konggogi.veganlife.global.util.AwsS3Folders;
 import com.konggogi.veganlife.global.util.AwsS3Uploader;
 import com.konggogi.veganlife.mealdata.service.MealDataService;
 import com.konggogi.veganlife.meallog.service.MealLogService;
-import com.konggogi.veganlife.member.controller.dto.request.AdditionalInfoUpdateRequest;
 import com.konggogi.veganlife.member.controller.dto.request.ProfileModifyRequest;
 import com.konggogi.veganlife.member.domain.Gender;
 import com.konggogi.veganlife.member.domain.Member;
@@ -124,53 +120,12 @@ class MemberServiceTest {
     }
 
     @Test
-    @DisplayName("추가 정보 입력")
-    void updateAdditionalInfoTest() {
-        // given
-        Long memberId = member.getId();
-        AdditionalInfoUpdateRequest request =
-                new AdditionalInfoUpdateRequest(
-                        "테스트유저", Gender.M, VegetarianType.LACTO, 1990, 180, 83);
-        given(memberRepository.findByNickname(request.nickname())).willReturn(Optional.empty());
-        given(memberQueryService.search(memberId)).willReturn(member);
-        // when
-        Member updatedMember = memberService.updateAdditionalInfo(memberId, request);
-        // then
-        assertThat(updatedMember.getNickname()).isEqualTo(request.nickname());
-        assertThat(updatedMember.getGender()).isEqualTo(request.gender());
-        assertThat(updatedMember.getVegetarianType()).isEqualTo(request.vegetarianType());
-        assertThat(updatedMember.getBirthYear()).isEqualTo(request.birthYear());
-        assertThat(updatedMember.getHeight()).isEqualTo(request.height());
-        assertThat(updatedMember.getWeight()).isEqualTo(request.weight());
-        then(memberRepository).should().findByNickname(request.nickname());
-    }
-
-    @Test
-    @DisplayName("추가 정보 입력 - Duplicated Nickname")
-    void updateAdditionalInfoDuplicatedNicknameTest() {
-        // given
-        Long memberId = member.getId();
-        Member existingMember = MemberFixture.DEFAULT_F.getWithId(1L);
-        String nickname = existingMember.getNickname();
-        AdditionalInfoUpdateRequest request =
-                new AdditionalInfoUpdateRequest(
-                        nickname, Gender.F, VegetarianType.VEGAN, 2000, 165, 50);
-        given(memberRepository.findByNickname(nickname)).willReturn(Optional.of(existingMember));
-        // when, then
-        assertThatThrownBy(() -> memberService.updateAdditionalInfo(memberId, request))
-                .isInstanceOf(DuplicatedNicknameException.class);
-        then(memberRepository).should().findByNickname(nickname);
-        then(memberRepository).should(never()).save(any(Member.class));
-    }
-
-    @Test
     @DisplayName("회원 프로필 수정")
     void modifyMemberProfileTest() {
         // given
-        ProfileModifyRequest profileRequest =
+        ProfileModifyRequest request =
                 new ProfileModifyRequest("nickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90);
-        given(memberRepository.findByNickname(profileRequest.nickname()))
-                .willReturn(Optional.empty());
+        given(memberRepository.findByNickname(request.nickname())).willReturn(Optional.empty());
         given(memberQueryService.search(anyLong())).willReturn(member);
         MultipartFile profileImage =
                 new MockMultipartFile(
@@ -182,15 +137,14 @@ class MemberServiceTest {
                 .given(awsS3Uploader)
                 .uploadFile(eq(AwsS3Folders.PROFILE), any());
         // when
-        Member updatedMember =
-                memberService.modifyProfile(member.getId(), profileRequest, profileImage);
+        Member update = memberService.modifyProfile(member.getId(), request, profileImage);
         // then
-        assertThat(updatedMember.getNickname()).isEqualTo(profileRequest.nickname());
-        assertThat(updatedMember.getVegetarianType()).isEqualTo(profileRequest.vegetarianType());
-        assertThat(updatedMember.getGender()).isEqualTo(profileRequest.gender());
-        assertThat(updatedMember.getBirthYear()).isEqualTo(profileRequest.birthYear());
-        assertThat(updatedMember.getHeight()).isEqualTo(profileRequest.height());
-        assertThat(updatedMember.getWeight()).isEqualTo(profileRequest.weight());
+        assertThat(update.getNickname()).isEqualTo(request.nickname());
+        assertThat(update.getVegetarianType()).isEqualTo(request.vegetarianType());
+        assertThat(update.getGender()).isEqualTo(request.gender());
+        assertThat(update.getBirthYear()).isEqualTo(request.birthYear());
+        assertThat(update.getHeight()).isEqualTo(request.height());
+        assertThat(update.getWeight()).isEqualTo(request.weight());
         then(memberRepository).should().findByNickname(anyString());
         then(memberQueryService).should().search(anyLong());
     }
@@ -199,50 +153,49 @@ class MemberServiceTest {
     @DisplayName("회원 프로필 수정 시 중복된 닉네임 중복 예외 발생")
     void modifyMemberProfileDuplicatedNicknameTest() {
         // given
-        Long memberId = member.getId();
-        Member existingMember = MemberFixture.DEFAULT_F.getWithId(1L);
+        Member existing = MemberFixture.DEFAULT_F.getWithId(1L);
+        Member other = MemberFixture.DEFAULT_M.getWithId(2L);
+        String newNickname = other.getNickname();
         ProfileModifyRequest request =
                 new ProfileModifyRequest(
-                        existingMember.getNickname(),
-                        VegetarianType.LACTO,
-                        Gender.M,
-                        1993,
-                        190,
-                        90);
-        given(memberRepository.findByNickname(request.nickname()))
-                .willReturn(Optional.of(existingMember));
+                        newNickname, VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+        given(memberQueryService.search(anyLong())).willReturn(existing);
+        given(memberRepository.findByNickname(anyString())).willReturn(Optional.of(other));
         // when, then
-        assertThatThrownBy(() -> memberService.modifyProfile(memberId, request, null))
+        assertThatThrownBy(() -> memberService.modifyProfile(existing.getId(), request, null))
                 .isInstanceOf(DuplicatedNicknameException.class)
                 .hasMessageContaining(ErrorCode.DUPLICATED_NICKNAME.getDescription());
         then(memberRepository).should().findByNickname(anyString());
-        then(memberQueryService).should(never()).search(anyLong());
     }
 
     @Test
-    @DisplayName("회원 프로필 수정 시 회원을 찾을 수 없으면 예외 발생")
-    void modifyNotMemberProfileTest() {
+    @DisplayName("회원 프로필 수정 시 기존 닉네임이 NULL인 경우 종복 검사")
+    void modifyMemberProfileExistingNicknameIsNULL() {
         // given
         Long memberId = member.getId();
         ProfileModifyRequest request =
-                new ProfileModifyRequest("nickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90);
-        given(memberRepository.findByNickname(request.nickname())).willReturn(Optional.empty());
-        given(memberQueryService.search(member.getId()))
-                .willThrow(new NotFoundEntityException(ErrorCode.NOT_FOUND_MEMBER));
-        MultipartFile profileImage =
-                new MockMultipartFile(
-                        "image",
-                        "profileImage1.png",
-                        MediaType.IMAGE_PNG_VALUE,
-                        "profileImage1.png".getBytes());
-        willReturn("profileImage1.png")
-                .given(awsS3Uploader)
-                .uploadFile(eq(AwsS3Folders.PROFILE), any());
-        // when, then
-        assertThatThrownBy(() -> memberService.modifyProfile(memberId, request, profileImage))
-                .isInstanceOf(NotFoundEntityException.class)
-                .hasMessageContaining(ErrorCode.NOT_FOUND_MEMBER.getDescription());
+                new ProfileModifyRequest(
+                        "newNickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        given(memberRepository.findByNickname(anyString())).willReturn(Optional.empty());
+        // when
+        memberService.modifyProfile(memberId, request, null);
+        // then
         then(memberRepository).should().findByNickname(anyString());
-        then(memberQueryService).should().search(anyLong());
+    }
+
+    @Test
+    @DisplayName("회원 프로필 수정 시 기존 닉네임과 같으면 중복 검사 하지 않음")
+    void modifyMemberProfileNotChangeNickname() {
+        // given
+        Member existing = MemberFixture.DEFAULT_F.getWithId(1L);
+        ProfileModifyRequest request =
+                new ProfileModifyRequest(
+                        existing.getNickname(), VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+        given(memberQueryService.search(anyLong())).willReturn(existing);
+        // when
+        memberService.modifyProfile(existing.getId(), request, null);
+        // then
+        then(memberRepository).should(never()).findByNickname(anyString());
     }
 }

--- a/src/test/java/com/konggogi/veganlife/support/restassured/IntegrationTest.java
+++ b/src/test/java/com/konggogi/veganlife/support/restassured/IntegrationTest.java
@@ -36,7 +36,7 @@ public class IntegrationTest {
     @BeforeEach
     void beforeEach() {
         member = Member.builder().email("test123@test.com").build();
-        member.updateAdditionalInfo("비건라이프", Gender.F, VegetarianType.VEGAN, 2000, 160, 50);
+        member.modifyProfile("비건라이프", null, VegetarianType.VEGAN, Gender.F, 2000, 160, 50);
         memberRepository.save(member);
     }
 


### PR DESCRIPTION
## 이슈 번호 (#304 )

## 요약
프로필 수정 시 기존 닉네임과 같으면 중복 처리되는 문제 해결

## 변경 내용
- 회원 추가 정보 입력 API 엔드포인트 삭제 → 프로필 수정 API로 대체
- 기존 회원의 닉네임이 `null`이거나, 닉네임 변경 사항이 없다면 중복 체크를 하지 않도록 변경
- 테스트 코드와 관련 문서 수정

