### PR TITLE
Feature 345: 사용자 프로필 조회 - 식단 기록 조회 기능 수정

### DIFF
--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -61,14 +61,6 @@ include::{snippets}/remove-member-not-found/http-response.adoc[]
 
 include::{snippets}/get-member-meal-log-list/request-headers.adoc[]
 
-==== Path Variable
-include::{snippets}/get-member-meal-log-list/path-parameters.adoc[]
-
-==== Query Parameters
-include::{snippets}/get-member-meal-log-list/query-parameters.adoc[]
-
-include::{snippets}/get-member-meal-log-list/http-request.adoc[]
-
 === Response
 
 ==== 200 OK

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/request/MealLogAddRequest.java
@@ -5,8 +5,10 @@ import com.konggogi.veganlife.meallog.domain.MealType;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 import java.util.List;
 
 public record MealLogAddRequest(
         @NotNull MealType mealType,
+        @NotNull LocalDate date,
         @Valid @NotNull @Size(min = 1, max = 5) List<MealAddRequest> meals) {}

--- a/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/DailyMealLogListResponse.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/controller/dto/response/DailyMealLogListResponse.java
@@ -1,0 +1,15 @@
+package com.konggogi.veganlife.meallog.controller.dto.response;
+
+
+import com.konggogi.veganlife.meallog.domain.MealLog;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public record DailyMealLogListResponse(LocalDate date, List<MealLogListResponse> mealLogs) {
+
+    public static DailyMealLogListResponse from(Map.Entry<LocalDate, List<MealLog>> entry) {
+        return new DailyMealLogListResponse(
+                entry.getKey(), entry.getValue().stream().map(MealLogListResponse::from).toList());
+    }
+}

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/MealLog.java
@@ -5,6 +5,7 @@ import com.konggogi.veganlife.global.domain.TimeStamped;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import jakarta.persistence.*;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -33,6 +34,9 @@ public class MealLog extends TimeStamped {
     @Enumerated(EnumType.STRING)
     private MealType mealType;
 
+    @Column(nullable = false)
+    private LocalDate date;
+
     @OneToMany(mappedBy = "mealLog", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Meal> meals = new ArrayList<>();
 
@@ -44,9 +48,10 @@ public class MealLog extends TimeStamped {
     private Member member;
 
     @Builder
-    public MealLog(Long id, MealType mealType, Member member) {
+    public MealLog(Long id, MealType mealType, LocalDate date, Member member) {
         this.id = id;
         this.mealType = mealType;
+        this.date = date;
         this.member = member;
     }
 

--- a/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/domain/mapper/MealLogMapper.java
@@ -8,6 +8,7 @@ import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.domain.MealType;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -20,7 +21,7 @@ import org.mapstruct.Named;
 public interface MealLogMapper {
 
     @Mapping(target = "id", ignore = true)
-    MealLog toEntity(MealType mealType, Member member);
+    MealLog toEntity(MealType mealType, LocalDate date, Member member);
 
     @Mapping(
             source = "mealLog.thumbnail",

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -20,11 +20,19 @@ public interface MealLogRepository extends JpaRepository<MealLog, Long>, MealLog
 
     @Query(
             " select distinct m from MealLog m join fetch m.meals"
-                    + " where cast(m.createdAt as localdate) = :date and m.member = :member")
+                    + " where m.date = :date and m.member = :member")
     List<MealLog> findAllByDateAndMember(LocalDate date, Member member);
 
     void deleteAllByMemberId(Long memberId);
 
     @Query(" select distinct m from MealLog m join fetch m.meals where m.member = :member")
     Page<MealLog> findAllByMember(Member member, Pageable pageable);
+
+    @Query(
+            " select distinct m from MealLog m join fetch m.meals"
+                    + " where m.date between :startDate and :endDate"
+                    + " and m.member = :member"
+                    + " order by m.createdAt desc")
+    List<MealLog> findAllByDateBetweenAndMember(
+            LocalDate startDate, LocalDate endDate, Member member);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -25,14 +25,11 @@ public interface MealLogRepository extends JpaRepository<MealLog, Long>, MealLog
 
     void deleteAllByMemberId(Long memberId);
 
-    @Query(" select distinct m from MealLog m join fetch m.meals where m.member = :member")
-    Page<MealLog> findAllByMember(Member member, Pageable pageable);
-
     @Query(
             " select distinct m from MealLog m join fetch m.meals"
                     + " where m.date between :startDate and :endDate"
                     + " and m.member = :member"
-                    + " order by m.createdAt desc")
+                    + " order by m.date desc")
     List<MealLog> findAllByDateBetweenAndMember(
             LocalDate startDate, LocalDate endDate, Member member);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/MealLogRepository.java
@@ -7,8 +7,6 @@ import com.konggogi.veganlife.member.domain.Member;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepository.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepository.java
@@ -2,11 +2,14 @@ package com.konggogi.veganlife.meallog.repository.querydsl;
 
 
 import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface MealLogCustomRepository {
 
-    List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
-            Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime);
+    List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+            Long memberId, LocalDate startDate, LocalDate endDate);
+
+    List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndDate(
+            Long memberId, LocalDate date);
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepositoryImpl.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepositoryImpl.java
@@ -6,7 +6,7 @@ import static com.konggogi.veganlife.meallog.domain.QMealLog.mealLog;
 import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
 import com.querydsl.core.types.Projections;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
@@ -19,15 +19,26 @@ public class MealLogCustomRepositoryImpl extends QuerydslRepositorySupport
     }
 
     @Override
-    public List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
-            Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    public List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+            Long memberId, LocalDate startDate, LocalDate endDate) {
         return from(mealLog)
                 .join(mealLog.meals, meal)
-                .where(
-                        mealLog.member
-                                .id
-                                .eq(memberId)
-                                .and(mealLog.createdAt.between(startDateTime, endDateTime)))
+                .where(mealLog.member.id.eq(memberId).and(mealLog.date.between(startDate, endDate)))
+                .groupBy(mealLog.mealType)
+                .select(
+                        Projections.fields(
+                                TotalCalorieOfMealType.class,
+                                mealLog.mealType,
+                                meal.calorie.sum().as("totalCalorie")))
+                .fetch();
+    }
+
+    @Override
+    public List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndDate(
+            Long memberId, LocalDate date) {
+        return from(mealLog)
+                .join(mealLog.meals, meal)
+                .where(mealLog.member.id.eq(memberId).and(mealLog.date.eq(date)))
                 .groupBy(mealLog.mealType)
                 .select(
                         Projections.fields(

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
@@ -9,11 +9,8 @@ import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,14 +33,21 @@ public class MealLogQueryService {
                 .orElseThrow(() -> new NotFoundEntityException(ErrorCode.NOT_FOUND_MEAL_LOG));
     }
 
-    public List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-            Long memberId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
-                memberId, startDateTime, endDateTime);
+    public List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndDate(
+            Long memberId, LocalDate date) {
+        return mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndDate(memberId, date);
     }
 
-    public Page<MealLog> searchAllByMember(Long memberId, Pageable pageable) {
+    public List<TotalCalorieOfMealType> sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+            Long memberId, LocalDate startDate, LocalDate EndDate) {
+        return mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+                memberId, startDate, EndDate);
+    }
+
+    public List<MealLog> searchWeeklyMealLogs(Long memberId) {
         Member member = memberQueryService.search(memberId);
-        return mealLogRepository.findAllByMember(member, pageable);
+        LocalDate endDate = LocalDate.now();
+        LocalDate startDate = endDate.minusDays(6);
+        return mealLogRepository.findAllByDateBetweenAndMember(startDate, endDate, member);
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogQueryService.java
@@ -9,7 +9,10 @@ import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.MemberQueryService;
 import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,10 +47,15 @@ public class MealLogQueryService {
                 memberId, startDate, EndDate);
     }
 
-    public List<MealLog> searchWeeklyMealLogs(Long memberId) {
+    public Map<LocalDate, List<MealLog>> searchWeeklyMealLogs(Long memberId) {
         Member member = memberQueryService.search(memberId);
         LocalDate endDate = LocalDate.now();
         LocalDate startDate = endDate.minusDays(6);
-        return mealLogRepository.findAllByDateBetweenAndMember(startDate, endDate, member);
+        return mealLogRepository.findAllByDateBetweenAndMember(startDate, endDate, member).stream()
+                .collect(
+                        Collectors.groupingBy(
+                                MealLog::getDate,
+                                LinkedHashMap::new,
+                                Collectors.toList())); // 순서 보장
     }
 }

--- a/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
+++ b/src/main/java/com/konggogi/veganlife/meallog/service/MealLogService.java
@@ -43,7 +43,8 @@ public class MealLogService {
 
     public void add(MealLogAddRequest request, List<MultipartFile> images, Long memberId) {
         MealLog mealLog =
-                mealLogMapper.toEntity(request.mealType(), memberQueryService.search(memberId));
+                mealLogMapper.toEntity(
+                        request.mealType(), request.date(), memberQueryService.search(memberId));
         modifyMeals(request.meals(), mealLog);
         modifyMealImages(images, mealLog);
         mealLogRepository.save(mealLog);

--- a/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
@@ -2,7 +2,8 @@ package com.konggogi.veganlife.member.controller;
 
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
-import com.konggogi.veganlife.meallog.controller.dto.response.MealLogListResponse;
+import com.konggogi.veganlife.meallog.controller.dto.response.DailyMealLogListResponse;
+import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.service.MealLogQueryService;
 import com.konggogi.veganlife.member.controller.dto.response.ProfileResponse;
 import com.konggogi.veganlife.member.service.MemberQueryService;
@@ -11,6 +12,8 @@ import com.konggogi.veganlife.post.controller.dto.response.PostSimpleResponse;
 import com.konggogi.veganlife.post.service.PostQueryService;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeResponse;
 import com.konggogi.veganlife.recipe.service.RecipeSearchService;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,12 +47,15 @@ public class MemberController {
     }
 
     @GetMapping("/{memberId}/meal-log")
-    public ResponseEntity<Page<MealLogListResponse>> getMembersMealLogList(
-            @PathVariable Long memberId, Pageable pageable) {
+    public ResponseEntity<List<DailyMealLogListResponse>> getMembersMealLogList(
+            @PathVariable Long memberId) {
         return ResponseEntity.ok(
-                mealLogQueryService
-                        .searchAllByMember(memberId, pageable)
-                        .map(MealLogListResponse::from));
+                mealLogQueryService.searchWeeklyMealLogs(memberId).stream()
+                        .collect(Collectors.groupingBy(MealLog::getDate))
+                        .entrySet()
+                        .stream()
+                        .map(DailyMealLogListResponse::from)
+                        .toList());
     }
 
     @GetMapping("/{memberId}/posts")

--- a/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
+++ b/src/main/java/com/konggogi/veganlife/member/controller/MemberController.java
@@ -3,7 +3,6 @@ package com.konggogi.veganlife.member.controller;
 
 import com.konggogi.veganlife.global.security.user.UserDetailsImpl;
 import com.konggogi.veganlife.meallog.controller.dto.response.DailyMealLogListResponse;
-import com.konggogi.veganlife.meallog.domain.MealLog;
 import com.konggogi.veganlife.meallog.service.MealLogQueryService;
 import com.konggogi.veganlife.member.controller.dto.response.ProfileResponse;
 import com.konggogi.veganlife.member.service.MemberQueryService;
@@ -13,7 +12,6 @@ import com.konggogi.veganlife.post.service.PostQueryService;
 import com.konggogi.veganlife.recipe.controller.dto.response.RecipeResponse;
 import com.konggogi.veganlife.recipe.service.RecipeSearchService;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -50,10 +48,7 @@ public class MemberController {
     public ResponseEntity<List<DailyMealLogListResponse>> getMembersMealLogList(
             @PathVariable Long memberId) {
         return ResponseEntity.ok(
-                mealLogQueryService.searchWeeklyMealLogs(memberId).stream()
-                        .collect(Collectors.groupingBy(MealLog::getDate))
-                        .entrySet()
-                        .stream()
+                mealLogQueryService.searchWeeklyMealLogs(memberId).entrySet().stream()
                         .map(DailyMealLogListResponse::from)
                         .toList());
     }

--- a/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
@@ -45,7 +45,8 @@ public class IntakeNutrientsService {
                 .datesUntil(endDate.plusDays(1))
                 .map(
                         date -> {
-                            return aggregateDailyCaloriesOfMealTypeForDay(memberId, date);
+                            return aggregateCaloriesOfMealTypeForPeriod(
+                                    memberId, startDate, endDate);
                         })
                 .toList();
     }
@@ -83,8 +84,7 @@ public class IntakeNutrientsService {
 
     private IntakeCalorie aggregateDailyCaloriesOfMealTypeForDay(Long memberId, LocalDate date) {
         List<TotalCalorieOfMealType> caloriesOfMeals =
-                mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-                        memberId, date.atStartOfDay(), date.atTime(23, 59, 59));
+                mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDate(memberId, date);
         return createCaloriesOfMealType(caloriesOfMeals);
     }
 
@@ -92,7 +92,7 @@ public class IntakeNutrientsService {
             Long memberId, LocalDate startDate, LocalDate endDate) {
         List<TotalCalorieOfMealType> caloriesOfMeals =
                 mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-                        memberId, startDate.atStartOfDay(), endDate.atTime(23, 59, 59));
+                        memberId, startDate, endDate);
         return createCaloriesOfMealType(caloriesOfMeals);
     }
 

--- a/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
+++ b/src/main/java/com/konggogi/veganlife/member/service/IntakeNutrientsService.java
@@ -45,8 +45,7 @@ public class IntakeNutrientsService {
                 .datesUntil(endDate.plusDays(1))
                 .map(
                         date -> {
-                            return aggregateCaloriesOfMealTypeForPeriod(
-                                    memberId, startDate, endDate);
+                            return aggregateDailyCaloriesOfMealTypeForDay(memberId, date);
                         })
                 .toList();
     }

--- a/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/controller/MealLogControllerTest.java
@@ -89,9 +89,9 @@ public class MealLogControllerTest extends RestDocsTest {
     @Test
     @DisplayName("식사 기록 등록 API")
     void addMealLogTest() throws Exception {
-
+        LocalDate date = LocalDate.now();
         MealLogAddRequest mealLogAddRequest =
-                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+                new MealLogAddRequest(MealType.BREAKFAST, date, mealAddRequests);
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",
@@ -136,9 +136,9 @@ public class MealLogControllerTest extends RestDocsTest {
     @Test
     @DisplayName("식사 기록 등록 API Member Not Found 예외")
     void addMealLogMemberNotFoundTest() throws Exception {
-
+        LocalDate date = LocalDate.now();
         MealLogAddRequest mealLogAddRequest =
-                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+                new MealLogAddRequest(MealType.BREAKFAST, date, mealAddRequests);
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",
@@ -179,9 +179,9 @@ public class MealLogControllerTest extends RestDocsTest {
     @Test
     @DisplayName("식사 기록 등록 API MealData Not Found 예외")
     void addMealLogMealDataNotFoundTest() throws Exception {
-
+        LocalDate date = LocalDate.now();
         MealLogAddRequest mealLogAddRequest =
-                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+                new MealLogAddRequest(MealType.BREAKFAST, date, mealAddRequests);
         MockMultipartFile request =
                 new MockMultipartFile(
                         "request",
@@ -230,11 +230,12 @@ public class MealLogControllerTest extends RestDocsTest {
         List<MealLogListResponse> mealLogs =
                 List.of(
                         mealLogMapper.toMealLogListResponse(
-                                MealLogFixture.BREAKFAST.get(1L, meals, mealImages, member)),
+                                MealLogFixture.BREAKFAST.get(1L, date, meals, mealImages, member)),
                         mealLogMapper.toMealLogListResponse(
-                                MealLogFixture.LUNCH.get(2L, meals, mealImages, member)),
+                                MealLogFixture.LUNCH.get(2L, date, meals, mealImages, member)),
                         mealLogMapper.toMealLogListResponse(
-                                MealLogFixture.DINNER_SNACK.get(3L, meals, mealImages, member)));
+                                MealLogFixture.DINNER_SNACK.get(
+                                        3L, date, meals, mealImages, member)));
 
         given(mealLogSearchService.searchByDate(date, member.getId())).willReturn(mealLogs);
 
@@ -262,14 +263,14 @@ public class MealLogControllerTest extends RestDocsTest {
     @Test
     @DisplayName("식사 기록 상세 조회 API")
     void getMealLogDetailsTest() throws Exception {
-
+        LocalDate date = LocalDate.now();
         List<String> imageUrls = List.of("image1.png", "image2.png", "image3.png");
         List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
         List<MealImage> mealImages =
                 imageUrls.stream().map(MealImageFixture.DEFAULT::getWithImageUrl).toList();
         MealLogDetailsResponse mealLog =
                 mealLogMapper.toMealLogDetailsResponse(
-                        MealLogFixture.BREAKFAST.get(1L, meals, mealImages, member));
+                        MealLogFixture.BREAKFAST.get(1L, date, meals, mealImages, member));
 
         given(mealLogSearchService.searchById(1L)).willReturn(mealLog);
 

--- a/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/fixture/MealLogFixture.java
@@ -25,48 +25,24 @@ public enum MealLogFixture {
         this.mealType = mealType;
     }
 
-    public MealLog get(List<Meal> meals, List<MealImage> mealImages, Member member) {
-        MealLog mealLog = MealLog.builder().mealType(mealType).member(member).build();
-        meals.forEach(meal -> setMealLog(meal, mealLog));
-        mealImages.forEach(mealImage -> setMealLog(mealImage, mealLog));
-        mealLog.getMeals().addAll(meals);
-        mealLog.getMealImages().addAll(mealImages);
-        return mealLog;
-    }
-
-    public MealLog get(Long id, List<Meal> meals, List<MealImage> mealImages, Member member) {
-        MealLog mealLog = MealLog.builder().id(id).mealType(mealType).member(member).build();
-        meals.forEach(meal -> setMealLog(meal, mealLog));
-        mealImages.forEach(mealImage -> setMealLog(mealImage, mealLog));
-        mealLog.getMeals().addAll(meals);
-        mealLog.getMealImages().addAll(mealImages);
-        return mealLog;
-    }
-
-    public MealLog getWithDate(
+    public MealLog get(
             LocalDate date, List<Meal> meals, List<MealImage> mealImages, Member member) {
-        MealLog mealLog = MealLog.builder().mealType(mealType).member(member).build();
+        MealLog mealLog = MealLog.builder().mealType(mealType).date(date).member(member).build();
         meals.forEach(meal -> setMealLog(meal, mealLog));
         mealImages.forEach(mealImage -> setMealLog(mealImage, mealLog));
         mealLog.getMeals().addAll(meals);
         mealLog.getMealImages().addAll(mealImages);
-        return setCreatedAt(mealLog, date);
+        return mealLog;
     }
 
-    public MealLog getWithDate(
+    public MealLog get(
             Long id, LocalDate date, List<Meal> meals, List<MealImage> mealImages, Member member) {
-        MealLog mealLog = MealLog.builder().id(id).mealType(mealType).member(member).build();
+        MealLog mealLog =
+                MealLog.builder().id(id).mealType(mealType).date(date).member(member).build();
         meals.forEach(meal -> setMealLog(meal, mealLog));
         mealImages.forEach(mealImage -> setMealLog(mealImage, mealLog));
         mealLog.getMeals().addAll(meals);
         mealLog.getMealImages().addAll(mealImages);
-        return setCreatedAt(mealLog, date);
-    }
-
-    private MealLog setCreatedAt(MealLog mealLog, LocalDate date) {
-        Field createdAt = ReflectionUtils.findField(MealLog.class, "createdAt");
-        ReflectionUtils.makeAccessible(createdAt);
-        ReflectionUtils.setField(createdAt, mealLog, date.atStartOfDay());
         return mealLog;
     }
 

--- a/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/repository/MealLogRepositoryTest.java
@@ -54,7 +54,8 @@ public class MealLogRepositoryTest {
     @DisplayName("MealLog 저장 테스트")
     void mealLogSaveTest() {
         // given
-        MealLog mealLog = createMealLog(member, mealData, null, MealLogFixture.BREAKFAST);
+        LocalDate date = LocalDate.now();
+        MealLog mealLog = createMealLog(member, mealData, date, MealLogFixture.BREAKFAST);
         // when
         MealLog result = mealLogRepository.save(mealLog);
         // then
@@ -77,13 +78,13 @@ public class MealLogRepositoryTest {
         List<MealImage> mealImages1 =
                 IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
         MealLog mealLog1 =
-                MealLogFixture.BREAKFAST.getWithDate(
+                MealLogFixture.BREAKFAST.get(
                         LocalDate.of(2023, 12, 22), meals1, mealImages1, member);
         List<Meal> meals2 = mealData.stream().map(MealFixture.DEFAULT::get).toList();
         List<MealImage> mealImages2 =
                 IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
         MealLog mealLog2 =
-                MealLogFixture.BREAKFAST.getWithDate(
+                MealLogFixture.BREAKFAST.get(
                         LocalDate.of(2023, 12, 23), meals2, mealImages2, member);
         mealLogRepository.save(mealLog1);
         mealLogRepository.save(mealLog2);
@@ -99,7 +100,8 @@ public class MealLogRepositoryTest {
     @DisplayName("MealLog 수정 테스트 - 연관된 자식 엔티티를 삭제하고 새로 삽입한다")
     void mealLogUpdateTest() {
         // given
-        MealLog mealLog = createMealLog(member, mealData, null, MealLogFixture.BREAKFAST);
+        LocalDate date = LocalDate.now();
+        MealLog mealLog = createMealLog(member, mealData, date, MealLogFixture.BREAKFAST);
         mealLogRepository.saveAndFlush(mealLog);
         // when
         List<Meal> modifiedMeals = new ArrayList<>();
@@ -120,10 +122,11 @@ public class MealLogRepositoryTest {
     @DisplayName("MealLog 삭제 테스트 - 연관된 자식 엔티티도 같이 삭제된다")
     void mealLogDeleteTest() {
         // given
+        LocalDate date = LocalDate.now();
         List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
         List<MealImage> mealImages =
                 IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
-        MealLog mealLog = MealLogFixture.BREAKFAST.get(meals, mealImages, member);
+        MealLog mealLog = MealLogFixture.BREAKFAST.get(date, meals, mealImages, member);
         mealLogRepository.saveAndFlush(mealLog);
         // when
         mealLogRepository.deleteById(mealLog.getId());
@@ -143,10 +146,11 @@ public class MealLogRepositoryTest {
     @DisplayName("회원의 MealLog 모두 삭제")
     void deleteAllByMemberIdTest() {
         // given
-        MealLog mealLog = createMealLog(member, mealData, null, MealLogFixture.BREAKFAST);
+        LocalDate date = LocalDate.now();
+        MealLog mealLog = createMealLog(member, mealData, date, MealLogFixture.BREAKFAST);
         Member otherMember = MemberFixture.DEFAULT_F.get();
         memberRepository.save(otherMember);
-        MealLog otherMealLog = createMealLog(otherMember, mealData, null, MealLogFixture.BREAKFAST);
+        MealLog otherMealLog = createMealLog(otherMember, mealData, date, MealLogFixture.BREAKFAST);
         mealLogRepository.save(mealLog);
         mealLogRepository.save(otherMealLog);
         // when
@@ -167,10 +171,6 @@ public class MealLogRepositoryTest {
                         .mapToObj(idx -> MealImageFixture.DEFAULT.get())
                         .toList();
 
-        if (date != null) {
-            return mealTypeOfFixture.getWithDate(date, meals, mealImages, member);
-        } else {
-            return mealTypeOfFixture.get(meals, mealImages, member);
-        }
+        return mealTypeOfFixture.get(date, meals, mealImages, member);
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepositoryImplTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/repository/querydsl/MealLogCustomRepositoryImplTest.java
@@ -57,7 +57,7 @@ class MealLogCustomRepositoryImplTest {
 
     @Test
     @DisplayName("회원 id와 기간에 해당하는 MealLog를 MealType별로 합산")
-    void sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetweenTest() {
+    void sumCaloriesOfMealTypeByMemberIdAndDateBetweenTest() {
         // given
         LocalDate startDate = LocalDate.of(2024, 2, 18);
         LocalDate endDate = LocalDate.of(2024, 2, 24);
@@ -75,10 +75,9 @@ class MealLogCustomRepositoryImplTest {
                                             });
                         });
         // when
-
         List<TotalCalorieOfMealType> totalCaloriesOfMealTypes =
-                mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
-                        member.getId(), startDate.atStartOfDay(), endDate.atTime(23, 59, 59));
+                mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+                        member.getId(), startDate, endDate);
         Map<MealType, Integer> totalCalorieOfMealTypeMap =
                 toTotalCalorieOfMealTypeMap(totalCaloriesOfMealTypes);
         // then
@@ -103,12 +102,7 @@ class MealLogCustomRepositoryImplTest {
                 IntStream.range(0, mealData.size())
                         .mapToObj(idx -> MealImageFixture.DEFAULT.get())
                         .toList();
-
-        if (date != null) {
-            return mealTypeOfFixture.getWithDate(date, meals, mealImages, member);
-        } else {
-            return mealTypeOfFixture.get(meals, mealImages, member);
-        }
+        return mealTypeOfFixture.get(date, meals, mealImages, member);
     }
 
     private Map<MealType, Integer> toTotalCalorieOfMealTypeMap(

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogQueryServiceTest.java
@@ -19,7 +19,6 @@ import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.fixture.MemberFixture;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -54,7 +53,7 @@ public class MealLogQueryServiceTest {
                 IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
         LocalDate date = LocalDate.of(2023, 12, 22);
         List<MealLog> mealLogs =
-                List.of(MealLogFixture.BREAKFAST.getWithDate(date, meals, mealImages, member));
+                List.of(MealLogFixture.BREAKFAST.get(date, meals, mealImages, member));
         given(mealLogRepository.findAllByDateAndMember(date, member)).willReturn(mealLogs);
 
         List<MealLog> found = mealLogQueryService.searchByDateAndMember(date, member);
@@ -66,7 +65,7 @@ public class MealLogQueryServiceTest {
     @Test
     @DisplayName("해당 id의 MealLog 상세 조회")
     void searchTest() {
-
+        LocalDate date = LocalDate.now();
         List<Meal> meals =
                 List.of(
                         MealFixture.DEFAULT.get(1L, mealData.get(0)),
@@ -74,7 +73,7 @@ public class MealLogQueryServiceTest {
                         MealFixture.DEFAULT.get(3L, mealData.get(2)));
         List<MealImage> mealImages =
                 LongStream.range(1, 4).mapToObj(MealImageFixture.DEFAULT::get).toList();
-        MealLog mealLog = MealLogFixture.BREAKFAST.get(1L, meals, mealImages, member);
+        MealLog mealLog = MealLogFixture.BREAKFAST.get(1L, date, meals, mealImages, member);
 
         given(mealLogRepository.findById(1L)).willReturn(Optional.ofNullable(mealLog));
 
@@ -99,17 +98,17 @@ public class MealLogQueryServiceTest {
     @Test
     @DisplayName("회원 id와 기간에 해당하는 MealLog를 MealType별로 합산")
     void sumCaloriesOfMealTypeByMemberIdAndDateBetweenTest() {
-        LocalDateTime startDateTime = LocalDate.of(2024, 2, 18).atStartOfDay();
-        LocalDateTime endDateTime = LocalDate.of(2024, 2, 24).atTime(23, 59, 59);
+        LocalDate startDate = LocalDate.of(2024, 2, 18);
+        LocalDate endDate = LocalDate.of(2024, 2, 24);
         given(
-                        mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndCreatedAtBetween(
-                                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                        mealLogRepository.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
+                                anyLong(), any(LocalDate.class), any(LocalDate.class)))
                 .willReturn(new ArrayList<>());
 
         assertThatNoException()
                 .isThrownBy(
                         () ->
                                 mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-                                        member.getId(), startDateTime, endDateTime));
+                                        member.getId(), startDate, endDate));
     }
 }

--- a/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/meallog/service/MealLogServiceTest.java
@@ -35,6 +35,7 @@ import com.konggogi.veganlife.meallog.repository.MealLogRepository;
 import com.konggogi.veganlife.member.domain.Member;
 import com.konggogi.veganlife.member.service.IntakeNotifyService;
 import com.konggogi.veganlife.member.service.MemberQueryService;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
@@ -79,8 +80,9 @@ public class MealLogServiceTest {
     @DisplayName("식사 기록 저장")
     void mealLogAddTest() {
         // given
+        LocalDate date = LocalDate.now();
         MealLogAddRequest mealLogAddRequest =
-                new MealLogAddRequest(MealType.BREAKFAST, mealAddRequests);
+                new MealLogAddRequest(MealType.BREAKFAST, date, mealAddRequests);
         given(memberQueryService.search(1L)).willReturn(member);
         doNothing().when(intakeNotifyService).notifyIfOverIntake(1L);
         mealData.forEach(m -> given(mealDataQueryService.search(m.getId())).willReturn(m));
@@ -108,10 +110,11 @@ public class MealLogServiceTest {
         MealLogModifyRequest mealLogModifyRequest =
                 new MealLogModifyRequest(
                         mealAddRequests, List.of("existingImage1.png", "existingImage2.png"));
+        LocalDate date = LocalDate.now();
         List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
         List<MealImage> mealImages =
                 IntStream.range(0, 3).mapToObj(idx -> MealImageFixture.DEFAULT.get()).toList();
-        MealLog mealLog = MealLogFixture.BREAKFAST.get(meals, mealImages, member);
+        MealLog mealLog = MealLogFixture.BREAKFAST.get(date, meals, mealImages, member);
         given(mealLogQueryService.search(1L)).willReturn(mealLog);
         doNothing().when(intakeNotifyService).notifyIfOverIntake(1L);
         mealData.forEach(m -> given(mealDataQueryService.search(m.getId())).willReturn(m));
@@ -135,10 +138,11 @@ public class MealLogServiceTest {
     @DisplayName("식사 기록 삭제")
     void mealLogRemoveTest() {
         // given
+        LocalDate date = LocalDate.now();
         List<Meal> meals = mealData.stream().map(MealFixture.DEFAULT::get).toList();
         List<MealImage> mealImages =
                 imageUrls.stream().map(MealImageFixture.DEFAULT::getWithImageUrl).toList();
-        MealLog mealLog = MealLogFixture.DINNER.get(1L, meals, mealImages, member);
+        MealLog mealLog = MealLogFixture.DINNER.get(1L, date, meals, mealImages, member);
         given(mealLogQueryService.search(1L)).willReturn(mealLog);
         // when
         mealLogService.remove(1L);

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -144,19 +144,19 @@ class MemberControllerTest extends RestDocsTest {
         Map<LocalDate, List<MealLog>> mealLogs = new LinkedHashMap<>();
         mealLogs.put(
                 LocalDate.of(2025, 10, 18),
-                List.of(MealLogFixture.BREAKFAST.get(
-                        3L, LocalDate.of(2025, 10, 18), meals, mealImages, member))
-        );
+                List.of(
+                        MealLogFixture.BREAKFAST.get(
+                                3L, LocalDate.of(2025, 10, 18), meals, mealImages, member)));
         mealLogs.put(
                 LocalDate.of(2025, 10, 17),
-                List.of(MealLogFixture.LUNCH.get(
-                        2L, LocalDate.of(2025, 10, 17), meals, mealImages, member))
-        );
+                List.of(
+                        MealLogFixture.LUNCH.get(
+                                2L, LocalDate.of(2025, 10, 17), meals, mealImages, member)));
         mealLogs.put(
                 LocalDate.of(2025, 10, 16),
-                List.of(MealLogFixture.BREAKFAST.get(
-                        1L, LocalDate.of(2025, 10, 16), meals, mealImages, member))
-        );
+                List.of(
+                        MealLogFixture.BREAKFAST.get(
+                                1L, LocalDate.of(2025, 10, 16), meals, mealImages, member)));
         given(mealLogQueryService.searchWeeklyMealLogs(anyLong())).willReturn(mealLogs);
 
         ResultActions perform =

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -140,34 +140,25 @@ class MemberControllerTest extends RestDocsTest {
         List<MealImage> mealImages =
                 imageUrls.stream().map(MealImageFixture.DEFAULT::getWithImageUrl).toList();
         List<MealLog> mealLogs =
-                List.of(MealLogFixture.BREAKFAST.get(1L, meals, mealImages, member));
-        Page<MealLog> mealLogList = new PageImpl<>(mealLogs, Pageable.ofSize(10), mealLogs.size());
-        given(mealLogQueryService.searchAllByMember(anyLong(), any(Pageable.class)))
-                .willReturn(mealLogList);
+                List.of(
+                        MealLogFixture.BREAKFAST.get(
+                                3L, LocalDate.of(2025, 10, 18), meals, mealImages, member),
+                        MealLogFixture.LUNCH.get(
+                                2L, LocalDate.of(2025, 10, 17), meals, mealImages, member),
+                        MealLogFixture.BREAKFAST.get(
+                                1L, LocalDate.of(2025, 10, 16), meals, mealImages, member));
+        given(mealLogQueryService.searchWeeklyMealLogs(anyLong())).willReturn(mealLogs);
 
         ResultActions perform =
                 mockMvc.perform(
                         get("/api/v1/members/{memberId}/meal-log", memberId)
-                                .headers(authorizationHeader())
-                                .queryParam("page", "0")
-                                .queryParam("size", "10"));
+                                .headers(authorizationHeader()));
 
         perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.totalElements").value(mealLogs.size()))
-                .andExpect(jsonPath("$.content[0].id").value(mealLogs.get(0).getId()))
-                .andExpect(
-                        jsonPath("$.content[0].mealType")
-                                .value(mealLogs.get(0).getMealType().name()))
-                .andExpect(
-                        jsonPath("$.content[0].thumbnailUrl")
-                                .value(
-                                        mealLogs.get(0)
-                                                .getThumbnail()
-                                                .map(MealImage::getImageUrl)
-                                                .orElse(null)))
-                .andExpect(
-                        jsonPath("$.content[0].totalCalorie")
-                                .value(mealLogs.get(0).getTotalCalorie()));
+                .andExpect(jsonPath("$.size()").value(mealLogs.size()))
+                .andExpect(jsonPath("$.[0].date").value(LocalDate.of(2025, 10, 18).toString()))
+                .andExpect(jsonPath("$.[1].date").value(LocalDate.of(2025, 10, 17).toString()))
+                .andExpect(jsonPath("$.[2].date").value(LocalDate.of(2025, 10, 16).toString()));
 
         perform.andDo(print())
                 .andDo(
@@ -178,10 +169,7 @@ class MemberControllerTest extends RestDocsTest {
                                 requestHeaders(authorizationDesc()),
                                 pathParameters(
                                         parameterWithName("memberId")
-                                                .description("식단 목록을 조회할 사용자의 id")),
-                                queryParameters(
-                                        parameterWithName("page").description("페이지 번호"),
-                                        parameterWithName("size").description("페이지 사이즈"))));
+                                                .description("식단 목록을 조회할 사용자의 id"))));
     }
 
     @Test

--- a/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/controller/MemberControllerTest.java
@@ -45,7 +45,9 @@ import com.konggogi.veganlife.recipe.fixture.RecipeTypeFixture;
 import com.konggogi.veganlife.recipe.service.RecipeSearchService;
 import com.konggogi.veganlife.support.docs.RestDocsTest;
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -139,14 +141,22 @@ class MemberControllerTest extends RestDocsTest {
         List<String> imageUrls = List.of("image1.png", "image2.png", "image3.png");
         List<MealImage> mealImages =
                 imageUrls.stream().map(MealImageFixture.DEFAULT::getWithImageUrl).toList();
-        List<MealLog> mealLogs =
-                List.of(
-                        MealLogFixture.BREAKFAST.get(
-                                3L, LocalDate.of(2025, 10, 18), meals, mealImages, member),
-                        MealLogFixture.LUNCH.get(
-                                2L, LocalDate.of(2025, 10, 17), meals, mealImages, member),
-                        MealLogFixture.BREAKFAST.get(
-                                1L, LocalDate.of(2025, 10, 16), meals, mealImages, member));
+        Map<LocalDate, List<MealLog>> mealLogs = new LinkedHashMap<>();
+        mealLogs.put(
+                LocalDate.of(2025, 10, 18),
+                List.of(MealLogFixture.BREAKFAST.get(
+                        3L, LocalDate.of(2025, 10, 18), meals, mealImages, member))
+        );
+        mealLogs.put(
+                LocalDate.of(2025, 10, 17),
+                List.of(MealLogFixture.LUNCH.get(
+                        2L, LocalDate.of(2025, 10, 17), meals, mealImages, member))
+        );
+        mealLogs.put(
+                LocalDate.of(2025, 10, 16),
+                List.of(MealLogFixture.BREAKFAST.get(
+                        1L, LocalDate.of(2025, 10, 16), meals, mealImages, member))
+        );
         given(mealLogQueryService.searchWeeklyMealLogs(anyLong())).willReturn(mealLogs);
 
         ResultActions perform =

--- a/src/test/java/com/konggogi/veganlife/member/service/IntakeNutrientsServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/IntakeNutrientsServiceTest.java
@@ -27,7 +27,6 @@ import com.konggogi.veganlife.member.service.dto.IntakeCalorie;
 import com.konggogi.veganlife.member.service.dto.IntakeNutrients;
 import com.konggogi.veganlife.member.service.dto.TotalCalorieOfMealType;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
@@ -106,14 +105,15 @@ class IntakeNutrientsServiceTest {
         given(memberQueryService.search(anyLong())).willReturn(member);
         given(
                         mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-                                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                                anyLong(), any(LocalDate.class), any(LocalDate.class)))
                 .willReturn(totalCalorieOfMealTypes);
+
         // when
         List<IntakeCalorie> intakeCalories =
                 intakeNutrientsService.searchWeeklyIntakeCalories(
                         member.getId(), startDate, endDate);
         // then
-
+        System.out.println(intakeCalories);
         assertThat(intakeCalories).hasSize(7);
         assertThat(intakeCalories.get(0).breakfast()).isEqualTo(totalCalorie);
         assertThat(intakeCalories.get(0).lunch()).isEqualTo(totalCalorie);
@@ -132,11 +132,12 @@ class IntakeNutrientsServiceTest {
         given(memberQueryService.search(anyLong())).willReturn(member);
         given(
                         mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-                                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                                anyLong(), any(LocalDate.class), any(LocalDate.class)))
                 .willReturn(totalCalorieOfMealTypes);
         // when
         List<IntakeCalorie> intakeCalories =
                 intakeNutrientsService.searchMonthlyIntakeCalories(member.getId(), startDate);
+
         // then
         assertThat(intakeCalories.get(0).breakfast()).isEqualTo(totalCalorie);
         assertThat(intakeCalories.get(0).lunch()).isEqualTo(totalCalorie);
@@ -155,7 +156,7 @@ class IntakeNutrientsServiceTest {
         given(memberQueryService.search(anyLong())).willReturn(member);
         given(
                         mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-                                anyLong(), any(LocalDateTime.class), any(LocalDateTime.class)))
+                                anyLong(), any(LocalDate.class), any(LocalDate.class)))
                 .willReturn(totalCalorieOfMealTypes);
         // when
         List<IntakeCalorie> intakeCalories =
@@ -170,12 +171,12 @@ class IntakeNutrientsServiceTest {
 
     private List<MealLog> createMealLogs(LocalDate date) {
         return List.of(
-                MealLogFixture.BREAKFAST.getWithDate(date, meals, mealImages, member),
-                MealLogFixture.LUNCH.getWithDate(date, meals, mealImages, member),
-                MealLogFixture.DINNER.getWithDate(date, meals, mealImages, member),
-                MealLogFixture.BREAKFAST_SNACK.getWithDate(date, meals, mealImages, member),
-                MealLogFixture.LUNCH_SNACK.getWithDate(date, meals, mealImages, member),
-                MealLogFixture.DINNER_SNACK.getWithDate(date, meals, mealImages, member));
+                MealLogFixture.BREAKFAST.get(date, meals, mealImages, member),
+                MealLogFixture.LUNCH.get(date, meals, mealImages, member),
+                MealLogFixture.DINNER.get(date, meals, mealImages, member),
+                MealLogFixture.BREAKFAST_SNACK.get(date, meals, mealImages, member),
+                MealLogFixture.LUNCH_SNACK.get(date, meals, mealImages, member),
+                MealLogFixture.DINNER_SNACK.get(date, meals, mealImages, member));
     }
 
     private List<TotalCalorieOfMealType> createTotalCalorieOfMealTypes(int totalCalorie) {

--- a/src/test/java/com/konggogi/veganlife/member/service/IntakeNutrientsServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/IntakeNutrientsServiceTest.java
@@ -104,10 +104,9 @@ class IntakeNutrientsServiceTest {
                 createTotalCalorieOfMealTypes(totalCalorie);
         given(memberQueryService.search(anyLong())).willReturn(member);
         given(
-                        mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDateBetween(
-                                anyLong(), any(LocalDate.class), any(LocalDate.class)))
+                        mealLogQueryService.sumCaloriesOfMealTypeByMemberIdAndDate(
+                                anyLong(), any(LocalDate.class)))
                 .willReturn(totalCalorieOfMealTypes);
-
         // when
         List<IntakeCalorie> intakeCalories =
                 intakeNutrientsService.searchWeeklyIntakeCalories(

--- a/src/test/java/com/konggogi/veganlife/member/service/IntakeNutrientsServiceTest.java
+++ b/src/test/java/com/konggogi/veganlife/member/service/IntakeNutrientsServiceTest.java
@@ -112,7 +112,6 @@ class IntakeNutrientsServiceTest {
                 intakeNutrientsService.searchWeeklyIntakeCalories(
                         member.getId(), startDate, endDate);
         // then
-        System.out.println(intakeCalories);
         assertThat(intakeCalories).hasSize(7);
         assertThat(intakeCalories.get(0).breakfast()).isEqualTo(totalCalorie);
         assertThat(intakeCalories.get(0).lunch()).isEqualTo(totalCalorie);


### PR DESCRIPTION
## 이슈 번호 (#345)

## 요약
### 사용자 프로필 조회 - 식단 기록 조회 기능 수정
- 최근 일주일 간의 식단 기록 조회, 기록일 기준 내림차순 정렬하여 반환

## 변경 내용
### 식단 기록(MealLog) 엔티티에 `date`(기록 날짜) 필드 추가
- 기존에는 기록 날짜 필드로 auditing 필드인 createdAt를 사용, 코드 유연성 떨어짐
- 또한, createdAt은 LocalDateTime 필드이기 때문에 쿼리에 사용 시 LocalDate로 변환 필요, 로직이 복잡해지고 쿼리 비효율 증가
- 이에 auditing 필드에 의존하지 않도록 독립적인 date 필드를 추가함

