### PR TITLE
Feature 338: 사용자 프로필 수정 DTO에 existingImageUrl 필드 추가

### DIFF
--- a/src/main/java/com/konggogi/veganlife/member/controller/dto/request/ProfileModifyRequest.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/dto/request/ProfileModifyRequest.java
@@ -14,4 +14,5 @@ public record ProfileModifyRequest(
         @NotNull Gender gender,
         @Positive @NotNull Integer birthYear,
         @Positive @NotNull Integer height,
-        @Positive @NotNull Integer weight) {}
+        @Positive @NotNull Integer weight,
+        String existingImageUrl) {}

--- a/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/MemberService.java
@@ -61,10 +61,21 @@ public class MemberService {
             Long memberId, ProfileModifyRequest request, MultipartFile profileImage) {
         Member member = memberQueryService.search(memberId);
         validateNickname(member.getNickname(), request.nickname());
-        String profileImageUrl = awsS3Uploader.uploadFile(AwsS3Folders.PROFILE, profileImage);
+        if (request.existingImageUrl() == null) {
+            String profileImageUrl = awsS3Uploader.uploadFile(AwsS3Folders.PROFILE, profileImage);
+            member.modifyProfile(
+                    request.nickname(),
+                    profileImageUrl,
+                    request.vegetarianType(),
+                    request.gender(),
+                    request.birthYear(),
+                    request.height(),
+                    request.weight());
+            return member;
+        }
         member.modifyProfile(
                 request.nickname(),
-                profileImageUrl,
+                request.existingImageUrl(),
                 request.vegetarianType(),
                 request.gender(),
                 request.birthYear(),

--- a/src/test/java/com/konggogi/veganlife/member/controller/MyPageControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MyPageControllerTest.java
@@ -129,7 +129,8 @@ class MyPageControllerTest extends RestDocsTest {
                         member.getGender(),
                         member.getBirthYear(),
                         member.getHeight(),
-                        member.getWeight());
+                        member.getWeight(),
+                        member.getProfileImageUrl());
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",
@@ -177,7 +178,8 @@ class MyPageControllerTest extends RestDocsTest {
     void modifyMemberProfileDuplicatedNicknameTest() throws Exception {
         // given
         ProfileModifyRequest profileModifyRequest =
-                new ProfileModifyRequest("nickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+                new ProfileModifyRequest(
+                        "nickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90, "profile.png");
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",
@@ -217,7 +219,8 @@ class MyPageControllerTest extends RestDocsTest {
     void modifyNotMemberProfileTest() throws Exception {
         // given
         ProfileModifyRequest profileModifyRequest =
-                new ProfileModifyRequest("nickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+                new ProfileModifyRequest(
+                        "nickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90, "profile.png");
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",

--- a/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/MemberServiceTest.java
@@ -124,7 +124,8 @@ class MemberServiceTest {
     void modifyMemberProfileTest() {
         // given
         ProfileModifyRequest request =
-                new ProfileModifyRequest("nickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+                new ProfileModifyRequest(
+                        "nickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90, null);
         given(memberRepository.findByNickname(request.nickname())).willReturn(Optional.empty());
         given(memberQueryService.search(anyLong())).willReturn(member);
         MultipartFile profileImage =
@@ -158,7 +159,7 @@ class MemberServiceTest {
         String newNickname = other.getNickname();
         ProfileModifyRequest request =
                 new ProfileModifyRequest(
-                        newNickname, VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+                        newNickname, VegetarianType.LACTO, Gender.M, 1993, 190, 90, "profile.png");
         given(memberQueryService.search(anyLong())).willReturn(existing);
         given(memberRepository.findByNickname(anyString())).willReturn(Optional.of(other));
         // when, then
@@ -175,7 +176,13 @@ class MemberServiceTest {
         Long memberId = member.getId();
         ProfileModifyRequest request =
                 new ProfileModifyRequest(
-                        "newNickname", VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+                        "newNickname",
+                        VegetarianType.LACTO,
+                        Gender.M,
+                        1993,
+                        190,
+                        90,
+                        "profile.png");
         given(memberQueryService.search(anyLong())).willReturn(member);
         given(memberRepository.findByNickname(anyString())).willReturn(Optional.empty());
         // when
@@ -191,7 +198,13 @@ class MemberServiceTest {
         Member existing = MemberFixture.DEFAULT_F.getWithId(1L);
         ProfileModifyRequest request =
                 new ProfileModifyRequest(
-                        existing.getNickname(), VegetarianType.LACTO, Gender.M, 1993, 190, 90);
+                        existing.getNickname(),
+                        VegetarianType.LACTO,
+                        Gender.M,
+                        1993,
+                        190,
+                        90,
+                        "profile.png");
         given(memberQueryService.search(anyLong())).willReturn(existing);
         // when
         memberService.modifyProfile(existing.getId(), request, null);


### PR DESCRIPTION
## 이슈 번호 (#338)

## 요약
- 사용자 프로필 수정 DTO에 existingImageUrl 필드 추가
- 기존프사 유지 = existingImageUrl 전송
- 프사 수정 = image 전송
- 프사 기본 = existingImageUrl, image 빈 값


