### PR TITLE
fix: 레시피 수정 - Recipe 수정 시 발생하는 양방향 참조 관계 문제 수정

### DIFF
--- a/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
@@ -87,21 +87,25 @@ public class Recipe extends TimeStamped {
 
     private void updateRecipeTypes(List<RecipeType> recipeTypes) {
         this.recipeTypes.clear();
+        recipeTypes.forEach((recipeType -> recipeType.setRecipe(this)));
         this.recipeTypes.addAll(recipeTypes);
     }
 
     private void updateRecipeImages(List<RecipeImage> recipeImages) {
         this.recipeImages.clear();
+        recipeImages.forEach(recipeImage -> recipeImage.setRecipe(this));
         this.recipeImages.addAll(recipeImages);
     }
 
     private void updateIngredients(List<RecipeIngredient> ingredients) {
         this.ingredients.clear();
+        ingredients.forEach((ingredient) -> ingredient.setRecipe(this));
         this.ingredients.addAll(ingredients);
     }
 
     private void updateDescriptions(List<RecipeDescription> descriptions) {
         this.descriptions.clear();
+        descriptions.forEach((description) -> description.setRecipe(this));
         this.descriptions.addAll(descriptions);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeDescription.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeDescription.java
@@ -42,4 +42,8 @@ public class RecipeDescription extends TimeStamped {
         this.description = description;
         this.recipe = recipe;
     }
+
+    public void setRecipe(Recipe recipe) {
+        this.recipe = recipe;
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeImage.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeImage.java
@@ -36,4 +36,8 @@ public class RecipeImage extends TimeStamped {
         this.imageUrl = imageUrl;
         this.recipe = recipe;
     }
+
+    public void setRecipe(Recipe recipe) {
+        this.recipe = recipe;
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeIngredient.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeIngredient.java
@@ -38,4 +38,8 @@ public class RecipeIngredient extends TimeStamped {
         this.name = name;
         this.recipe = recipe;
     }
+
+    public void setRecipe(Recipe recipe) {
+        this.recipe = recipe;
+    }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeType.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/RecipeType.java
@@ -40,4 +40,8 @@ public class RecipeType extends TimeStamped {
         this.vegetarianType = vegetarianType;
         this.recipe = recipe;
     }
+
+    public void setRecipe(Recipe recipe) {
+        this.recipe = recipe;
+    }
 }


### PR DESCRIPTION
## 이슈 번호 (#336)

## 요약
- 레시피를 수정하는 경우, Recipe와 양방향 참조 관계를 맺고 있는 엔티티들도 함께 수정됨
  - 정확히는, List 컬렉션 내의 기존 엔티티를 모두 삭제하고 새로운(수정된) 엔티티들을 삽입하는 방식
- 그러나 새로 삽입되는 엔티티들에게 Recipe와의 참조 관계를 설정해주지 않아 해당 오류 발생
- Recipe 엔티티의 `updateXXX()` 마다 양방향 참조 관계를 설정해주는 코드를 추가함

