### PR TITLE
[ENHANCEMENT] 이미지 압축 로직 Lambda로 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,10 +109,6 @@ dependencies {
     //elastic search
     implementation 'org.opensearch.client:spring-data-opensearch:1.2.1'
     implementation 'org.springframework.data:spring-data-elasticsearch:5.1.12'
-
-    //webp
-    implementation 'com.sksamuel.scrimage:scrimage-core:4.2.0'
-    implementation 'com.sksamuel.scrimage:scrimage-webp:4.2.0'
 }
 
 test {

--- a/src/main/java/com/konggogi/veganlife/global/handler/FilterExceptionHandler.java
+++ b/src/main/java/com/konggogi/veganlife/global/handler/FilterExceptionHandler.java
@@ -40,8 +40,8 @@ public class FilterExceptionHandler {
         if (response.isCommitted()) {
             return;
         }
-        LoggingUtils.exceptionLog(HttpStatus.UNAUTHORIZED, e.getCause());
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        LoggingUtils.exceptionLog(HttpStatus.INTERNAL_SERVER_ERROR, e.getCause());
+        response.setStatus(HttpStatus.INTERNAL_SERVER_ERROR.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
 


### PR DESCRIPTION
## 이슈 번호 (#317)

## 요약
### 문제
- 기존에는 **이미지를 압축하는 로직을 애플리케이션 서버에서 실행**하고 있었습니다.
- 그러나 이미지 압축에 소요되는 시간으로 인해 다량의 이미지 업로드 요청시, **다른 요청들까지 대기함으로써 서버의 응답성이 저하**되는 문제가 있었습니다.
  - VU를 10으로 설정하고 성능 테스트를 진행한 결과, 요청 처리가 불가능할 정도로 서버에 부하가 오는 것을 확인할 수 있었습니다.

### 아이디어
- **이미지 압축 로직을 애플리케이션 서버에서 분리**한다면, 요청이 이미지 압축이 끝날 때까지 대기하는 시간을 없앨 수 있을 것이라고 생각했습니다.

### 해결
- **이미지 압축 로직을 Lambda로 분리**하여 기존 로직을 제거했습니다.
- 콜드스타트 문제를 회피하기 위해 Node 기반의 코드로 이미지 압축 로직을 재작성했습니다.
  - 압축 퀄리티는 기본값인 80을 사용했습니다.
- **S3에 이미지가 업로드**되는 이벤트를 트리거로 **Lambda 함수가 자동으로 실행**되게 설정했습니다.
  - 중간에 Amazon SQS(메시지큐)를 추가해 안정적인 이벤트 전달이 가능하도록 했습니다.
![image](https://github.com/user-attachments/assets/6879ccf7-169e-47e9-832d-3d89744c766d)
