### PR TITLE
[FEATURE] 식단 기록 수정 API Request DTO 필드에 기존 이미지 url 리스트 추가

### DIFF
--- a/src/docs/asciidoc/recipe.adoc
+++ b/src/docs/asciidoc/recipe.adoc
@@ -18,7 +18,7 @@ endif::[]
 
 include::{snippets}/recipe-get-recipe-list/request-headers.adoc[]
 
-==== Parameter
+==== Query Parameter
 
 include::{snippets}/recipe-get-recipe-list/query-parameters.adoc[]
 
@@ -167,3 +167,23 @@ include::{snippets}/recipe-get-recommended-recipe/http-response.adoc[]
 include::{snippets}/recipe-get-recommended-recipe-member-not-found/http-response.adoc[]
 
 include::{snippets}/recipe-get-recommended-recipe-recipe-not-found/http-response.adoc[]
+
+== 레시피 검색 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/recipe-get-recipe-list-by-keyword/request-headers.adoc[]
+
+=== Query Parameter
+
+include::{snippets}/recipe-get-recipe-list-by-keyword/query-parameters.adoc[]
+
+include::{snippets}/recipe-get-recipe-list-by-keyword/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/recipe-get-recipe-list-by-keyword/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogModifyRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogModifyRequest.java
@@ -7,4 +7,5 @@ import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record MealLogModifyRequest(
-        @Valid @NotNull @Size(min = 1, max = 5) List<MealAddRequest> meals) {}
+        @Valid @NotNull @Size(min = 1, max = 5) List<MealAddRequest> meals,
+        @Valid @NotNull @Size(max = 5) List<String> existingImageUrls) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -17,6 +17,7 @@ import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.IntakeNotifyService;
 import com.konggogi.veganlife.member.service.MemberQueryService;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,7 +53,7 @@ public class MealLogService {
     public void modify(Long mealLogId, MealLogModifyRequest request, List<MultipartFile> images) {
         MealLog mealLog = mealLogQueryService.search(mealLogId);
         modifyMeals(request.meals(), mealLog);
-        modifyMealImages(images, mealLog);
+        modifyMealImages(request.existingImageUrls(), images, mealLog);
         mealLogRepository.flush();
         intakeNotifyService.notifyIfOverIntake(mealLog.getMember().getId());
     }
@@ -83,6 +84,18 @@ public class MealLogService {
 
     private void modifyMealImages(List<MultipartFile> images, MealLog mealLog) {
         List<String> imageUrls = awsS3Uploader.uploadFiles(AwsS3Folders.LIFE_CHECK, images);
+        List<MealImage> mealImages =
+                imageUrls.stream()
+                        .map(request -> mealImageMapper.toEntity(request, mealLog))
+                        .toList();
+        mealLog.modifyMealImages(mealImages);
+    }
+
+    private void modifyMealImages(
+            List<String> existingImages, List<MultipartFile> images, MealLog mealLog) {
+        List<String> imageUrls = new ArrayList<>(existingImages);
+        imageUrls.addAll(awsS3Uploader.uploadFiles(AwsS3Folders.LIFE_CHECK, images));
+
         List<MealImage> mealImages =
                 imageUrls.stream()
                         .map(request -> mealImageMapper.toEntity(request, mealLog))

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -320,7 +320,9 @@ public class MealLogControllerTest extends RestDocsTest {
     @DisplayName("식사 기록 수정 API")
     void modifyMealLogTest() throws Exception {
 
-        MealLogModifyRequest mealLogModifyRequest = new MealLogModifyRequest(mealAddRequests);
+        MealLogModifyRequest mealLogModifyRequest =
+                new MealLogModifyRequest(
+                        mealAddRequests, List.of("existingImage1.png", "existingImage2.png"));
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",
@@ -372,7 +374,9 @@ public class MealLogControllerTest extends RestDocsTest {
     @DisplayName("식사 기록 수정 API Member Not Found 예외")
     void modifyMealLogMemberNotFoundTest() throws Exception {
 
-        MealLogModifyRequest mealLogModifyRequest = new MealLogModifyRequest(mealAddRequests);
+        MealLogModifyRequest mealLogModifyRequest =
+                new MealLogModifyRequest(
+                        mealAddRequests, List.of("existingImage1.png", "existingImage2.png"));
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",
@@ -419,7 +423,9 @@ public class MealLogControllerTest extends RestDocsTest {
     @DisplayName("식사 기록 수정 API MealData Not Found 예외")
     void modifyMealLogMealDataNotFoundTest() throws Exception {
 
-        MealLogModifyRequest mealLogModifyRequest = new MealLogModifyRequest(mealAddRequests);
+        MealLogModifyRequest mealLogModifyRequest =
+                new MealLogModifyRequest(
+                        mealAddRequests, List.of("existingImage1.png", "existingImage2.png"));
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -100,7 +100,9 @@ public class MealLogServiceTest {
     @DisplayName("식사 기록 수정")
     void mealLogModifyTest() {
         // given
-        MealLogModifyRequest mealLogModifyRequest = new MealLogModifyRequest(mealAddRequests);
+        MealLogModifyRequest mealLogModifyRequest =
+                new MealLogModifyRequest(
+                        mealAddRequests, List.of("existingImage1.png", "existingImage2.png"));
         List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
         List<MealImage> mealImages =
                 IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();

--- a/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/controller/RecipeControllerTest.java
@@ -527,4 +527,59 @@ public class RecipeControllerTest extends RestDocsTest {
         return RecipeFixture.DEFAULT.getWithName(
                 id, name, recipeTypes, recipeImages, ingredients, descriptions, member);
     }
+
+    @Test
+    @DisplayName("레시피 목록 조회 API")
+    void getRecipeListByKeyword() throws Exception {
+
+        List<RecipeResponse> recipe =
+                List.of(
+                        recipeMapper.toRecipeResponse(
+                                createRecipe(1L, "표고버섯 탕수", RecipeTypeFixture.LACTO.get()), true),
+                        recipeMapper.toRecipeResponse(
+                                createRecipe(2L, "가지 탕수", RecipeTypeFixture.LACTO.get()), false));
+        Page<RecipeResponse> response =
+                PageableExecutionUtils.getPage(recipe, Pageable.ofSize(20), recipe::size);
+
+        given(
+                        recipeSearchService.searchAllByKeyword(
+                                any(String.class), any(Pageable.class), anyLong()))
+                .willReturn(response);
+
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/api/v1/recipes/search")
+                                .headers(authorizationHeader())
+                                .queryParam("keyword", "탕수")
+                                .queryParam("page", "0")
+                                .queryParam("size", "20"));
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.size()").value(2))
+                .andExpect(jsonPath("$.content.[0].id").value(1L))
+                .andExpect(jsonPath("$.content.[0].name").value("표고버섯 탕수"))
+                .andExpect(
+                        jsonPath("$.content.[0].thumbnailUrl").value(recipe.get(0).thumbnailUrl()))
+                .andExpect(jsonPath("$.content.[0].recipeTypes.size()").value(1))
+                .andExpect(
+                        jsonPath("$.content.[0].recipeTypes[0]").value(VegetarianType.LACTO.name()))
+                .andExpect(jsonPath("$.content.[0].author.id").value(member.getId()))
+                .andExpect(jsonPath("$.content.[0].author.nickname").value(member.getNickname()))
+                .andExpect(
+                        jsonPath("$.content.[0].author.vegetarianType")
+                                .value(member.getVegetarianType().name()))
+                .andExpect(jsonPath("$.content.[0].isLiked").value(true));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "recipe-get-recipe-list-by-keyword",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                queryParameters(
+                                        parameterWithName("keyword").description("검색 키워드"),
+                                        pageDesc(),
+                                        sizeDesc())));
+    }
 }


### PR DESCRIPTION
## 이슈 번호 (#332)

## 요약
- 식단 기록 수정 API Request DTO 필드에 기존 이미지 url 리스트 추가
- 누락된 레시피 검색 API Rest Docs에 추가

