### PR TITLE
Feature 343: 사용자 프로필 조회 기능 구현

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -29,3 +29,92 @@ include::{snippets}/remove-member/http-response.adoc[]
 ==== 404 NOT FOUND
 
 include::{snippets}/remove-member-not-found/http-response.adoc[]
+
+== 다른 사용자의 프로필 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/get-member-profile/request-headers.adoc[]
+
+==== Path Variable
+include::{snippets}/get-member-profile/path-parameters.adoc[]
+
+include::{snippets}/get-member-profile/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/get-member-profile/http-response.adoc[]
+
+==== 404 NOT FOUND
+
+include::{snippets}/remove-member-not-found/http-response.adoc[]
+
+== 다른 사용자의 식단 기록 목록 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/get-member-meal-log-list/request-headers.adoc[]
+
+==== Path Variable
+include::{snippets}/get-member-meal-log-list/path-parameters.adoc[]
+
+==== Query Parameters
+include::{snippets}/get-member-meal-log-list/query-parameters.adoc[]
+
+include::{snippets}/get-member-meal-log-list/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/get-member-meal-log-list/http-response.adoc[]
+
+== 다른 사용자의 피드 목록 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/get-member-post-list/request-headers.adoc[]
+
+==== Path Variable
+include::{snippets}/get-member-post-list/path-parameters.adoc[]
+
+==== Query Parameters
+include::{snippets}/get-member-post-list/query-parameters.adoc[]
+
+include::{snippets}/get-member-post-list/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/get-member-post-list/http-response.adoc[]
+
+== 다른 사용자의 레시피 목록 조회 API
+
+=== Request
+
+==== Header
+
+include::{snippets}/get-member-recipe-list/request-headers.adoc[]
+
+==== Path Variable
+include::{snippets}/get-member-recipe-list/path-parameters.adoc[]
+
+==== Query Parameters
+include::{snippets}/get-member-recipe-list/query-parameters.adoc[]
+
+include::{snippets}/get-member-recipe-list/http-request.adoc[]
+
+=== Response
+
+==== 200 OK
+
+include::{snippets}/get-member-recipe-list/http-response.adoc[]

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealLogListResponse.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/MealLogListResponse.java
@@ -1,7 +1,18 @@
 package com.konggogi.veganlife.meallog.controller.dto.response;
 
 
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 
 public record MealLogListResponse(
-        Long id, MealType mealType, String thumbnailUrl, Integer totalCalorie) {}
+        Long id, MealType mealType, String thumbnailUrl, Integer totalCalorie) {
+
+    public static MealLogListResponse from(MealLog mealLog) {
+        return new MealLogListResponse(
+                mealLog.getId(),
+                mealLog.getMealType(),
+                mealLog.getThumbnail().map(MealImage::getImageUrl).orElse(null),
+                mealLog.getTotalCalorie());
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -7,6 +7,7 @@ import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.ToIntFunction;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -59,12 +60,11 @@ public class MealLog extends TimeStamped {
         this.mealImages.addAll(mealImages);
     }
 
-    public MealImage getThumbnail() {
-
+    public Optional<MealImage> getThumbnail() {
         if (mealImages.isEmpty()) {
-            return null;
+            return Optional.empty();
         }
-        return mealImages.get(0);
+        return Optional.of(mealImages.get(0));
     }
 
     public int getTotalCalorie() {

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -10,6 +10,7 @@ import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -24,7 +25,7 @@ public interface MealLogMapper {
     @Mapping(
             source = "mealLog.thumbnail",
             target = "thumbnailUrl",
-            qualifiedByName = "mealImageToImageUrl")
+            qualifiedByName = "optionalMealImageToImageUrl")
     @Mapping(target = "totalCalorie", expression = "java(mealLog.getTotalCalorie())")
     MealLogListResponse toMealLogListResponse(MealLog mealLog);
 
@@ -48,10 +49,14 @@ public interface MealLogMapper {
 
     @Named("mealImageToImageUrl")
     static String mealImageToImageUrl(MealImage mealImage) {
-
         if (mealImage == null) {
             return null;
         }
         return mealImage.getImageUrl();
+    }
+
+    @Named("optionalMealImageToImageUrl")
+    static String optionalMealImageToImageUrl(Optional<MealImage> thumbnail) {
+        return thumbnail.map(MealImage::getImageUrl).orElse(null);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -7,6 +7,8 @@ import com.konggogi.veganlife.member.domain.Member;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -22,4 +24,7 @@ public interface MealLogRepository extends JpaRepository<MealLog, Long>, MealLog
     List<MealLog> findAllByDateAndMember(LocalDate date, Member member);
 
     void deleteAllByMemberId(Long memberId);
+
+    @Query(" select distinct m from MealLog m join fetch m.meals where m.member = :member")
+    Page<MealLog> findAllByMember(Member member, Pageable pageable);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
@@ -6,11 +6,14 @@ import com.konggogi.veganlife.global.exception.NotFoundEntityException;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MealLogQueryService {
-
     private final MealLogRepository mealLogRepository;
+    private final MemberQueryService memberQueryService;
 
     public List<MealLog> searchByDateAndMember(LocalDate date, Member member) {
 
@@ -37,5 +40,10 @@ public class MealLogQueryService {
             Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
         return mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
                 memberId, startDateTime, endDateTime);
+    }
+
+    public Page<MealLog> searchAllByMember(Long memberId, Pageable pageable) {
+        Member member = memberQueryService.search(memberId);
+        return mealLogRepository.findAllByMember(member, pageable);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
@@ -2,11 +2,23 @@ package com.konggogi.veganlife.member.controller;
 
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
+import com.konggogi.veganlife.meallog.controller.dto.response.MealLogListResponse;
+import com.konggogi.veganlife.meallog.service.MealLogQueryService;
+import com.konggogi.veganlife.member.controller.dto.response.ProfileResponse;
+import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.member.service.MemberService;
+import com.konggogi.veganlife.post.controller.dto.response.PostSimpleResponse;
+import com.konggogi.veganlife.post.service.PostQueryService;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeResponse;
+import com.konggogi.veganlife.recipe.service.RecipeSearchService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,10 +27,41 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("api/v1/members")
 public class MemberController {
     private final MemberService memberService;
+    private final MemberQueryService memberQueryService;
+    private final MealLogQueryService mealLogQueryService;
+    private final PostQueryService postQueryService;
+    private final RecipeSearchService recipeSearchService;
 
     @DeleteMapping()
     public ResponseEntity<Void> removeMember(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         memberService.removeMember(userDetails.id());
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ProfileResponse> getMembersProfile(@PathVariable Long memberId) {
+        return ResponseEntity.ok(ProfileResponse.from(memberQueryService.search(memberId)));
+    }
+
+    @GetMapping("/{memberId}/meal-log")
+    public ResponseEntity<Page<MealLogListResponse>> getMembersMealLogList(
+            @PathVariable Long memberId, Pageable pageable) {
+        return ResponseEntity.ok(
+                mealLogQueryService
+                        .searchAllByMember(memberId, pageable)
+                        .map(MealLogListResponse::from));
+    }
+
+    @GetMapping("/{memberId}/posts")
+    public ResponseEntity<Page<PostSimpleResponse>> getMembersPostList(
+            @PathVariable Long memberId, Pageable pageable) {
+        return ResponseEntity.ok(
+                postQueryService.searchAll(memberId, pageable).map(PostSimpleResponse::from));
+    }
+
+    @GetMapping("/{memberId}/recipes")
+    public ResponseEntity<Page<RecipeResponse>> getMembersRecipeList(
+            @PathVariable Long memberId, Pageable pageable) {
+        return ResponseEntity.ok(recipeSearchService.searchAllByMemberId(memberId, pageable));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/member/controller/MyPageController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/MyPageController.java
@@ -3,7 +3,7 @@ package com.konggogi.veganlife.member.controller;
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
 import com.konggogi.veganlife.member.controller.dto.request.ProfileModifyRequest;
-import com.konggogi.veganlife.member.controller.dto.response.MemberProfileResponse;
+import com.konggogi.veganlife.member.controller.dto.response.MyProfileResponse;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.mapper.MemberMapper;
 import com.konggogi.veganlife.member.service.MemberQueryService;
@@ -35,14 +35,14 @@ public class MyPageController {
     private final PostMapper postMapper;
 
     @GetMapping("/profile")
-    public ResponseEntity<MemberProfileResponse> getMemberDetails(
+    public ResponseEntity<MyProfileResponse> getMemberDetails(
             @AuthenticationPrincipal UserDetailsImpl userDetails) {
         Member member = memberQueryService.search(userDetails.id());
         return ResponseEntity.ok(memberMapper.toMemberProfileResponse(member));
     }
 
     @PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<MemberProfileResponse> modifyMemberProfile(
+    public ResponseEntity<MyProfileResponse> modifyMemberProfile(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestPart @Valid ProfileModifyRequest request,
             @RequestPart(required = false) MultipartFile image) {

--- a/src/main/java/com/konggogi/veganlife/member/controller/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/dto/response/MyProfileResponse.java
@@ -4,7 +4,7 @@ package com.konggogi.veganlife.member.controller.dto.response;
 import com.konggogi.veganlife.member.domain.Gender;
 import com.konggogi.veganlife.member.domain.VegetarianType;
 
-public record MemberProfileResponse(
+public record MyProfileResponse(
         String email,
         String nickname,
         VegetarianType vegetarianType,

--- a/src/main/java/com/konggogi/veganlife/member/controller/dto/response/ProfileResponse.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/dto/response/ProfileResponse.java
@@ -1,0 +1,17 @@
+package com.konggogi.veganlife.member.controller.dto.response;
+
+
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.domain.VegetarianType;
+
+public record ProfileResponse(
+        Long id, String nickname, String profileImageUrl, VegetarianType vegetarianType) {
+
+    public static ProfileResponse from(Member member) {
+        return new ProfileResponse(
+                member.getId(),
+                member.getNickname(),
+                member.getProfileImageUrl(),
+                member.getVegetarianType());
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
+++ b/src/main/java/com/konggogi/veganlife/member/domain/mapper/MemberMapper.java
@@ -2,7 +2,7 @@ package com.konggogi.veganlife.member.domain.mapper;
 
 
 import com.konggogi.veganlife.member.controller.dto.response.AdditionalInfoUpdateResponse;
-import com.konggogi.veganlife.member.controller.dto.response.MemberProfileResponse;
+import com.konggogi.veganlife.member.controller.dto.response.MyProfileResponse;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.dto.MemberLoginDto;
 import org.mapstruct.Mapper;
@@ -17,7 +17,7 @@ public interface MemberMapper {
     MemberLoginDto toMemberLoginDto(Member member, String accessToken, String refreshToken);
 
     @Mapping(target = "imageUrl", source = "member.profileImageUrl")
-    MemberProfileResponse toMemberProfileResponse(Member member);
+    MyProfileResponse toMemberProfileResponse(Member member);
 
     AdditionalInfoUpdateResponse toAdditionalInfoUpdateResponse(Member member);
 }

--- a/src/main/java/com/konggogi/veganlife/post/controller/dto/response/PostSimpleResponse.java
+++ b/src/main/java/com/konggogi/veganlife/post/controller/dto/response/PostSimpleResponse.java
@@ -1,7 +1,18 @@
 package com.konggogi.veganlife.post.controller.dto.response;
 
 
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.PostImage;
 import java.time.LocalDateTime;
 
 public record PostSimpleResponse(
-        Long id, String title, String content, String imageUrl, LocalDateTime createdAt) {}
+        Long id, String title, String content, String imageUrl, LocalDateTime createdAt) {
+    public static PostSimpleResponse from(Post post) {
+        return new PostSimpleResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getThumbnail().map(PostImage::getImageUrl).orElse(null),
+                post.getCreatedAt());
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/post/domain/Post.java
+++ b/src/main/java/com/konggogi/veganlife/post/domain/Post.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -108,5 +109,12 @@ public class Post extends TimeStamped {
         participants.add(this.member);
         participants.addAll(this.comments.stream().map(Comment::getMember).toList());
         return new ArrayList<>(participants);
+    }
+
+    public Optional<PostImage> getThumbnail() {
+        if (imageUrls.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(imageUrls.get(0));
     }
 }

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeAuthorResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeAuthorResponse.java
@@ -1,6 +1,12 @@
 package com.konggogi.veganlife.recipe.controller.dto.response;
 
 
+import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.domain.VegetarianType;
 
-public record RecipeAuthorResponse(Long id, String nickname, VegetarianType vegetarianType) {}
+public record RecipeAuthorResponse(Long id, String nickname, VegetarianType vegetarianType) {
+    public static RecipeAuthorResponse from(Member member) {
+        return new RecipeAuthorResponse(
+                member.getId(), member.getNickname(), member.getVegetarianType());
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeResponse.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/controller/dto/response/RecipeResponse.java
@@ -2,6 +2,9 @@ package com.konggogi.veganlife.recipe.controller.dto.response;
 
 
 import com.konggogi.veganlife.member.domain.VegetarianType;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
 import java.util.List;
 
 public record RecipeResponse(
@@ -10,4 +13,14 @@ public record RecipeResponse(
         String thumbnailUrl,
         List<VegetarianType> recipeTypes,
         RecipeAuthorResponse author,
-        boolean isLiked) {}
+        boolean isLiked) {
+    public static RecipeResponse from(Recipe recipe, boolean isLiked) {
+        return new RecipeResponse(
+                recipe.getId(),
+                recipe.getName(),
+                recipe.getThumbnail().map(RecipeImage::getImageUrl).orElse(null),
+                recipe.getRecipeTypes().stream().map(RecipeType::getVegetarianType).toList(),
+                RecipeAuthorResponse.from(recipe.getMember()),
+                isLiked);
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/Recipe.java
@@ -18,6 +18,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OrderBy;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -60,11 +61,11 @@ public class Recipe extends TimeStamped {
         this.member = member;
     }
 
-    public RecipeImage getThumbnail() {
+    public Optional<RecipeImage> getThumbnail() {
         if (recipeImages.isEmpty()) {
-            return null;
+            return Optional.empty();
         }
-        return recipeImages.get(0);
+        return Optional.of(recipeImages.get(0));
     }
 
     public void update(

--- a/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
+++ b/src/main/java/com/konggogi/veganlife/recipe/domain/mapper/RecipeMapper.java
@@ -13,6 +13,7 @@ import com.konggogi.veganlife.recipe.domain.RecipeImage;
 import com.konggogi.veganlife.recipe.domain.RecipeIngredient;
 import com.konggogi.veganlife.recipe.domain.RecipeType;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -26,7 +27,7 @@ public interface RecipeMapper {
     @Mapping(
             source = "recipe.thumbnail",
             target = "thumbnailUrl",
-            qualifiedByName = "recipeImageToImageUrl")
+            qualifiedByName = "optionalRecipeImageToImageUrl")
     @Mapping(
             source = "recipe.recipeTypes",
             target = "recipeTypes",
@@ -132,6 +133,11 @@ public interface RecipeMapper {
             return null;
         }
         return recipeImage.getImageUrl();
+    }
+
+    @Named("optionalRecipeImageToImageUrl")
+    static String optionalRecipeImageToImageUrl(Optional<RecipeImage> recipeImage) {
+        return recipeImage.map(RecipeImage::getImageUrl).orElse(null);
     }
 
     @Named("recipeTypeToVegetarianType")

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -180,7 +180,7 @@ class MemberControllerTest extends RestDocsTest {
                                         parameterWithName("memberId")
                                                 .description("식단 목록을 조회할 사용자의 id")),
                                 queryParameters(
-                                        parameterWithName("page").description("페이지 크기"),
+                                        parameterWithName("page").description("페이지 번호"),
                                         parameterWithName("size").description("페이지 사이즈"))));
     }
 
@@ -224,7 +224,7 @@ class MemberControllerTest extends RestDocsTest {
                                         parameterWithName("memberId")
                                                 .description("피드 목록을 조회할 사용자의 id")),
                                 queryParameters(
-                                        parameterWithName("page").description("페이지 크기"),
+                                        parameterWithName("page").description("페이지 번호"),
                                         parameterWithName("size").description("페이지 사이즈"))));
     }
 
@@ -284,7 +284,7 @@ class MemberControllerTest extends RestDocsTest {
                                         parameterWithName("memberId")
                                                 .description("레시피 목록을 조회할 사용자의 id")),
                                 queryParameters(
-                                        parameterWithName("page").description("페이지 크기"),
+                                        parameterWithName("page").description("페이지 번호"),
                                         parameterWithName("size").description("페이지 사이즈"))));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -3,26 +3,65 @@ package com.konggogi.veganlife.member.controller;
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentRequest;
 import static com.konggogi.veganlife.support.docs.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.konggogi.veganlife.global.exception.ErrorCode;
 import com.konggogi.veganlife.global.exception.NotFoundEntityException;
+import com.konggogi.veganlife.mealdata.domain.MealData;
+import com.konggogi.veganlife.mealdata.fixture.MealDataFixture;
+import com.konggogi.veganlife.meallog.domain.Meal;
+import com.konggogi.veganlife.meallog.domain.MealImage;
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import com.konggogi.veganlife.meallog.fixture.MealFixture;
+import com.konggogi.veganlife.meallog.fixture.MealImageFixture;
+import com.konggogi.veganlife.meallog.fixture.MealLogFixture;
+import com.konggogi.veganlife.meallog.service.MealLogQueryService;
+import com.konggogi.veganlife.member.domain.Member;
+import com.konggogi.veganlife.member.fixture.MemberFixture;
+import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.member.service.MemberService;
+import com.konggogi.veganlife.post.domain.Post;
+import com.konggogi.veganlife.post.domain.PostImage;
+import com.konggogi.veganlife.post.fixture.PostFixture;
+import com.konggogi.veganlife.post.service.PostQueryService;
+import com.konggogi.veganlife.recipe.controller.dto.response.RecipeResponse;
+import com.konggogi.veganlife.recipe.domain.Recipe;
+import com.konggogi.veganlife.recipe.domain.RecipeImage;
+import com.konggogi.veganlife.recipe.domain.RecipeType;
+import com.konggogi.veganlife.recipe.fixture.RecipeFixture;
+import com.konggogi.veganlife.recipe.fixture.RecipeTypeFixture;
+import com.konggogi.veganlife.recipe.service.RecipeSearchService;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.web.servlet.ResultActions;
 
 @WebMvcTest(MemberController.class)
 class MemberControllerTest extends RestDocsTest {
     @MockBean MemberService memberService;
+    @MockBean MemberQueryService memberQueryService;
+    @MockBean MealLogQueryService mealLogQueryService;
+    @MockBean PostQueryService postQueryService;
+    @MockBean RecipeSearchService recipeSearchService;
 
     @Test
     @DisplayName("회원 탈퇴 API")
@@ -56,5 +95,196 @@ class MemberControllerTest extends RestDocsTest {
         perform.andExpect(status().isNotFound());
 
         perform.andDo(print()).andDo(document("remove-member-not-found", getDocumentResponse()));
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 프로필을 조회한다.")
+    void getMembersProfile() throws Exception {
+        Long memberId = 1L;
+        Member member = MemberFixture.DEFAULT_M.getWithId(memberId);
+        given(memberQueryService.search(anyLong())).willReturn(member);
+
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/api/v1/members/{memberId}", memberId).headers(authorizationHeader()));
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(member.getId()))
+                .andExpect(jsonPath("$.nickname").value(member.getNickname()))
+                .andExpect(jsonPath("$.vegetarianType").value(member.getVegetarianType().name()))
+                .andExpect(jsonPath("$.profileImageUrl").value(member.getProfileImageUrl()));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "get-member-profile",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(
+                                        parameterWithName("memberId").description("조회할 사용자의 id"))));
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 식단 기록 목록을 조회한다.")
+    void getMembersMealLogList() throws Exception {
+        Long memberId = 1L;
+        Member member = MemberFixture.DEFAULT_M.getWithId(memberId);
+        given(memberQueryService.search(anyLong())).willReturn(member);
+        List<MealData> mealData =
+                List.of(
+                        MealDataFixture.TOTAL_AMOUNT.get(1L, member),
+                        MealDataFixture.AMOUNT_PER_SERVE.get(2L, member),
+                        MealDataFixture.TOTAL_AMOUNT.get(3L, member));
+        List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
+        List<String> imageUrls = List.of("image1.png", "image2.png", "image3.png");
+        List<MealImage> mealImages =
+                imageUrls.stream().map(MealImageFixture.DEFAULT::getWithImageUrl).toList();
+        List<MealLog> mealLogs =
+                List.of(MealLogFixture.BREAKFAST.get(1L, meals, mealImages, member));
+        Page<MealLog> mealLogList = new PageImpl<>(mealLogs, Pageable.ofSize(10), mealLogs.size());
+        given(mealLogQueryService.searchAllByMember(anyLong(), any(Pageable.class)))
+                .willReturn(mealLogList);
+
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/api/v1/members/{memberId}/meal-log", memberId)
+                                .headers(authorizationHeader())
+                                .queryParam("page", "0")
+                                .queryParam("size", "10"));
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(mealLogs.size()))
+                .andExpect(jsonPath("$.content[0].id").value(mealLogs.get(0).getId()))
+                .andExpect(
+                        jsonPath("$.content[0].mealType")
+                                .value(mealLogs.get(0).getMealType().name()))
+                .andExpect(
+                        jsonPath("$.content[0].thumbnailUrl")
+                                .value(
+                                        mealLogs.get(0)
+                                                .getThumbnail()
+                                                .map(MealImage::getImageUrl)
+                                                .orElse(null)))
+                .andExpect(
+                        jsonPath("$.content[0].totalCalorie")
+                                .value(mealLogs.get(0).getTotalCalorie()));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "get-member-meal-log-list",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(
+                                        parameterWithName("memberId")
+                                                .description("식단 목록을 조회할 사용자의 id")),
+                                queryParameters(
+                                        parameterWithName("page").description("페이지 크기"),
+                                        parameterWithName("size").description("페이지 사이즈"))));
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 피드 목록을 조회한다.")
+    void getMembersPostList() throws Exception {
+        Long memberId = 1L;
+        Member member = MemberFixture.DEFAULT_M.getWithId(memberId);
+        List<Post> posts = List.of(PostFixture.BAKERY.getWithDate(1L, member, LocalDate.now()));
+        Page<Post> postList = new PageImpl<>(posts, Pageable.ofSize(10), posts.size());
+        given(postQueryService.searchAll(anyLong(), any(Pageable.class))).willReturn(postList);
+
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/api/v1/members/{memberId}/posts", memberId)
+                                .headers(authorizationHeader())
+                                .queryParam("page", "0")
+                                .queryParam("size", "10"));
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(posts.size()))
+                .andExpect(jsonPath("$.content[0].id").value(posts.get(0).getId()))
+                .andExpect(jsonPath("$.content[0].title").value(posts.get(0).getTitle()))
+                .andExpect(jsonPath("$.content[0].content").value(posts.get(0).getContent()))
+                .andExpect(
+                        jsonPath("$.content[0].imageUrl")
+                                .value(
+                                        posts.get(0)
+                                                .getThumbnail()
+                                                .map(PostImage::getImageUrl)
+                                                .orElse(null)));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "get-member-post-list",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(
+                                        parameterWithName("memberId")
+                                                .description("피드 목록을 조회할 사용자의 id")),
+                                queryParameters(
+                                        parameterWithName("page").description("페이지 크기"),
+                                        parameterWithName("size").description("페이지 사이즈"))));
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 레시피 목록을 조회한다.")
+    void getMembersRecipeList() throws Exception {
+        Long memberId = 1L;
+        Member member = MemberFixture.DEFAULT_M.getWithId(memberId);
+        List<RecipeType> recipeTypes = List.of(RecipeTypeFixture.LACTO.get());
+        List<Recipe> recipes =
+                List.of(RecipeFixture.DEFAULT.getSimpleWithRecipeTypes(1L, recipeTypes, member));
+        Page<RecipeResponse> recipeList =
+                new PageImpl<>(
+                        recipes.stream().map((r) -> RecipeResponse.from(r, true)).toList(),
+                        Pageable.ofSize(10),
+                        recipes.size());
+        given(recipeSearchService.searchAllByMemberId(anyLong(), any(Pageable.class)))
+                .willReturn(recipeList);
+
+        ResultActions perform =
+                mockMvc.perform(
+                        get("/api/v1/members/{memberId}/recipes", memberId)
+                                .headers(authorizationHeader())
+                                .queryParam("page", "0")
+                                .queryParam("size", "10"));
+
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalElements").value(recipes.size()))
+                .andExpect(jsonPath("$.content[0].id").value(recipes.get(0).getId()))
+                .andExpect(jsonPath("$.content[0].name").value(recipes.get(0).getName()))
+                .andExpect(
+                        jsonPath("$.content[0].thumbnailUrl")
+                                .value(
+                                        recipes.get(0)
+                                                .getThumbnail()
+                                                .map(RecipeImage::getImageUrl)
+                                                .orElse(null)))
+                .andExpect(
+                        jsonPath("$.content[0].author.id")
+                                .value(recipes.get(0).getMember().getId()))
+                .andExpect(
+                        jsonPath("$.content[0].author.nickname")
+                                .value(recipes.get(0).getMember().getNickname()))
+                .andExpect(
+                        jsonPath("$.content[0].author.vegetarianType")
+                                .value(recipes.get(0).getMember().getVegetarianType().name()))
+                .andExpect(jsonPath("$.content[0].isLiked").value(true));
+
+        perform.andDo(print())
+                .andDo(
+                        document(
+                                "get-member-recipe-list",
+                                getDocumentRequest(),
+                                getDocumentResponse(),
+                                requestHeaders(authorizationDesc()),
+                                pathParameters(
+                                        parameterWithName("memberId")
+                                                .description("레시피 목록을 조회할 사용자의 id")),
+                                queryParameters(
+                                        parameterWithName("page").description("페이지 크기"),
+                                        parameterWithName("size").description("페이지 사이즈"))));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeFixture.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/fixture/RecipeFixture.java
@@ -20,6 +20,12 @@ public enum RecipeFixture {
         this.name = name;
     }
 
+    public Recipe getSimpleWithRecipeTypes(Long id, List<RecipeType> recipeTypes, Member member) {
+        Recipe recipe = Recipe.builder().id(id).name(name).member(member).build();
+        recipeTypes.forEach(recipeType -> setRecipe(recipeType, recipe));
+        return recipe;
+    }
+
     public Recipe get(
             List<RecipeType> recipeTypes,
             List<RecipeImage> recipeImages,

--- a/src/test/java/com/konggogi/veganlife/recipe/service/RecipeSearchServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/recipe/service/RecipeSearchServiceTest.java
@@ -73,9 +73,11 @@ public class RecipeSearchServiceTest {
 
         assertThat(response.getNumberOfElements()).isEqualTo(2);
         assertThat(response.getContent().get(0).thumbnailUrl())
-                .isEqualTo(recipes.get(0).getThumbnail().getImageUrl());
+                .isEqualTo(
+                        recipes.get(0).getThumbnail().map(RecipeImage::getImageUrl).orElse(null));
         assertThat(response.getContent().get(1).thumbnailUrl())
-                .isEqualTo(recipes.get(1).getThumbnail().getImageUrl());
+                .isEqualTo(
+                        recipes.get(1).getThumbnail().map(RecipeImage::getImageUrl).orElse(null));
         assertThat(response.getContent().get(0).recipeTypes())
                 .containsAll(
                         recipes.get(0).getRecipeTypes().stream()


### PR DESCRIPTION
## 이슈 번호 (#343)

## 요약
- 사용자 프로필 조회 기능 구현
- 해당 사용자가 등록한 식단 목록 조회 기능 구현
- 해당 사용자가 작성한 피드 목록 조회 기능 구현
- 해당 사용자가 작성한 레시피 목록 조회

## 변경사항
- 피드, 레시피의 thumbnail은 nullable함, 그러나 기존 코드는 null-safe하지 않았음
```java
    public RecipeImage getThumbnail() {
        if (recipeImages.isEmpty()) {
            return null; // null pointer exception 발생 가능
        }
        return recipeImages.get(0);
    }
```
- null-safe를 보장하기 위해 `getThumbnail` 메서드가 Optional을 반환하도록 수정함
