### PR TITLE
[#334] fix: 추천 레시피-조회된 레시피의 개수가 0개일 경우 예외처리 추가

### DIFF
--- a/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/service/RecipeSearchService.java
@@ -95,7 +95,9 @@ public class RecipeSearchService {
     private List<Recipe> getRecommendRecipes(Member member) {
 
         int totalElements = recipeQueryService.countAllRecipeType(member.getVegetarianType());
-
+        if (totalElements == 0) {
+            return List.of();
+        }
         return getRandomPageNumber(totalElements, member.getId()).stream()
                 .map(
                         pageNumber ->


### PR DESCRIPTION
## 이슈 번호 (#334)

## 원인
- 사용자 타입과 일치하는 레시피 개수가 0개일 때 예외 발생
- `Random.nextInt()`에 들어가는 매개변수는 양수값이어야 함, bound가 0 이하일 경우 예외처리 추가
```java
    public static List<Integer> generateNotDuplicatedRandomNumbers(int bound, int size, long seed) {

        Assert.isTrue(size > 0, "size는 양수여야 합니다.");  

        Random random = new Random(seed);
        Set<Integer> generated = new HashSet<>();

        do {
            generated.add(random.nextInt(bound));  // 이곳에서 오류 발생
        } while (generated.size() < bound && generated.size() < size);

        return generated.stream().toList();
    }
```