### PR TITLE
Fix 313: Elasticsearch -> Opensearch 마이그레이션

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         ELASTIC_HOST: ${{ secrets.ELASTIC_HOST }}
         ELASTIC_USER: ${{ secrets.ELASTIC_USER }}
         ELASTIC_PASSWORD: ${{ secrets.ELASTIC_PASSWORD }}
+        ELASTIC_PORT: ${{ secrets.ELASTIC_PORT }}
       run: ./gradlew clean test spotlessCheck
 
     - name: Send Notification to Discord

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -44,6 +44,7 @@ jobs:
         ELASTIC_HOST: ${{ secrets.ELASTIC_HOST }}
         ELASTIC_USER: ${{ secrets.ELASTIC_USER }}
         ELASTIC_PASSWORD: ${{ secrets.ELASTIC_PASSWORD }}
+        ELASTIC_PORT: ${{ secrets.ELASTIC_PORT }}
       run: |
         ./gradlew clean build
 

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     //elastic search
-    implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'org.opensearch.client:spring-data-opensearch:1.2.1'
+    implementation 'org.springframework.data:spring-data-elasticsearch:5.1.12'
 
     //webp
     implementation 'com.sksamuel.scrimage:scrimage-core:4.2.0'

--- a/src/main/java/com/konggogi/veganlife/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/konggogi/veganlife/global/config/ElasticsearchConfig.java
@@ -1,24 +1,18 @@
 package com.konggogi.veganlife.global.config;
 
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.ElasticsearchTransport;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.elasticsearch.client.RestClient;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.data.client.orhlc.AbstractOpenSearchConfiguration;
+import org.opensearch.data.client.orhlc.ClientConfiguration;
+import org.opensearch.data.client.orhlc.RestClients;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 
 @Configuration
-@EnableElasticsearchRepositories
-public class ElasticsearchConfig extends ElasticsearchConfiguration {
+@EnableElasticsearchRepositories(basePackages = "com.konggogi.veganlife.*.repository.elastic")
+public class ElasticsearchConfig extends AbstractOpenSearchConfiguration {
+
     @Value("${spring.elasticsearch.username}")
     private String username;
 
@@ -28,24 +22,18 @@ public class ElasticsearchConfig extends ElasticsearchConfiguration {
     @Value("${spring.elasticsearch.host}")
     private String host;
 
+    @Value("${spring.elasticsearch.port}")
+    private Integer port;
+
     @Override
-    public ClientConfiguration clientConfiguration() {
-        return ClientConfiguration.builder()
-                .connectedTo(host)
-                .usingSsl()
-                .withBasicAuth(username, password)
-                .build();
-    }
+    public RestHighLevelClient opensearchClient() {
 
-    @Bean
-    public ElasticsearchClient elasticsearchClient(RestClient restClient) {
-        ObjectMapper objectMapper =
-                new ObjectMapper()
-                        .registerModule(new JavaTimeModule())
-                        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-        ElasticsearchTransport transport =
-                new RestClientTransport(restClient, new JacksonJsonpMapper(objectMapper));
-        return new ElasticsearchClient(transport);
+        ClientConfiguration clientConfiguration =
+                ClientConfiguration.builder()
+                        .connectedTo(host + ":" + port)
+                        .usingSsl()
+                        .withBasicAuth(username, password)
+                        .build();
+        return RestClients.create(clientConfiguration).rest();
     }
 }

--- a/src/main/java/com/konggogi/veganlife/post/repository/elastic/PostCustomElasticRepositoryImpl.java
+++ b/src/main/java/com/konggogi/veganlife/post/repository/elastic/PostCustomElasticRepositoryImpl.java
@@ -35,7 +35,7 @@ public class PostCustomElasticRepositoryImpl implements PostCustomElasticReposit
 
     private Query autoCompleteSuggestionQuery(String keyword, int size) {
         QueryBuilder matchPhraseQuery =
-                QueryBuilders.matchPhraseQuery("title", keyword).slop(1).boost(3.0f);
+                QueryBuilders.matchPhraseQuery("title", keyword).slop(1).boost(5.0f);
 
         QueryBuilder matchNoriQuery =
                 QueryBuilders.matchQuery("title.nori", keyword)

--- a/src/main/java/com/konggogi/veganlife/post/repository/elastic/PostCustomElasticRepositoryImpl.java
+++ b/src/main/java/com/konggogi/veganlife/post/repository/elastic/PostCustomElasticRepositoryImpl.java
@@ -1,64 +1,57 @@
 package com.konggogi.veganlife.post.repository.elastic;
 
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._types.query_dsl.*;
-import co.elastic.clients.elasticsearch.core.SearchRequest;
-import co.elastic.clients.elasticsearch.core.SearchResponse;
-import co.elastic.clients.elasticsearch.core.search.Hit;
-import co.elastic.clients.util.ObjectBuilder;
-import com.konggogi.veganlife.global.exception.ElasticsearchOperationException;
-import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.post.domain.document.PostDocument;
-import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.opensearch.common.unit.Fuzziness;
+import org.opensearch.data.client.orhlc.NativeSearchQueryBuilder;
+import org.opensearch.index.query.Operator;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
 public class PostCustomElasticRepositoryImpl implements PostCustomElasticRepository {
-    private final ElasticsearchClient elasticsearchClient;
+    private final ElasticsearchOperations elasticsearchOperations;
     private final String POSTS_INDEX = "posts";
 
     @Override
     public List<PostDocument> findAutoCompleteSuggestion(String keyword, int size) {
-        try {
-            SearchResponse<PostDocument> response =
-                    elasticsearchClient.search(
-                            s -> autoCompleteSuggestionQuery(s, keyword, size), PostDocument.class);
+        SearchHits<PostDocument> response =
+                elasticsearchOperations.search(
+                        autoCompleteSuggestionQuery(keyword, size),
+                        PostDocument.class,
+                        IndexCoordinates.of(POSTS_INDEX));
 
-            return response.hits().hits().stream().map(Hit::source).toList();
-        } catch (IOException e) {
-            throw new ElasticsearchOperationException(ErrorCode.ES_OPERATION_FAILED);
-        }
+        return response.getSearchHits().stream().map(SearchHit::getContent).toList();
     }
 
-    private ObjectBuilder<SearchRequest> autoCompleteSuggestionQuery(
-            SearchRequest.Builder builder, String keyword, int size) {
-        Query matchPhraseQuery =
-                MatchPhraseQuery.of(mp -> mp.field("title").query(keyword).slop(1).boost(3.0f))
-                        ._toQuery();
-        Query matchNoriQuery =
-                MatchQuery.of(
-                                m ->
-                                        m.field("title.nori")
-                                                .query(keyword)
-                                                .operator(Operator.And)
-                                                .boost(2.0f)
-                                                .fuzziness("1"))
-                        ._toQuery();
-        Query matchNgramQuery =
-                MatchQuery.of(m -> m.field("title.ngram").query(keyword))._toQuery();
-        Query boolQuery =
-                BoolQuery.of(
-                                b ->
-                                        b.should(matchPhraseQuery)
-                                                .should(matchNoriQuery)
-                                                .should(matchNgramQuery)
-                                                .minimumShouldMatch("1"))
-                        ._toQuery();
+    private Query autoCompleteSuggestionQuery(String keyword, int size) {
+        QueryBuilder matchPhraseQuery =
+                QueryBuilders.matchPhraseQuery("title", keyword).slop(1).boost(3.0f);
 
-        return builder.index(POSTS_INDEX).size(size).query(boolQuery);
+        QueryBuilder matchNoriQuery =
+                QueryBuilders.matchQuery("title.nori", keyword)
+                        .operator(Operator.AND)
+                        .boost(2.0f)
+                        .fuzziness(Fuzziness.ONE);
+
+        QueryBuilder matchNgramQuery = QueryBuilders.matchQuery("title.ngram", keyword);
+
+        QueryBuilder boolQuery =
+                QueryBuilders.boolQuery()
+                        .should(matchPhraseQuery)
+                        .should(matchNoriQuery)
+                        .should(matchNgramQuery)
+                        .minimumShouldMatch(1);
+
+        return new NativeSearchQueryBuilder().withQuery(boolQuery).withMaxResults(size).build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,6 @@ spring:
     port: ${ELASTIC_PORT}
     username: ${ELASTIC_USER}
     password: ${ELASTIC_PASSWORD}
-    uris: ["https://search-vegan-life-elastic-cy6kvgv27uk6oj7u3aqtv5abqa.ap-northeast-2.es.amazonaws.com"]
 
 management:
   health:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,8 +26,16 @@ spring:
       enabled: true
   elasticsearch:
     host: ${ELASTIC_HOST}
+    port: ${ELASTIC_PORT}
     username: ${ELASTIC_USER}
     password: ${ELASTIC_PASSWORD}
+    uris: ["https://search-vegan-life-elastic-cy6kvgv27uk6oj7u3aqtv5abqa.ap-northeast-2.es.amazonaws.com"]
+
+management:
+  health:
+    elasticsearch:
+      enabled: false
+
 jwt:
   secret-key: ${SECRET_KEY}
   expiration: 7200


### PR DESCRIPTION
## 이슈 번호 (#313)
- 이슈 번호를 클릭하시면 왜 Opensearch를 선택했는지 확인할 수 있습니다.

## 요약
- Opensearch 기반으로 동작하도록 코드 마이그레이션

## 변경 내용
- Config 파일 변경 -> `RestHighLevelClient` 클라이언트 초기화
- 쿼리 변경 -> `ElasticOperations`를 사용하여 쿼리

