### PR TITLE
Fix 325: RecipeImage null 처리 추가

### DIFF
--- a/src/docs/asciidoc/recipe.adoc
+++ b/src/docs/asciidoc/recipe.adoc
@@ -72,7 +72,7 @@ include::{snippets}/recipe-add-recipe/http-request.adoc[]
 
 === Response
 
-==== 200 OK
+==== 201 CREATED
 
 include::{snippets}/recipe-add-recipe/http-response.adoc[]
 

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
@@ -94,7 +94,9 @@ public interface RecipeMapper {
 
     @Named("recipeImageToImageUrl")
     static String recipeImageToImageUrl(RecipeImage recipeImage) {
-
+        if (recipeImage == null) {
+            return null;
+        }
         return recipeImage.getImageUrl();
     }
 


### PR DESCRIPTION
## 이슈 번호 (#325)

## 요약
- RecipeImage의 url을 가져오는 과정에서 오류 발생, RecipeImage가 null일 경우 처리를 추가

