### PR TITLE
Fix 319: SSE 알림 목록 조회 시 SSE 연결 알림은 조회되지 않도록 수정

### DIFF
--- a/src/main/java/com/konggogi/veganlife/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/konggogi/veganlife/notification/repository/NotificationRepository.java
@@ -1,7 +1,6 @@
 package com.konggogi.veganlife.notification.repository;
 
 
-import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.notification.domain.Notification;
 import com.konggogi.veganlife.notification.domain.NotificationType;
 import java.time.LocalDate;
@@ -19,5 +18,7 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     void deleteAllByMemberId(Long memberId);
 
-    Page<Notification> findByMemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+    @Query(
+            "select n from Notification n where n.member.id = :memberId and n.type != 'SSE' order by n.createdAt desc")
+    Page<Notification> findAllByMember(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/konggogi/veganlife/notification/service/NotificationService.java
+++ b/src/main/java/com/konggogi/veganlife/notification/service/NotificationService.java
@@ -55,7 +55,7 @@ public class NotificationService {
     public Page<Notification> searchByMember(Long memberId, Pageable pageable) {
 
         Member member = memberQueryService.search(memberId);
-        return notificationRepository.findByMemberOrderByCreatedAtDesc(member, pageable);
+        return notificationRepository.findAllByMember(member.getId(), pageable);
     }
 
     private void sendToClient(Long memberId, Object data) {

--- a/src/test/java/com/konggogi/veganlife/notification/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/notification/repository/NotificationRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.konggogi.veganlife.notification.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
@@ -9,12 +10,14 @@ import com.konggogi.veganlife.notification.domain.Notification;
 import com.konggogi.veganlife.notification.domain.NotificationType;
 import com.konggogi.veganlife.notification.fixture.NotificationFixture;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @DataJpaTest
@@ -59,5 +62,64 @@ class NotificationRepositoryTest {
         // then
         assertThat(notificationRepository.findById(otherNotification.getId())).isPresent();
         assertThat(notificationRepository.findById(notification.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("사용자의 알림 목록 조회 시 SSE 연결 설정 알림은 제외하고 조회한다.")
+    void findByMember_ExceptSSENotification() {
+        // given
+        List<Notification> notifications =
+                List.of(
+                        NotificationFixture.SSE.getWithDate(
+                                member, LocalDateTime.of(2024, 10, 15, 0, 0, 0)),
+                        NotificationFixture.COMMENT.getWithDate(
+                                member, LocalDateTime.of(2024, 10, 15, 1, 0, 0)),
+                        NotificationFixture.INTAKE_OVER_30.getWithDate(
+                                member, LocalDateTime.of(2024, 10, 15, 2, 0, 0)));
+        notificationRepository.saveAll(notifications);
+
+        // when
+        List<Notification> found =
+                notificationRepository
+                        .findAllByMember(member.getId(), Pageable.ofSize(10))
+                        .getContent();
+        // then
+        assertAll(
+                () -> {
+                    assertThat(found).hasSize(2);
+                    found.forEach(
+                            (result) ->
+                                    assertThat(result.getType())
+                                            .isNotEqualTo(NotificationType.SSE));
+                });
+    }
+
+    @Test
+    @DisplayName("사용자의 알림 목록은 생성날짜의 역순으로 조회된다.")
+    void findByMemberTest_CreatedAtIsDesc() {
+        // given
+        List<Notification> notifications =
+                List.of(
+                        NotificationFixture.COMMENT.getWithDate(
+                                member, LocalDateTime.of(2024, 10, 15, 1, 0, 0)),
+                        NotificationFixture.INTAKE_OVER_30.getWithDate(
+                                member, LocalDateTime.of(2024, 10, 14, 2, 0, 0)),
+                        NotificationFixture.MENTION.getWithDate(
+                                member, LocalDateTime.of(2024, 10, 16, 3, 0, 0)));
+        notificationRepository.saveAll(notifications);
+
+        // when
+        List<Notification> found =
+                notificationRepository
+                        .findAllByMember(member.getId(), Pageable.ofSize(10))
+                        .getContent();
+        // then
+        assertAll(
+                () -> {
+                    assertThat(found).hasSize(3);
+                    assertThat(found.get(0).getType()).isEqualTo(NotificationType.MENTION);
+                    assertThat(found.get(1).getType()).isEqualTo(NotificationType.COMMENT);
+                    assertThat(found.get(2).getType()).isEqualTo(NotificationType.INTAKE_OVER_30);
+                });
     }
 }


### PR DESCRIPTION
## 이슈 번호 (#319)

## 요약
- 사용자의 SSE 알림 목록을 조회할 때, SSE 연결 알림까지 모두 조회되는 문제가 있었습니다.
- 이를 필터링하여 유의미한 알림만을 조회할 수 있도록 수정했습니다.

